### PR TITLE
Add version indicator using commit metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+<meta name="app-version" content="dev" />
 <title>GOONER TERMINAL V32 [PVP FIX]</title>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
 
@@ -358,6 +359,8 @@
     <div class="restart-hint">[ PRESS SPACE TO REBOOT ]</div>
     <button class="menu-btn" id="goExit" style="margin-top:20px;">EXIT TO MENU</button>
 </div>
+
+<div class="version-indicator" id="versionIndicator">VERSION: --</div>
 
 <script type="module" src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -53,3 +53,33 @@ document.getElementById("goExit").onclick = () => {
   closeOverlays();
   document.getElementById("modalGameOver").classList.remove("active");
 };
+
+const formatVersionValue = (value) => {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.replace(/^v/i, "");
+  if (normalized.toLowerCase() === "dev") return "dev";
+  if (/^[0-9a-f]{7,40}$/i.test(normalized)) return normalized.slice(0, 7);
+  return normalized;
+};
+
+const setVersionIndicator = () => {
+  const indicator = document.getElementById("versionIndicator");
+  if (!indicator) return;
+
+  const metaAppVersion = document.querySelector('meta[name="app-version"]')?.content;
+  const metaCommit = document.querySelector('meta[name="git-commit"]')?.content;
+  const candidates = [
+    window.APP_COMMIT,
+    window.COMMIT_SHA,
+    metaCommit,
+    window.APP_VERSION,
+    metaAppVersion,
+  ];
+
+  const resolved = candidates.map(formatVersionValue).find(Boolean) || "dev";
+  indicator.textContent = `VERSION: ${resolved}`;
+};
+
+setVersionIndicator();

--- a/styles.css
+++ b/styles.css
@@ -69,6 +69,14 @@
     .menu-btn:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; }
     .menu-btn:hover { background: var(--accent); color: #000; box-shadow: 0 0 10px var(--accent); }
     .sys-info { display: flex; gap: 15px; font-size: 8px; color: var(--accent); opacity: 0.8; }
+
+    .version-indicator {
+        position: fixed; bottom: 12px; left: 12px; z-index: 2000;
+        font-size: 8px; letter-spacing: 1px; color: var(--accent);
+        background: rgba(0, 0, 0, 0.7); border: 1px solid var(--accent-dim);
+        padding: 4px 6px; text-shadow: 0 0 8px var(--accent);
+        text-transform: uppercase; pointer-events: none;
+    }
     
     .dropdown-content {
         display: none; position: absolute; right: 20px; top: 50px; background-color: #000;


### PR DESCRIPTION
### Motivation
- Surface a build/version marker in the UI (bottom-left) so operators can see the current app version or commit short-hash at runtime. 
- Prefer a commit identifier when available so deployed instances can be traced to source.

### Description
- Added a `meta` tag `meta[name="app-version"]` and a new DOM element `<div id="versionIndicator">` in `index.html` to host the badge. 
- Added `.version-indicator` styling in `styles.css` to anchor and theme the badge to match the terminal UI. 
- Implemented `formatVersionValue` and `setVersionIndicator` in `script.js` to read version hints from `window.APP_COMMIT`, `window.COMMIT_SHA`, `meta[name="git-commit"]`, `window.APP_VERSION`, and `meta[name="app-version"]`, normalize values (strip leading `v`, shorten commit hashes to 7 chars), and fall back to `dev` when nothing is found. 

### Testing
- Launched a local HTTP server with `python -m http.server` and ran a Playwright script to load `http://127.0.0.1:8000/` and capture a screenshot, which completed successfully and produced `artifacts/version-indicator.png`.
- Verified repository changes with `git status` and committed the modifications with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985389bf7548333b00cb306f4b08e9f)