### PR TITLE
Fix Geo Dash overlay id selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ window.setPongDiff = setPongDiff;
 
 window.launchGame = (game) => {
   window.closeOverlays();
-  const overlayId = "overlay" + (game === "ttt" || game === "geo" ? game.toUpperCase() : game.charAt(0).toUpperCase() + game.slice(1));
+  const overlayId = "overlay" + (game === "ttt" ? game.toUpperCase() : game.charAt(0).toUpperCase() + game.slice(1));
   const el = document.getElementById(overlayId);
   if (el) el.classList.add("active");
   if (game === "pong") initPong();


### PR DESCRIPTION
### Motivation
- Geo Dash overlay wasn't opening because the overlay id was constructed as `overlayGEO`, which doesn't match the DOM id `overlayGeo`, so the game overlay selection needs to match the DOM.

### Description
- Update `script.js` to remove the `geo` special-case from the `overlayId` expression so the default capitalization (`game.charAt(0).toUpperCase() + game.slice(1)`) is used and the computed id matches the DOM.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985378a1b5c8333bd278604acf7f649)