### PR TITLE
Add Discord-style voice dock to the home screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,9 +36,7 @@
         <span id="sysPing">24ms</span> | BANK: $<span id="globalBank">0</span>
       </div>
       <div style="display: flex; gap: 10px">
-        <button class="menu-btn" onclick="window.openGame('overlayChat')">
-          VOICE
-        </button>
+        <button class="menu-btn" id="voiceDockToggle">VOICE</button>
         <button class="menu-btn" onclick="window.openGame('overlayBank')">
           BANK
         </button>
@@ -57,7 +55,7 @@
 
     <!-- Dropdown game menu (toggled from the top bar). -->
     <div class="dropdown-content" id="menuDropdown">
-      <button onclick="window.openGame('overlayChat')">VOICE</button>
+      <button id="voiceDockToggleMenu">VOICE</button>
       <button onclick="window.launchGame('geo')">GEO DASH</button>
       <button onclick="window.launchGame('type')">TYPE RUNNER</button>
       <button onclick="window.launchGame('pong')">PONG</button>
@@ -92,6 +90,30 @@
       />
     </div>
 
+    <!-- Voice chat dock (Discord-style, always visible on home). -->
+    <div id="voiceDock" class="voice-dock">
+      <div class="voice-dock-header">
+        <span>VOICE CHANNELS</span>
+        <button class="voice-dock-toggle" id="voiceDockCollapse">–</button>
+      </div>
+      <div class="voice-panel">
+        <div class="voice-channels">
+          <button class="menu-btn voice-btn" data-channel="alpha">ALPHA</button>
+          <button class="menu-btn voice-btn" data-channel="bravo">BRAVO</button>
+          <button class="menu-btn voice-btn" data-channel="charlie">CHARLIE</button>
+        </div>
+        <div class="voice-status">
+          <span>STATUS:</span>
+          <span id="voiceStatus">OFFLINE</span>
+        </div>
+        <div class="voice-controls">
+          <button class="menu-btn" id="voiceMuteBtn">MUTE</button>
+          <button class="menu-btn" id="voiceLeaveBtn">LEAVE</button>
+        </div>
+        <audio id="voiceRemote" autoplay></audio>
+      </div>
+    </div>
+
     <!-- Landing splash section + operator info. -->
     <div class="wrap">
       <div class="gooner-btn" id="mainBtn">GOONER</div>
@@ -103,44 +125,6 @@
           style="color: #fff; background: var(--accent-dim); padding: 2px 5px"
           >[RAT]</span
         >
-      </div>
-    </div>
-
-    <!-- Voice chat overlay (WebRTC channels). -->
-    <div class="overlay" id="overlayChat">
-      <div class="score-box chat-box">
-        <h2 style="text-align: center">VOICE CHANNELS</h2>
-        <div class="voice-panel">
-          <div class="voice-header">VOICE CHANNELS</div>
-          <div class="voice-channels">
-            <button class="menu-btn voice-btn" data-channel="alpha">
-              ALPHA
-            </button>
-            <button class="menu-btn voice-btn" data-channel="bravo">
-              BRAVO
-            </button>
-            <button class="menu-btn voice-btn" data-channel="charlie">
-              CHARLIE
-            </button>
-          </div>
-          <div class="voice-status">
-            <span>STATUS:</span>
-            <span id="voiceStatus">OFFLINE</span>
-          </div>
-          <div class="voice-controls">
-            <button class="menu-btn" id="voiceMuteBtn">MUTE</button>
-            <button class="menu-btn" id="voiceLeaveBtn">LEAVE</button>
-          </div>
-          <audio id="voiceRemote" autoplay></audio>
-        </div>
-        <button
-          class="term-btn"
-          id="chatCloseBtn"
-          style="margin-top: 20px"
-          onclick="window.closeOverlays()"
-        >
-          CLOSE
-        </button>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ import { initRunner } from "./games/runner.js";
 import { initBJ } from "./games/blackjack.js";
 import { initTTT } from "./games/ttt.js";
 import { initHangman } from "./games/hangman.js";
+import { initVoiceChat } from "./voice.js";
 
 // Expose select helpers globally for inline HTML event handlers.
 window.openGame = openGame;
