### PR TITLE
Debit solo blackjack bet and prevent over-betting

### DIFF
--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -74,6 +74,12 @@ function startSoloBetting() {
 
 async function startSoloRound() {
   if (bjCurrentBet <= 0) return beep(200, "sawtooth", 0.5);
+  if (state.myMoney < bjCurrentBet) {
+    showToast("Not enough cash for that bet.");
+    return;
+  }
+  state.myMoney -= bjCurrentBet;
+  updBJ();
   document.getElementById("bjBetBtns").style.visibility = "hidden";
   bjDeck = createDeck();
   bjPlayerHand = [bjDeck.pop(), bjDeck.pop()];


### PR DESCRIPTION
### Motivation
- Fix a bug in solo blackjack where bets were not deducted at round start allowing players to never lose money and to block starting a round when `bjCurrentBet` exceeds `state.myMoney`.

### Description
- In `startSoloRound` added a guard `if (state.myMoney < bjCurrentBet)` to `showToast` and abort, then deducted the bet with `state.myMoney -= bjCurrentBet` and refreshed the UI via `updBJ()` before dealing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698537dbc8f483338594a4c7aaa279b3)