### PR TITLE
Fix matrix canvas border/outline in Matrix Mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,11 @@
     }
 
     /* --- 2. VISUAL EFFECTS --- */
-    #matrixCanvas { position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; z-index: 0; opacity: 0.8; pointer-events: none; display: none; }
+    #matrixCanvas {
+        position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; z-index: 0;
+        opacity: 0.8; pointer-events: none; display: none;
+        border: none; box-shadow: none; margin: 0; max-width: none; max-height: none;
+    }
     #matrixCanvas.active { display: block; }
     
     #hackOverlay {


### PR DESCRIPTION
### Motivation
- Remove an unwanted border/outline around the matrix background canvas so Matrix Mode displays cleanly without visual artifacts.

### Description
- Update `styles.css` to modify the `#matrixCanvas` rule by removing `border` and `box-shadow` and resetting `margin`, `max-width`, and `max-height` so the canvas renders without an outline.

### Testing
- Started a local server (`python -m http.server 8000`) and ran a Playwright script that enabled matrix mode and captured `artifacts/matrix-mode.png`, which confirms the visual border/outline is resolved (initial Playwright runs timed out but the final run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c5315480832bab9d7fa1fc426d98)