### PR TITLE
Adjust Flappy difficulty and tuning constants

### DIFF
--- a/games/flappy.js
+++ b/games/flappy.js
@@ -5,6 +5,12 @@ let fPipes = [];
 let fScore = 0;
 let fAnim;
 
+const FLAP_STRENGTH = -7;
+const GRAVITY = 0.3;
+const PIPE_SPEED = 2.2;
+const PIPE_GAP = 200;
+const PIPE_SPAWN_CHANCE = 0.01;
+
 export function initFlappy() {
   state.currentGame = "flappy";
   loadHighScores();
@@ -21,10 +27,10 @@ function loopFlappy() {
   ctx.fillStyle = "#000";
   ctx.fillRect(0, 0, 400, 600);
   if (state.keysPressed[" "]) {
-    fBird.dy = -6;
+    fBird.dy = FLAP_STRENGTH;
     state.keysPressed[" "] = false;
   }
-  fBird.dy += 0.4;
+  fBird.dy += GRAVITY;
   fBird.y += fBird.dy;
   ctx.fillStyle = "#fff";
   ctx.fillRect(fBird.x, fBird.y, 20, 20);
@@ -32,12 +38,12 @@ function loopFlappy() {
     showGameOver("flappy", fScore);
     return;
   }
-  if (Math.random() < 0.015) {
-    fPipes.push({ x: 400, gap: 150, h: Math.random() * 300 + 50 });
+  if (Math.random() < PIPE_SPAWN_CHANCE) {
+    fPipes.push({ x: 400, gap: PIPE_GAP, h: Math.random() * 250 + 50 });
   }
   for (let i = fPipes.length - 1; i >= 0; i--) {
     const p = fPipes[i];
-    p.x -= 3;
+    p.x -= PIPE_SPEED;
     ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
     ctx.fillRect(p.x, 0, 40, p.h);
     ctx.fillRect(p.x, p.h + p.gap, 40, 600);
@@ -56,7 +62,7 @@ function loopFlappy() {
 }
 
 document.getElementById("flappyCanvas").onclick = () => {
-  if (state.currentGame === "flappy") fBird.dy = -6;
+  if (state.currentGame === "flappy") fBird.dy = FLAP_STRENGTH;
 };
 
 registerGameStop(() => {


### PR DESCRIPTION
### Motivation
- Make the Flappy game more forgiving by tuning jump strength, gravity, pipe speed, gap size, and spawn frequency.

### Description
- Added tuning constants in `games/flappy.js`: `FLAP_STRENGTH`, `GRAVITY`, `PIPE_SPEED`, `PIPE_GAP`, and `PIPE_SPAWN_CHANCE` and replaced hardcoded values with these constants.
- Increased pipe gap to `PIPE_GAP = 200` and reduced random pipe height range (`Math.random() * 250 + 50`) to give the player more room.
- Reduced gravity to `0.3`, lowered pipe speed to `2.2`, adjusted flap strength to `-7`, and reduced spawn chance to `0.01` to slow down pacing and reduce difficulty.
- Updated both spacebar input and canvas `onclick` to use `FLAP_STRENGTH` so controls are consistent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c4fe99dc832b8ac46de1db436854)