### PR TITLE
Make arcade game loops frame-rate independent (use delta time)

### DIFF
--- a/games/flappy.js
+++ b/games/flappy.js
@@ -14,6 +14,8 @@ let fBird = {};
 let fPipes = [];
 let fScore = 0;
 let fAnim;
+let fLastTime = 0;
+let fSpawnAccumulator = 0;
 
 const FLAP_STRENGTH = -7;
 const GRAVITY = 0.5;
@@ -23,6 +25,8 @@ const MIN_PIPE_GAP = 130;
 const BASE_PIPE_SPAWN_CHANCE = 0.01;
 const MAX_PIPE_SPAWN_CHANCE = 0.03;
 const PIPE_MIN_DISTANCE = 220;
+const BASE_FRAME_MS = 1000 / 60;
+const MAX_DT_FRAMES = 2.5;
 
 function getDifficultyFactor() {
   return Math.min(fScore, 30) / 30;
@@ -49,13 +53,20 @@ export function initFlappy() {
   fBird = { x: 50, y: 300, dy: 0 };
   fPipes = [];
   fScore = 0;
+  fLastTime = 0;
+  fSpawnAccumulator = 0;
   setText("flappyScore", "SCORE: 0");
-  loopFlappy();
+  loopFlappy(performance.now());
 }
 
 // Main game loop: physics update, pipe spawn, collision, render.
-function loopFlappy() {
+function loopFlappy(now) {
   if (state.currentGame !== "flappy") return;
+  const dtFrames = fLastTime
+    ? Math.min((now - fLastTime) / BASE_FRAME_MS, MAX_DT_FRAMES)
+    : 1;
+  fLastTime = now;
+
   const ctx = document.getElementById("flappyCanvas").getContext("2d");
   ctx.fillStyle = "#000";
   ctx.fillRect(0, 0, 400, 600);
@@ -63,8 +74,8 @@ function loopFlappy() {
     fBird.dy = FLAP_STRENGTH;
     state.keysPressed[" "] = false;
   }
-  fBird.dy += GRAVITY;
-  fBird.y += fBird.dy;
+  fBird.dy += GRAVITY * dtFrames;
+  fBird.y += fBird.dy * dtFrames;
   ctx.fillStyle = "#fff";
   ctx.fillRect(fBird.x, fBird.y, 20, 20);
   if (fBird.y > 600 || fBird.y < 0) {
@@ -80,12 +91,14 @@ function loopFlappy() {
   }
   const lastPipe = fPipes[fPipes.length - 1];
   const canSpawnPipe = !lastPipe || lastPipe.x < 400 - PIPE_MIN_DISTANCE;
-  if (canSpawnPipe && Math.random() < getPipeSpawnChance()) {
+  fSpawnAccumulator = Math.min(1.5, fSpawnAccumulator + getPipeSpawnChance() * dtFrames);
+  if (canSpawnPipe && fSpawnAccumulator >= 1) {
+    fSpawnAccumulator -= 1;
     fPipes.push({ x: 400, gap: getPipeGap(), h: Math.random() * 250 + 50 });
   }
   for (let i = fPipes.length - 1; i >= 0; i--) {
     const p = fPipes[i];
-    p.x -= getPipeSpeed();
+    p.x -= getPipeSpeed() * dtFrames;
     ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
     ctx.fillRect(p.x, 0, 40, p.h);
     ctx.fillRect(p.x, p.h + p.gap, 40, 600);

--- a/games/pong.js
+++ b/games/pong.js
@@ -21,6 +21,10 @@ let pSc = 0;
 let aiSc = 0;
 let pDiff = 0.08;
 let pAnim;
+let pLastTime = 0;
+
+const BASE_FRAME_MS = 1000 / 60;
+const MAX_DT_FRAMES = 2.5;
 
 export function setPongDiff(level) {
   pDiff = level === "hard" ? 0.14 : 0.055;
@@ -35,8 +39,9 @@ export function initPong() {
   pCtx = pCv.getContext("2d");
   pSc = 0;
   aiSc = 0;
+  pLastTime = 0;
   resetBall();
-  loopPong();
+  loopPong(performance.now());
 }
 
 // Reset ball position and velocity to a new random serve.
@@ -49,20 +54,26 @@ function resetBall() {
 }
 
 // Main animation loop: update paddles, ball, scores, and render.
-function loopPong() {
+function loopPong(now) {
   if (state.currentGame !== "pong") return;
+  const dtFrames = pLastTime
+    ? Math.min((now - pLastTime) / BASE_FRAME_MS, MAX_DT_FRAMES)
+    : 1;
+  pLastTime = now;
+
   pCtx.fillStyle = "rgba(0,0,0,0.2)";
   pCtx.fillRect(0, 0, 800, 600);
   if (hasActiveItem("item_aimbot")) {
-    p1.y += (ball.y - p1.h / 2 - p1.y) * 0.1;
+    p1.y += (ball.y - p1.h / 2 - p1.y) * (1 - Math.pow(1 - 0.1, dtFrames));
   } else {
-    if (state.keysPressed.w || state.keysPressed.ArrowUp) p1.y -= 8;
-    if (state.keysPressed.s || state.keysPressed.ArrowDown) p1.y += 8;
+    if (state.keysPressed.w || state.keysPressed.ArrowUp) p1.y -= 8 * dtFrames;
+    if (state.keysPressed.s || state.keysPressed.ArrowDown) p1.y += 8 * dtFrames;
   }
   if (p1.y < 0) p1.y = 0;
   if (p1.y > 520) p1.y = 520;
   const aiCatchupDebuff = aiSc - pSc >= 3 ? 0.7 : 1;
-  p2.y += (ball.y - p2.h / 2 - p2.y) * pDiff * aiCatchupDebuff;
+  const aiRate = pDiff * aiCatchupDebuff;
+  p2.y += (ball.y - p2.h / 2 - p2.y) * (1 - Math.pow(1 - aiRate, dtFrames));
   if (p2.y < 0) p2.y = 0;
   if (p2.y > 520) p2.y = 520;
   pCtx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
@@ -71,8 +82,8 @@ function loopPong() {
   pCtx.beginPath();
   pCtx.arc(ball.x, ball.y, 8, 0, Math.PI * 2);
   pCtx.fill();
-  ball.x += ball.dx;
-  ball.y += ball.dy;
+  ball.x += ball.dx * dtFrames;
+  ball.y += ball.dy * dtFrames;
   if (ball.y < 0 || ball.y > 600) ball.dy *= -1;
   if (ball.x < 30 && ball.y > p1.y && ball.y < p1.y + p1.h) {
     ball.dx = Math.min(Math.abs(ball.dx) + 0.4, 9);

--- a/games/runner.js
+++ b/games/runner.js
@@ -19,8 +19,12 @@ let player = {};
 let rObs = [];
 let rSpeed = 5;
 let rScore = 0;
-let rFrame = 0;
 let rAnim;
+let rSpawnTimer = 0;
+let rLastTime = 0;
+
+const BASE_FRAME_MS = 1000 / 60;
+const MAX_DT_FRAMES = 2.5;
 
 export function initRunner() {
   state.currentGame = "runner";
@@ -31,15 +35,19 @@ export function initRunner() {
   rObs = [];
   rSpeed = 5;
   rScore = 0;
-  rFrame = 0;
+  rSpawnTimer = 0;
+  rLastTime = 0;
   setText("runnerScoreBoard", "SCORE: 0");
-  loopRunner();
+  loopRunner(performance.now());
 }
 
 // Main runner loop: update physics, spawn obstacles, render, and score.
-function loopRunner() {
+function loopRunner(now) {
   if (state.currentGame !== "runner") return;
-  rFrame++;
+  const dtFrames = rLastTime
+    ? Math.min((now - rLastTime) / BASE_FRAME_MS, MAX_DT_FRAMES)
+    : 1;
+  rLastTime = now;
   rCtx.fillStyle = "#000";
   rCtx.fillRect(0, 0, 800, 400);
   rCtx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
@@ -53,8 +61,8 @@ function loopRunner() {
     player.dy = -player.jumpForce;
     player.grounded = false;
   }
-  player.dy += player.gravity;
-  player.y += player.dy;
+  player.dy += player.gravity * dtFrames;
+  player.y += player.dy * dtFrames;
   if (player.y > 300) {
     player.y = 300;
     player.dy = 0;
@@ -62,13 +70,16 @@ function loopRunner() {
   }
   rCtx.fillStyle = "#fff";
   rCtx.fillRect(player.x, player.y, player.w, player.h);
-  if (rFrame % Math.floor(1000 / currentSpeed) === 0) {
+  rSpawnTimer += dtFrames;
+  const spawnInterval = Math.max(40, Math.floor(1000 / currentSpeed));
+  while (rSpawnTimer >= spawnInterval) {
+    rSpawnTimer -= spawnInterval;
     const height = Math.random() > 0.7 ? 60 : 30;
     rObs.push({ x: 800, y: 350 - height, w: 20, h: height });
   }
   for (let i = rObs.length - 1; i >= 0; i--) {
     const o = rObs[i];
-    o.x -= currentSpeed;
+    o.x -= currentSpeed * dtFrames;
     rCtx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
     rCtx.fillRect(o.x, o.y, o.w, o.h);
     if (


### PR DESCRIPTION
### Motivation
- Remove frame-rate dependence so gameplay (movement, gravity, AI, and spawn pacing) is consistent across different monitor refresh rates and during frame hiccups.
- Replace brittle frame-count and modulo-based spawn logic with time-based accumulators so spawn cadence does not speed up or slow down with FPS.
- Prevent large frame gaps from producing extreme jumps by clamping `dt` and smoothing multi-frame updates.

### Description
- Converted main loops to use timestamped `requestAnimationFrame` handlers and a per-game `dt` (frame multiplier) with clamping, and updated calls to `loop*(performance.now())` where appropriate in `dodge`, `pong`, `runner`, `flappy`, and `geo`.
- Rewrote movement, gravity, ball motion, and obstacle/projectile updates to multiply by `dt` (e.g. `* dtFrames`) instead of relying on one update-per-frame, and smoothed AI/aimbot interpolation using exponential step composition.
- Replaced frame-modulo spawn logic with timer/accumulator-based spawning (and limited accumulators where applicable) and changed dodge scoring to track elapsed real time rather than frame count.
- Added per-file constants for base frame ms and max `dt` clamping to avoid runaway updates and preserved existing gameplay rules and scoring.

### Testing
- Ran syntax checks with `node --check` on `games/dodge.js`, `games/pong.js`, `games/runner.js`, `games/flappy.js`, and `games/geo.js`, and they completed successfully. 
- Served the app locally (`python -m http.server 4173`) and validated the site loaded; automated Playwright captured a screenshot of the running app successfully. 
- No automated unit tests existed for these scripts, so validation was limited to static checks and a runtime smoke test which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cab3d63dc83278287374f4915f327)