### PR TITLE
Expand Scores overlay: add PLAYERS tab and all game leaderboards

### DIFF
--- a/core.js
+++ b/core.js
@@ -1186,6 +1186,19 @@ function loadLeaderboard(game) {
   const list = document.getElementById("scoreList");
   list.innerHTML = "LOADING...";
   if (leaderboardUnsub) leaderboardUnsub();
+  if (game === "players") {
+    const q = query(collection(db, "gooner_users"), orderBy("name"), limit(100));
+    leaderboardUnsub = onSnapshot(q, (snap) => {
+      const rows = [];
+      snap.forEach((d) => {
+        const data = d.data();
+        rows.push({ name: data.name || d.id, score: data.rank || "RAT" });
+      });
+      renderLeaderboardRows(list, rows);
+    });
+    return;
+  }
+
   if (game === "richest") {
     const q = query(collection(db, "gooner_users"), orderBy("money", "desc"), limit(10));
     leaderboardUnsub = onSnapshot(q, (snap) => {

--- a/index.html
+++ b/index.html
@@ -260,11 +260,18 @@
           GLOBAL LEADERBOARD
         </h2>
         <div class="score-tabs">
+          <div class="score-tab" data-tab="players">PLAYERS</div>
           <div class="score-tab active" data-tab="richest">RICHEST</div>
           <div class="score-tab" data-tab="geo">GEO DASH</div>
           <div class="score-tab" data-tab="type">TYPER</div>
           <div class="score-tab" data-tab="snake">SNAKE</div>
           <div class="score-tab" data-tab="pong">PONG</div>
+          <div class="score-tab" data-tab="runner">RUNNER</div>
+          <div class="score-tab" data-tab="dodge">DODGE</div>
+          <div class="score-tab" data-tab="flappy">FLAPPY</div>
+          <div class="score-tab" data-tab="blackjack">BLACKJACK</div>
+          <div class="score-tab" data-tab="ttt">TIC TAC TOE</div>
+          <div class="score-tab" data-tab="hangman">HANGMAN</div>
         </div>
         <div class="score-list" id="scoreList">
           <div class="score-item">LOADING DATA...</div>

--- a/styles.css
+++ b/styles.css
@@ -739,6 +739,9 @@ canvas {
   gap: 10px;
   margin-bottom: 20px;
   justify-content: center;
+  flex-wrap: wrap;
+  max-height: 140px;
+  overflow-y: auto;
 }
 .score-tab {
   padding: 10px;


### PR DESCRIPTION
### Motivation
- Make the Scores overlay expose leaderboards for every tracked game and provide a quick player directory so users can browse players and game-specific leaderboards from the same UI.

### Description
- Added new score tabs in `index.html` for `players`, `runner`, `dodge`, `flappy`, `blackjack`, `ttt`, and `hangman` so all games are selectable from the Scores overlay.
- Implemented support for the `players` tab in `core.js` by adding a `loadLeaderboard` branch that queries `gooner_users` ordered by `name` and renders each player with their `rank` value.
- Adjusted leaderboard tab styling in `styles.css` to `flex-wrap` and enable scrolling so the expanded tab set fits the overlay without layout breakage.

### Testing
- Ran JavaScript syntax checks with `node --check core.js && node --check script.js`, which completed successfully.
- Served the app with `python -m http.server 4173` and verified the Scores overlay visually using a Playwright-driven screenshot, confirming the new tabs and player list render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b611e38b4832ba0ae102487950622)