### PR TITLE
Fix player leaderboard rank calculation

### DIFF
--- a/core.js
+++ b/core.js
@@ -1589,7 +1589,10 @@ function loadLeaderboard(game) {
       const rows = [];
       snap.forEach((d) => {
         const data = d.data();
-        rows.push({ name: data.name || d.id, score: data.rank || "RAT" });
+        rows.push({
+          name: data.name || d.id,
+          score: data.rank || getRank(Number(data.money) || 0),
+        });
       });
       renderLeaderboardRows(list, rows);
     });


### PR DESCRIPTION
### Motivation
- Player entries on the `players` leaderboard were showing the default label `RAT` for accounts that don't have a stored `rank` field, which masks their actual standing.

### Description
- Update the `players` branch of `loadLeaderboard` to derive a player's displayed rank from `money` when `data.rank` is missing by calling `getRank(Number(data.money) || 0)`.
- Preserve backwards compatibility by still using the stored `rank` value when present.

### Testing
- Ran `node --check core.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cad728e848327811a7df13b34fd65)