### PR TITLE
Add home screen chat panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <span id="sysClock">00:00:00</span> | PING: <span id="sysPing">24ms</span> | BANK: $<span id="globalBank">0</span>
     </div>
     <div style="display:flex; gap:10px;">
-        <button class="menu-btn" onclick="window.openGame('overlayChat')">CHAT</button>
+        <button class="menu-btn" onclick="window.openGame('overlayChat')">VOICE</button>
         <button class="menu-btn" onclick="window.openGame('overlayBank')">BANK</button>
         <button class="menu-btn" onclick="window.openGame('overlayShop')">SHOP</button>
         <button class="menu-btn" onclick="window.openGame('overlayProfile')">PROFILE</button>
@@ -31,7 +31,7 @@
 </div>
 
 <div class="dropdown-content" id="menuDropdown">
-    <button onclick="window.openGame('overlayChat')">CHAT</button>
+    <button onclick="window.openGame('overlayChat')">VOICE</button>
     <button onclick="window.launchGame('geo')">GEO DASH</button>
     <button onclick="window.launchGame('type')">TYPE RUNNER</button>
     <button onclick="window.launchGame('pong')">PONG</button>
@@ -44,6 +44,7 @@
 </div>
 
 <div id="globalChat" class="home-chat">
+    <div class="chat-header">GLOBAL CHAT</div>
     <div id="chatHistory"></div>
     <input type="text" id="chatInput" placeholder="TYPE MESSAGE..." maxlength="30">
 </div>

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,10 @@
         box-shadow: 0 0 18px var(--accent-dim);
     }
     .home-chat { z-index: 50; }
+    .chat-header {
+        padding: 8px 10px; border-bottom: 1px solid var(--accent-dim);
+        font-size: 9px; letter-spacing: 1px; text-align: center; color: #fff;
+    }
     #chatHistory { flex: 1; overflow-y: auto; padding: 10px; color: #fff; text-shadow:none; }
     .chat-msg { margin-bottom: 5px; word-wrap: break-word; }
     .chat-user { color: var(--accent); font-weight: bold; }


### PR DESCRIPTION
### Motivation
- Make global chat visible on the home screen while converting the chat overlay into a voice-only panel for faster access and cleaner UX.

### Description
- Move the `#globalChat` markup from inside `#overlayChat` to the main layout (inserted after `#menuDropdown`), update the overlay header to "VOICE CHANNELS", and add `.home-chat` styling plus a `box-shadow` and higher `z-index` in `styles.css` to visually polish the new panel.

### Testing
- Launched a local server with `python -m http.server` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture `artifacts/home-chat.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698537f0d8088333a7c02873f52d5fb7)