### PR TITLE
Fix bank transfer flow and improve send-money UX

### DIFF
--- a/core.js
+++ b/core.js
@@ -532,6 +532,7 @@ const initAuth = async () => {
   }
 };
 initAuth();
+setupBankTransferUX();
 onAuthStateChanged(auth, (u) => {
   if (u) {
     myUid = u.uid;
@@ -696,6 +697,34 @@ export async function saveStats() {
 }
 
 // Send money to another player account using a transaction for consistency.
+function setupBankTransferUX() {
+  const userInput = document.getElementById("bankTransferUser");
+  const amountInput = document.getElementById("bankTransferAmount");
+  const presetContainer = document.getElementById("bankTransferPresets");
+  if (!userInput || !amountInput || !presetContainer) return;
+
+  const sendOnEnter = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      tradeMoney();
+    }
+  };
+  userInput.addEventListener("keydown", sendOnEnter);
+  amountInput.addEventListener("keydown", sendOnEnter);
+
+  presetContainer.querySelectorAll("button[data-amount]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const value = button.dataset.amount;
+      if (value === "max") {
+        amountInput.value = Math.max(1, myMoney);
+      } else {
+        amountInput.value = value;
+      }
+      amountInput.focus();
+    });
+  });
+}
+
 export async function tradeMoney() {
   const msg = document.getElementById("bankTransferMsg");
   const userInput = document.getElementById("bankTransferUser");
@@ -748,6 +777,7 @@ export async function tradeMoney() {
     msg.innerText = e.message || "TRANSFER FAILED";
     msg.style.color = "#f66";
   }
+}
 // Consume exactly one shield charge if available.
 export function consumeShield() {
   const shieldIndex = myInventory.indexOf("item_shield");

--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
             id="bankTransferUser"
             type="text"
             maxlength="20"
-            placeholder="PLAYER"
+            placeholder="PLAYER NAME"
           />
           <input
             class="term-input bank-transfer-input"
@@ -238,9 +238,16 @@
             type="number"
             min="1"
             step="1"
-            placeholder="AMOUNT"
+            placeholder="AMOUNT ($)"
           />
+          <div class="bank-transfer-presets" id="bankTransferPresets">
+            <button class="term-btn bank-preset-btn" data-amount="100">$100</button>
+            <button class="term-btn bank-preset-btn" data-amount="500">$500</button>
+            <button class="term-btn bank-preset-btn" data-amount="1000">$1000</button>
+            <button class="term-btn bank-preset-btn" data-amount="max">MAX</button>
+          </div>
           <button class="term-btn" onclick="window.tradeMoney()">SEND MONEY</button>
+          <div class="bank-transfer-help">TIP: PRESS ENTER TO SEND</div>
           <div id="bankTransferMsg" class="bank-transfer-msg"></div>
         </div>
         <div class="bank-log" id="bankLog"></div>

--- a/styles.css
+++ b/styles.css
@@ -1287,6 +1287,23 @@ canvas {
   padding: 8px;
 }
 
+.bank-transfer-presets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.bank-preset-btn {
+  padding: 6px;
+  font-size: 9px;
+}
+
+.bank-transfer-help {
+  text-align: center;
+  color: #777;
+  font-size: 8px;
+}
+
 .bank-transfer-msg {
   min-height: 12px;
   font-size: 10px;


### PR DESCRIPTION
### Motivation
- Fix a bug where the `tradeMoney` flow could break later code boundaries and make sending money more convenient.
- Improve the bank overlay UX so users can send transfers faster with presets and keyboard submit.

### Description
- Close the `tradeMoney` function block and call `setupBankTransferUX()` at startup to ensure clean function boundaries and initialization.
- Add `setupBankTransferUX()` to wire Enter-to-send from both inputs and to handle quick preset buttons (`$100`, `$500`, `$1000`, `MAX`).
- Update `index.html` to use clearer placeholders (`PLAYER NAME`, `AMOUNT ($)`), add preset buttons and a small help tip, and keep the existing `SEND MONEY` button.
- Add styles in `styles.css` for `.bank-transfer-presets`, `.bank-preset-btn`, and `.bank-transfer-help` to match the UI.

### Testing
- `node --check core.js` — passed.
- `node --check script.js` — passed.
- Served the app with `python -m http.server 4173` to validate the UI rendered and the server started successfully.
- Attempted a Playwright screenshot to visually verify the overlay but the Chromium process crashed in this environment (`TargetClosedError` / SIGSEGV), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b66e0ad70832bbd09b4c1ad0fee6a)