### PR TITLE
Fix voice chat status updates during ICE connection

### DIFF
--- a/voice.js
+++ b/voice.js
@@ -87,7 +87,10 @@ async function createPeerConnection() {
   pc.oniceconnectionstatechange = () => {
     if (!pc) return;
     if (pc.iceConnectionState === "checking") setStatus("CONNECTING");
+    if (pc.iceConnectionState === "connected") setStatus("LIVE");
+    if (pc.iceConnectionState === "completed") setStatus("LIVE");
     if (pc.iceConnectionState === "disconnected") setStatus("RECONNECTING");
+    if (pc.iceConnectionState === "failed") setStatus("FAILED");
   };
   pc.onicecandidate = async (event) => {
     if (!event.candidate || !currentChannel) return;


### PR DESCRIPTION
### Motivation
- Prevent the voice UI from lingering on `CONNECTING` by updating ICE connection state handling so successful ICE transitions show the call as `LIVE` and failures show `FAILED`.

### Description
- Update `pc.oniceconnectionstatechange` in `voice.js` to set status to `LIVE` when `pc.iceConnectionState` is `connected` or `completed`, and to set `FAILED` when it is `failed`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854aabb980833399127cee10200b2a)