### PR TITLE
Fix bank transfer handler and remove lowercase global alias

### DIFF
--- a/core.js
+++ b/core.js
@@ -712,7 +712,8 @@ function setupBankTransferUX() {
   const userInput = document.getElementById("bankTransferUser");
   const amountInput = document.getElementById("bankTransferAmount");
   const presetContainer = document.getElementById("bankTransferPresets");
-  if (!userInput || !amountInput || !presetContainer) return;
+  const sendButton = document.getElementById("bankTransferSend");
+  if (!userInput || !amountInput || !presetContainer || !sendButton) return;
 
   const sendOnEnter = (event) => {
     if (event.key === "Enter") {
@@ -733,6 +734,10 @@ function setupBankTransferUX() {
       }
       amountInput.focus();
     });
+  });
+
+  sendButton.addEventListener("click", () => {
+    tradeMoney();
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
             <button class="term-btn bank-preset-btn" data-amount="1000">$1000</button>
             <button class="term-btn bank-preset-btn" data-amount="max">MAX</button>
           </div>
-          <button class="term-btn" onclick="window.tradeMoney()">SEND MONEY</button>
+          <button class="term-btn" id="bankTransferSend">SEND MONEY</button>
           <div class="bank-transfer-help">TIP: PRESS ENTER TO SEND</div>
           <div id="bankTransferMsg" class="bank-transfer-msg"></div>
         </div>


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by relying on an inline global call for the bank "SEND MONEY" action and undo the temporary lowercase alias that masked a typo. 

### Description
- Replaced the inline `onclick=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6c31368c832ba045c6f335808032)