### PR TITLE
Improve voice chat reliability, UX, and styling

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,6 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
 import { getAuth, signInAnonymously, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
-import { getFirestore, collection, doc, setDoc, getDoc, updateDoc, onSnapshot, runTransaction, query, orderBy, limit, addDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+import { getFirestore, collection, doc, setDoc, getDoc, updateDoc, onSnapshot, runTransaction, query, orderBy, limit, addDoc, deleteDoc, getDocs } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
 const firebaseConfig = { apiKey: "AIzaSyAoXwDA6KtqSD4yfGprus8C8Mi_--1KwSw", authDomain: "funnys-18ff7.firebaseapp.com", projectId: "funnys-18ff7", storageBucket: "funnys-18ff7.firebasestorage.app", messagingSenderId: "368675604960", appId: "1:368675604960:web:24c5dcd6a5329c9fd94385", measurementId: "G-6PE47RLP8V" };
 const app = initializeApp(firebaseConfig);
@@ -103,7 +103,9 @@ export const firebase = {
   query,
   orderBy,
   limit,
-  addDoc
+  addDoc,
+  deleteDoc,
+  getDocs
 };
 
 const ACHIEVEMENTS = [

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,28 @@
     .chat-msg { margin-bottom: 5px; word-wrap: break-word; }
     .chat-user { color: var(--accent); font-weight: bold; }
     #chatInput { background: #000; border: none; border-top: 1px solid var(--accent); color: var(--accent); padding: 10px; font-family: inherit; outline: none; }
+    .chat-box { max-width: 760px; width: min(90vw, 760px); }
+    .voice-panel {
+        margin-top: 15px; padding: 15px; border: 1px solid var(--accent-dim);
+        background: rgba(0,0,0,0.7); box-shadow: inset 0 0 20px rgba(255, 6, 6, 0.1);
+        display: flex; flex-direction: column; gap: 12px;
+    }
+    .voice-header { font-size: 10px; letter-spacing: 2px; text-align: center; color: #fff; }
+    .voice-channels { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+    .voice-btn.active { background: var(--accent); color: #000; box-shadow: 0 0 15px var(--accent-glow); }
+    .voice-status {
+        display: flex; justify-content: space-between; font-size: 9px; padding: 6px 10px;
+        border: 1px dashed var(--accent-dim); background: #050505;
+    }
+    #voiceStatus[data-state="live"] { color: #0f0; }
+    #voiceStatus[data-state="connecting"] { color: #ffd700; }
+    #voiceStatus[data-state="reconnecting"] { color: #ff8800; }
+    #voiceStatus[data-state="busy"] { color: #ff8800; }
+    #voiceStatus[data-state="failed"],
+    #voiceStatus[data-state="mic blocked"] { color: #ff4d4d; }
+    .voice-controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    #voiceMuteBtn.active { background: #fff; color: #000; }
+    #voiceRemote { width: 100%; height: 36px; background: #000; border: 1px solid var(--accent-dim); }
 
     /* --- 5. MAIN LOGO --- */
     .gooner-btn {


### PR DESCRIPTION
### Motivation
- Improve reliability and cleanup for the in-app voice chat so channels don't get stuck and ICE candidates are cleaned up between sessions.
- Surface clearer connection and microphone status to the user and fail gracefully when mic permission is denied.
- Make the voice panel visually clearer and match the app theme with better status colors and button states.

### Description
- Added Firestore helper imports (`deleteDoc`, `getDocs`) and implemented `clearCandidates(channel, role)` and `resetChannel(channel)` to remove stale candidate docs and reset channel state in `voice.js` and exported them via `core.js`.
- Normalized status UI by setting `data-state` on `#voiceStatus` (sanitizing the text), added connection state listeners (`onconnectionstatechange`, `oniceconnectionstatechange`), and updated status strings for clearer feedback (e.g. `CONNECTING`, `LIVE`, `RECONNECTING`, `BUSY`, `FAILED`, `MIC BLOCKED`).
- Improved audio/mic handling by wrapping `getUserMedia` in `try/catch` with a `MIC BLOCKED` state and showing a toast when `audioEl.play()` is blocked by the browser.
- Cleaned up candidate handling on join/leave (clear guests/host candidates), add `updatedAt` metadata to room docs, and guarded join logic so busy channels are reported correctly.
- UI and UX tweaks: mute button now toggles an `active` class and channel buttons clear on errors; added `beforeunload` handler to leave voice on page exit.
- Styling: added `.voice-panel`, channel grid, status color rules, `.voice-btn.active`, and a small remote audio element style in `styles.css` to polish the voice UI.

### Testing
- Performed a local smoke test by serving the site with `python -m http.server 8000` and running a Playwright script that opens `index.html`, activates the chat overlay, and captures a screenshot with the overlay; the screenshot was produced at `artifacts/voice-chat.png` (UI render verification succeeded).
- No unit tests were added; changes focused on runtime behavior and manual/automated UI verification described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c460c204832baeb605434407f4ba)