### PR TITLE
Remove version indicator UI and rendering logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -75,36 +75,3 @@ document.getElementById("goExit").onclick = () => {
   closeOverlays();
   document.getElementById("modalGameOver").classList.remove("active");
 };
-
-// Normalize version strings (semver, commit sha, or "dev") for display.
-const formatVersionValue = (value) => {
-  if (!value) return null;
-  const trimmed = String(value).trim();
-  if (!trimmed) return null;
-  const normalized = trimmed.replace(/^v/i, "");
-  if (normalized.toLowerCase() === "dev") return "dev";
-  if (/^[0-9a-f]{7,40}$/i.test(normalized)) return normalized.slice(0, 7);
-  return normalized;
-};
-
-// Pull version metadata from globals and <meta> tags, then render to the UI.
-const setVersionIndicator = () => {
-  const indicator = document.getElementById("versionIndicator");
-  if (!indicator) return;
-
-  const metaAppVersion = document.querySelector('meta[name="app-version"]')?.content;
-  const metaCommit = document.querySelector('meta[name="git-commit"]')?.content;
-  const candidates = [
-    window.APP_COMMIT,
-    window.COMMIT_SHA,
-    metaCommit,
-    window.APP_VERSION,
-    metaAppVersion,
-  ];
-
-  const resolved = candidates.map(formatVersionValue).find(Boolean) || "dev";
-  indicator.textContent = `VERSION: ${resolved}`;
-};
-
-// Initialize the version indicator on load.
-setVersionIndicator();

--- a/styles.css
+++ b/styles.css
@@ -221,22 +221,6 @@ body::before {
   opacity: 0.8;
 }
 
-.version-indicator {
-  position: fixed;
-  bottom: 12px;
-  left: 12px;
-  z-index: 2000;
-  font-size: 8px;
-  letter-spacing: 1px;
-  color: var(--accent);
-  background: rgba(0, 0, 0, 0.7);
-  border: 1px solid var(--accent-dim);
-  padding: 4px 6px;
-  text-shadow: 0 0 8px var(--accent);
-  text-transform: uppercase;
-  pointer-events: none;
-}
-
 /* Games dropdown menu anchored to the top bar. */
 .dropdown-content {
   display: none;


### PR DESCRIPTION
### Motivation
- The app should no longer render a version badge in the UI, so remove the DOM element, associated display logic, and unused styles to simplify the codebase and avoid showing build metadata.

### Description
- Deleted the `VERSION: DEV` indicator element from `index.html` so there is no DOM target for version display.
- Removed the `formatVersionValue` and `setVersionIndicator` functions and the initialization call from `script.js` to drop all runtime version rendering logic.
- Removed the `.version-indicator` CSS block from `styles.css` to eliminate unused styling related to the badge.

### Testing
- Performed static file inspections using `nl`/`sed` on `index.html`, `script.js`, and `styles.css` to confirm the version element, rendering code, and CSS block were removed, and those inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698559547fa08333ae646ae5743551ea)