@@ -105,3 +106,25 @@ const setVersionIndicator = () => {
 
 // Initialize the version indicator on load.
 setVersionIndicator();
+
+const toggleVoiceDock = (forceOpen = null) => {
+  const dock = document.getElementById("voiceDock");
+  if (!dock) return;
+  const shouldCollapse =
+    forceOpen === null ? !dock.classList.contains("collapsed") : !forceOpen;
+  dock.classList.toggle("collapsed", shouldCollapse);
+  const toggleBtn = document.getElementById("voiceDockCollapse");
+  if (toggleBtn) toggleBtn.textContent = shouldCollapse ? "+" : "–";
+};
+
+document.getElementById("voiceDockToggle")?.addEventListener("click", () => {
+  toggleVoiceDock(true);
+});
+document.getElementById("voiceDockToggleMenu")?.addEventListener("click", () => {
+  toggleVoiceDock(true);
+});
+document.getElementById("voiceDockCollapse")?.addEventListener("click", () => {
+  toggleVoiceDock();
+});
+
+initVoiceChat();

--- a/styles.css
+++ b/styles.css
@@ -292,6 +292,46 @@ body::before {
 .home-chat {
   z-index: 50;
 }
+.voice-dock {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 280px;
+  background: rgba(7, 7, 7, 0.92);
+  border: 1px solid var(--accent);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  font-size: 10px;
+  box-shadow: 0 0 18px var(--accent-dim);
+  pointer-events: auto;
+  touch-action: auto;
+}
+.voice-dock.collapsed .voice-panel {
+  display: none;
+}
+.voice-dock-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--accent-dim);
+  color: #fff;
+  letter-spacing: 1px;
+  font-size: 9px;
+  text-align: center;
+}
+.voice-dock-toggle {
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent);
+  font-size: 12px;
+  width: 24px;
+  height: 24px;
+  line-height: 18px;
+  cursor: pointer;
+  padding: 0;
+}
 .chat-header {
   padding: 8px 10px;
   border-bottom: 1px solid var(--accent-dim);
@@ -333,20 +373,14 @@ body::before {
   width: min(90vw, 760px);
 }
 .voice-panel {
-  margin-top: 15px;
-  padding: 15px;
+  margin-top: 10px;
+  padding: 12px;
   border: 1px solid var(--accent-dim);
   background: rgba(0, 0, 0, 0.7);
   box-shadow: inset 0 0 20px rgba(255, 6, 6, 0.1);
   display: flex;
   flex-direction: column;
   gap: 12px;
-}
-.voice-header {
-  font-size: 10px;
-  letter-spacing: 2px;
-  text-align: center;
-  color: #fff;
 }
 .voice-channels {
   display: grid;


### PR DESCRIPTION
### Motivation
- Provide a persistent, Discord-like voice chat UI on the home screen positioned in the bottom-right so users can join voice channels without opening a separate overlay.  
- Make voice chat immediately accessible and collapsible while reusing the existing WebRTC/Firestore signaling in `voice.js`.

### Description
- Replaced the modal voice overlay with a persistent dock by adding a `#voiceDock` element to `index.html` and removing the old `overlayChat` block.  
- Added UI controls and wiring: top bar/menu VOICE buttons now use `voiceDockToggle` / `voiceDockToggleMenu`, the dock header has a collapse button `voiceDockCollapse`, and channel buttons use existing `voice-btn` classes.  
- Added dock styling and collapse behavior in `styles.css` (`.voice-dock`, `.voice-dock-header`, `.voice-dock.collapsed`, etc.) and adjusted voice panel spacing.  
- Initialized the voice module and wired the dock toggle/collapse in `script.js` by importing `initVoiceChat` from `voice.js`, adding `toggleVoiceDock(...)` helper, hooking the topbar/menu toggles, and calling `initVoiceChat()` on load.

### Testing
- Started a local static server with `python3 -m http.server 8000` and verified the page loads.  
- Ran a headless browser script (Playwright) that opened `http://127.0.0.1:8000/index.html` and captured a screenshot (`artifacts/voice-dock.png`) showing the dock rendered in the bottom-right, which succeeded.  
- No automated unit tests were added or failed; visual smoke test passed and the code was committed (`Add voice chat dock on home screen`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985488e65b4833390fd4dcc0bac1945)