### PR TITLE
Add lowercase window.trademoney alias

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,6 +30,8 @@ window.closeOverlays = closeOverlays;
 window.showGameOver = showGameOver;
 window.buyItem = buyItem;
 window.tradeMoney = tradeMoney;
+// Backward-compatible alias for legacy/lowercase callers.
+window.trademoney = tradeMoney;
 window.startJob = startJob;
 window.submitJob = submitJob;
 window.initTypeGame = initTypeGame;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from callers using `window.trademoney()` (lowercase `m`) by providing a backward-compatible global alias.

### Description
- Added `window.trademoney = tradeMoney;` in `script.js` alongside the existing `window.tradeMoney` binding so the canonical API is preserved while supporting legacy/lowercase callers.

### Testing
- Ran `node --check script.js` and `node --check core.js`, and both syntax checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6c31368c832ba045c6f335808032)