### PR TITLE
Restore home chat interactivity and surface persistent chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <span id="sysClock">00:00:00</span> | PING: <span id="sysPing">24ms</span> | BANK: $<span id="globalBank">0</span>
     </div>
     <div style="display:flex; gap:10px;">
-        <button class="menu-btn" onclick="window.openGame('overlayChat')">CHAT</button>
+        <button class="menu-btn" onclick="window.openGame('overlayChat')">VOICE</button>
         <button class="menu-btn" onclick="window.openGame('overlayBank')">BANK</button>
         <button class="menu-btn" onclick="window.openGame('overlayShop')">SHOP</button>
         <button class="menu-btn" onclick="window.openGame('overlayProfile')">PROFILE</button>
@@ -31,7 +31,7 @@
 </div>
 
 <div class="dropdown-content" id="menuDropdown">
-    <button onclick="window.openGame('overlayChat')">CHAT</button>
+    <button onclick="window.openGame('overlayChat')">VOICE</button>
     <button onclick="window.launchGame('geo')">GEO DASH</button>
     <button onclick="window.launchGame('type')">TYPE RUNNER</button>
     <button onclick="window.launchGame('pong')">PONG</button>
@@ -43,6 +43,12 @@
     <button onclick="window.launchGame('flappy')" id="btnFlappy" style="display:none; color:gold;">FLAPPY GOON</button>
 </div>
 
+<div id="globalChat" class="home-chat">
+    <div class="chat-header">GLOBAL CHAT</div>
+    <div id="chatHistory"></div>
+    <input type="text" id="chatInput" placeholder="TYPE MESSAGE..." maxlength="30">
+</div>
+
 <div class="wrap">
     <div class="gooner-btn" id="mainBtn">GOONER</div>
     <div class="subtitle">TERMINAL ONLINE</div>
@@ -51,11 +57,7 @@
 
 <div class="overlay" id="overlayChat">
     <div class="score-box chat-box">
-        <h2 style="text-align:center;">GLOBAL CHAT</h2>
-        <div id="globalChat">
-            <div id="chatHistory"></div>
-            <input type="text" id="chatInput" placeholder="TYPE MESSAGE..." maxlength="30">
-        </div>
+        <h2 style="text-align:center;">VOICE CHANNELS</h2>
         <div class="voice-panel">
             <div class="voice-header">VOICE CHANNELS</div>
             <div class="voice-channels">

--- a/styles.css
+++ b/styles.css
@@ -88,11 +88,19 @@
         position: fixed; bottom: 20px; left: 20px; width: 300px; height: 200px;
         background: rgba(0,0,0,0.8); border: 1px solid var(--accent); z-index: 10;
         display: flex; flex-direction: column; font-size: 10px;
+        box-shadow: 0 0 18px var(--accent-dim);
+        pointer-events: auto; touch-action: auto;
     }
-    #chatHistory { flex: 1; overflow-y: auto; padding: 10px; color: #fff; text-shadow:none; }
+    .home-chat { z-index: 900; pointer-events: auto; touch-action: auto; }
+    .home-chat * { pointer-events: auto; touch-action: auto; }
+    .chat-header {
+        padding: 8px 10px; border-bottom: 1px solid var(--accent-dim);
+        font-size: 9px; letter-spacing: 1px; text-align: center; color: #fff;
+    }
+    #chatHistory { flex: 1; overflow-y: auto; padding: 10px; color: #fff; text-shadow:none; user-select: text; }
     .chat-msg { margin-bottom: 5px; word-wrap: break-word; }
     .chat-user { color: var(--accent); font-weight: bold; }
-    #chatInput { background: #000; border: none; border-top: 1px solid var(--accent); color: var(--accent); padding: 10px; font-family: inherit; outline: none; }
+    #chatInput { background: #000; border: none; border-top: 1px solid var(--accent); color: var(--accent); padding: 10px; font-family: inherit; outline: none; cursor: text; user-select: text; touch-action: auto; }
     .chat-box { max-width: 760px; width: min(90vw, 760px); }
     .voice-panel {
         margin-top: 15px; padding: 15px; border: 1px solid var(--accent-dim);


### PR DESCRIPTION
### Motivation
- The home/global chat on the landing screen was non-interactive (treated like a raster/PNG) because pointer events and touch actions were disabled and the chat UI was not surfaced above other layers.
- Users should be able to click, scroll, select text, and type directly in the persistent chat without opening the overlay.

### Description
- Moved the persistent chat markup into the home UI by adding `<div id="globalChat" class="home-chat">` with a header, `#chatHistory`, and `#chatInput` to `index.html` and repurposed the overlay to show voice channels instead of duplicating the home chat.
- Enabled interaction by updating `styles.css` to set `pointer-events: auto; touch-action: auto;` on `#globalChat`, `.home-chat`, and `.home-chat *`, increased the home chat `z-index` to `900`, and added `user-select: text` to `#chatHistory` and `cursor: text; user-select: text; touch-action: auto;` to `#chatInput`.
- Tidy: added a subtle `box-shadow` for the home chat panel and reorganized the chat CSS block for clarity.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and ran a Playwright script to open `http://127.0.0.1:8000/index.html` and capture `artifacts/home-chat-clickable.png`, and the script completed successfully.
- Confirmed via grep searches (`rg`) that the updated rules apply to the home chat selectors and inspected the rendered output with the captured screenshot."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698537f0d8088333a7c02873f52d5fb7)