### PR TITLE
Make Pong easier and less punishing

### DIFF
--- a/games/pong.js
+++ b/games/pong.js
@@ -14,7 +14,7 @@ import {
 let pCtx;
 let pCv;
 let ball = { x: 400, y: 300, dx: 5, dy: 5 };
-let p1 = { y: 250, h: 80 };
+let p1 = { y: 250, h: 100 };
 let p2 = { y: 250, h: 80 };
 let pSc = 0;
 let aiSc = 0;
@@ -22,7 +22,7 @@ let pDiff = 0.08;
 let pAnim;
 
 export function setPongDiff(level) {
-  pDiff = level === "hard" ? 0.15 : 0.08;
+  pDiff = level === "hard" ? 0.14 : 0.055;
   resetBall();
 }
 
@@ -60,7 +60,8 @@ function loopPong() {
   }
   if (p1.y < 0) p1.y = 0;
   if (p1.y > 520) p1.y = 520;
-  p2.y += (ball.y - p2.h / 2 - p2.y) * pDiff;
+  const aiCatchupDebuff = aiSc - pSc >= 3 ? 0.7 : 1;
+  p2.y += (ball.y - p2.h / 2 - p2.y) * pDiff * aiCatchupDebuff;
   if (p2.y < 0) p2.y = 0;
   if (p2.y > 520) p2.y = 520;
   pCtx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
@@ -73,12 +74,12 @@ function loopPong() {
   ball.y += ball.dy;
   if (ball.y < 0 || ball.y > 600) ball.dy *= -1;
   if (ball.x < 30 && ball.y > p1.y && ball.y < p1.y + p1.h) {
-    ball.dx = Math.abs(ball.dx) + 0.5;
+    ball.dx = Math.min(Math.abs(ball.dx) + 0.4, 9);
     ball.x = 30;
     beep(600);
   }
   if (ball.x > 770 && ball.y > p2.y && ball.y < p2.y + p2.h) {
-    ball.dx = -(Math.abs(ball.dx) + 0.5);
+    ball.dx = -Math.min(Math.abs(ball.dx) + 0.4, 9);
     ball.x = 770;
     beep(600);
   }
@@ -87,7 +88,6 @@ function loopPong() {
     resetBall();
     beep(200);
     checkLossStreak();
-    pSc = 0;
   }
   if (ball.x > 800) {
     pSc++;


### PR DESCRIPTION
### Motivation
- Improve playability by reducing unfair difficulty spikes and giving players a better chance to recover during matches.
- Prevent infinite or overly fast rallies that make the game feel impossible while keeping hard mode challenging.

### Description
- Increased player paddle height from `80` to `100` to improve defensive coverage by changing `p1.h` in `games/pong.js`.
- Rebalanced difficulty by setting `setPongDiff` easy to `0.055` and hard to `0.14` to make easy mode noticeably slower while retaining challenge on hard.
- Added an AI catch-up debuff that reduces AI tracking to `0.7x` when the AI leads by 3 or more points to give players a recovery window.
- Capped horizontal ball speed growth with `Math.min(..., 9)` and reduced per-hit acceleration to `0.4`, and removed the player score reset on AI scores so progress is not wiped.

### Testing
- Ran `node --check games/pong.js` to ensure no syntax errors and it succeeded.
- Launched the app with `python3 -m http.server 4173` and verified the page loaded successfully.
- Captured a gameplay screenshot via Playwright after launching the `pong` overlay to validate the in-browser behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca0de98a0832b92d437717b590e4e)