### PR TITLE
Scale Flappy Goon difficulty with score

### DIFF
--- a/games/flappy.js
+++ b/games/flappy.js
@@ -15,10 +15,31 @@ let fAnim;
 
 const FLAP_STRENGTH = -7;
 const GRAVITY = 0.5;
-const PIPE_SPEED = 2.2;
-const PIPE_GAP = 200;
-const PIPE_SPAWN_CHANCE = 0.01;
+const BASE_PIPE_SPEED = 2.2;
+const BASE_PIPE_GAP = 200;
+const MIN_PIPE_GAP = 130;
+const BASE_PIPE_SPAWN_CHANCE = 0.01;
+const MAX_PIPE_SPAWN_CHANCE = 0.03;
 const PIPE_MIN_DISTANCE = 220;
+
+function getDifficultyFactor() {
+  return Math.min(fScore, 30) / 30;
+}
+
+function getPipeSpeed() {
+  return BASE_PIPE_SPEED + getDifficultyFactor() * 1.8;
+}
+
+function getPipeGap() {
+  return BASE_PIPE_GAP - getDifficultyFactor() * (BASE_PIPE_GAP - MIN_PIPE_GAP);
+}
+
+function getPipeSpawnChance() {
+  return (
+    BASE_PIPE_SPAWN_CHANCE +
+    getDifficultyFactor() * (MAX_PIPE_SPAWN_CHANCE - BASE_PIPE_SPAWN_CHANCE)
+  );
+}
 
 export function initFlappy() {
   state.currentGame = "flappy";
@@ -50,12 +71,12 @@ function loopFlappy() {
   }
   const lastPipe = fPipes[fPipes.length - 1];
   const canSpawnPipe = !lastPipe || lastPipe.x < 400 - PIPE_MIN_DISTANCE;
-  if (canSpawnPipe && Math.random() < PIPE_SPAWN_CHANCE) {
-    fPipes.push({ x: 400, gap: PIPE_GAP, h: Math.random() * 250 + 50 });
+  if (canSpawnPipe && Math.random() < getPipeSpawnChance()) {
+    fPipes.push({ x: 400, gap: getPipeGap(), h: Math.random() * 250 + 50 });
   }
   for (let i = fPipes.length - 1; i >= 0; i--) {
     const p = fPipes[i];
-    p.x -= PIPE_SPEED;
+    p.x -= getPipeSpeed();
     ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
     ctx.fillRect(p.x, 0, 40, p.h);
     ctx.fillRect(p.x, p.h + p.gap, 40, 600);


### PR DESCRIPTION
### Motivation
- Make the Flappy Goon experience progressively more challenging as the player scores to keep runs engaging and increase difficulty over time.
- Adjust pipe behavior (speed, gap, spawn frequency) based on a capped difficulty factor so the ramp is predictable and bounded.

### Description
- Replace static `PIPE_SPEED`, `PIPE_GAP`, and `PIPE_SPAWN_CHANCE` with `BASE_PIPE_SPEED`, `BASE_PIPE_GAP`, `BASE_PIPE_SPAWN_CHANCE`, `MIN_PIPE_GAP`, and `MAX_PIPE_SPAWN_CHANCE` and introduce a capped difficulty factor (0→1 over the first 30 points) computed in `getDifficultyFactor()`.
- Add helper functions `getPipeSpeed()`, `getPipeGap()`, and `getPipeSpawnChance()` that scale pipe speed, gap, and spawn chance with the difficulty factor.
- Use the new getters when spawning pipes and moving them so obstacle speed, spacing, and frequency increase as `fScore` rises while leaving collision and scoring logic unchanged.
- Keep existing player controls, rendering, and high-score updates intact (changes localized to `games/flappy.js`).

### Testing
- Ran `node --check games/flappy.js` and it completed without errors.
- Launched a local server with `python3 -m http.server 4173` and used a Playwright script to open the page and verify the Flappy view rendered; the browser capture was produced successfully.
- No automated unit tests existed for the game; the above static check and manual browser verification were used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b612b19c4832ba071489c46700ee5)