### PR TITLE
Fix score menu scaling and leaderboard empty-state

### DIFF
--- a/core.js
+++ b/core.js
@@ -1232,10 +1232,14 @@ document.querySelectorAll(".score-tab").forEach((t) => {
   };
 });
 let leaderboardUnsub = null;
-const renderLeaderboardRows = (list, rows, { valuePrefix = "" } = {}) => {
+const renderLeaderboardRows = (
+  list,
+  rows,
+  { valuePrefix = "", emptyText = "NO DATA YET — PLAY A ROUND TO POPULATE THIS BOARD" } = {}
+) => {
   list.innerHTML = "";
   if (!rows.length) {
-    list.innerHTML = '<div style="padding:10px">NO DATA</div>';
+    list.innerHTML = `<div style="padding:10px">${emptyText}</div>`;
     return;
   }
   rows.forEach((row, i) => {

--- a/index.html
+++ b/index.html
@@ -288,9 +288,6 @@
           <div class="score-tab" data-tab="runner">RUNNER</div>
           <div class="score-tab" data-tab="dodge">DODGE</div>
           <div class="score-tab" data-tab="flappy">FLAPPY</div>
-          <div class="score-tab" data-tab="blackjack">BLACKJACK</div>
-          <div class="score-tab" data-tab="ttt">TIC TAC TOE</div>
-          <div class="score-tab" data-tab="hangman">HANGMAN</div>
         </div>
         <div class="score-list" id="scoreList">
           <div class="score-item">LOADING DATA...</div>

--- a/styles.css
+++ b/styles.css
@@ -728,42 +728,44 @@ canvas {
 
 /* Leaderboard */
 .score-box {
-  width: 80%;
-  max-width: 600px;
+  width: min(96vw, 920px);
   border: 2px solid var(--accent);
   background: #000;
-  padding: 20px;
+  padding: clamp(12px, 2.5vw, 24px);
 }
 .score-tabs {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 20px;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-height: 140px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  margin-bottom: 14px;
+  max-height: 220px;
   overflow-y: auto;
 }
 .score-tab {
-  padding: 10px;
+  padding: 10px 8px;
   border: 1px solid var(--accent);
   cursor: pointer;
-  font-size: 10px;
+  font-size: clamp(9px, 1.8vw, 12px);
+  text-align: center;
+  line-height: 1.3;
 }
 .score-tab.active {
   background: var(--accent);
   color: #000;
 }
 .score-list {
-  max-height: 300px;
+  max-height: min(50vh, 420px);
   overflow-y: auto;
   text-align: left;
 }
 .score-item {
   display: flex;
   justify-content: space-between;
-  padding: 10px;
+  gap: 10px;
+  padding: 10px 8px;
   border-bottom: 1px dashed var(--accent-dim);
-  font-size: 12px;
+  font-size: clamp(10px, 2vw, 13px);
+  word-break: break-word;
 }
 .profile-stats {
   text-align: left;


### PR DESCRIPTION
### Motivation
- The Scores overlay was not scaling properly on different viewports and some tabs showed a terse `NO DATA` message that confused users.
- The goal is to make the leaderboard UI responsive, reduce empty/unsupported tabs, and provide a clearer empty-state prompt so users know how to populate leaderboards.

### Description
- Adjusted leaderboard layout and typography in `styles.css` by making `.score-box` responsive, converting `.score-tabs` to a responsive grid, and tuning `.score-item` sizing and wrapping.
- Removed unsupported/rarely-populated tabs (`BLACKJACK`, `TIC TAC TOE`, `HANGMAN`) from the Scores overlay in `index.html` to avoid showing empty boards.
- Improved the empty-state UX in `core.js` by extending `renderLeaderboardRows` to accept a clearer `emptyText` and replacing the generic `NO DATA` string with a helpful prompt.
- Changes touch `styles.css`, `index.html`, and `core.js` to implement layout and messaging fixes.

### Testing
- Ran `node --check core.js` and it succeeded.
- Ran `node --check script.js` and it succeeded.
- Attempted an automated Playwright screenshot of the overlay after launching a local server, but the browser tooling could not load the page in this environment (screenshot attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b66595f70832bad961e2f6121a0a8)