### PR TITLE
Add interactive simulated stock market to Bank overlay (live charts & trading)

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,26 @@
           </div>
           <div id="bankLoanMsg" class="bank-transfer-msg"></div>
         </div>
+        <div class="stock-market">
+          <div class="stock-market-header">
+            <div>SIM STOCK MARKET</div>
+            <div id="stockPortfolioValue">PORTFOLIO: $0</div>
+          </div>
+          <div class="stock-market-grid">
+            <div id="stockList" class="stock-list"></div>
+            <div class="stock-detail">
+              <div id="stockDetailName" class="stock-detail-title">SELECT A STOCK</div>
+              <div id="stockDetailPrice" class="stock-detail-price">$0.00</div>
+              <canvas id="stockChart" width="420" height="170"></canvas>
+              <div id="stockDetailMeta" class="stock-detail-meta">NO DATA</div>
+              <div class="stock-actions">
+                <button class="term-btn" id="stockBuyBtn">BUY 1</button>
+                <button class="term-btn" id="stockSellBtn">SELL 1</button>
+              </div>
+              <div id="stockTradeMsg" class="bank-transfer-msg"></div>
+            </div>
+          </div>
+        </div>
         <div class="bank-log" id="bankLog"></div>
         <button
           class="term-btn"

--- a/styles.css
+++ b/styles.css
@@ -1463,6 +1463,93 @@ canvas {
   gap: 6px;
 }
 
+
+.stock-market {
+  border-top: 1px dashed #333;
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+.stock-market-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  color: #aaa;
+  margin-bottom: 8px;
+}
+
+.stock-market-grid {
+  display: grid;
+  grid-template-columns: minmax(170px, 220px) 1fr;
+  gap: 10px;
+}
+
+.stock-list {
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid #333;
+}
+
+.stock-row {
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid #222;
+  background: transparent;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 9px;
+  padding: 8px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.stock-row:hover,
+.stock-row.active {
+  background: var(--accent-dim);
+}
+
+.stock-detail {
+  border: 1px solid #333;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stock-detail-title {
+  font-size: 11px;
+}
+
+.stock-detail-price {
+  font-size: 16px;
+  color: #fff;
+}
+
+#stockChart {
+  width: 100%;
+  border: 1px solid #222;
+  background: #050505;
+  image-rendering: pixelated;
+}
+
+.stock-detail-meta {
+  font-size: 8px;
+  color: #aaa;
+  min-height: 18px;
+}
+
+.stock-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+@media (max-width: 900px) {
+  .stock-market-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 ::-webkit-scrollbar {
   width: 5px;
 }


### PR DESCRIPTION
### Motivation
- Provide a simple, interactive simulated stock market inside the Bank overlay so players can open a stock, watch a live chart, and trade shares like a real market view.
- Persist portfolio state so holdings survive profile save/load and integrate trading with the existing bank/transaction system.

### Description
- Added a new Sim Stock Market UI inside the Bank overlay with a stock list, per-stock detail panel, a `canvas` chart (`#stockChart`), buy/sell buttons and a portfolio value display (`index.html`).
- Implemented a client-side market simulator and charting in `core.js` including `STOCK_SYMBOLS`, `marketState`, `tickStockMarket()`, `drawStockGraph()`, `renderStockMarket()`, and trading via `tradeStock()` with one-share buy/sell actions.
- Wired UX and lifecycle: added `setupStockMarketUX()` and invoked it on init, render the market when opening the bank overlay, and update the market periodically (`setInterval` tick) so charts move while the overlay is open.
- Persisted portfolio and selection to profile state by adding `stockData` to the in-memory state and saving/loading it in `saveStats()`, `loadProfile()` and `register()`; adjusted money display to show cents by using `toFixed(2)` where appropriate.
- Styled the new market UI in `styles.css` to match the existing terminal theme and to be responsive on smaller screens.

### Testing
- Ran static checks with `node --check core.js` and `node --check script.js` and both succeeded.
- Launched a local HTTP server (`python -m http.server 4173`) and performed a manual browser validation with an automated Playwright run that opened the Bank overlay and captured a screenshot; the stock UI and live chart rendered as expected.
- Verified interactive flows: selecting stocks, buying/selling one share updates `myMoney`, logs a transaction, updates portfolio value, and persists via `saveStats()`; periodic market ticks update prices and redraw the chart.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc16ad9048327b12c9baa694c8381)