### PR TITLE
Add CHAT entry to main menu dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 </div>
 
 <div class="dropdown-content" id="menuDropdown">
+    <button onclick="window.openGame('overlayChat')">CHAT</button>
     <button onclick="window.launchGame('geo')">GEO DASH</button>
     <button onclick="window.launchGame('type')">TYPE RUNNER</button>
     <button onclick="window.launchGame('pong')">PONG</button>


### PR DESCRIPTION
### Motivation
- Make the global chat overlay reachable from the main dropdown so users can open chat from the main menu (not only from the voice/chat screen).

### Description
- Inserted a `CHAT` button into the `#menuDropdown` in `index.html` that calls `window.openGame('overlayChat')` to open the global chat overlay.

### Testing
- This is a static HTML change; a local dev server was started with `python -m http.server 8000` and a Playwright screenshot run was attempted but timed out, so no automated verification completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c8ab57b8832b98c0abade79a45d1)