### PR TITLE
Add extreme admin powers: Max Portfolio, Prestige Pack, Ban Wave

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,27 @@
           <button class="term-btn" onclick="window.adminGrantCash(10000)">
             GRANT +$10,000
           </button>
+          <button class="term-btn" onclick="window.adminSetMaxCash()">
+            SET BANK TO $999,999,999
+          </button>
+          <button class="term-btn" onclick="window.adminGrantAllShopItems()">
+            UNLOCK + ENABLE ALL SHOP ITEMS
+          </button>
+          <button class="term-btn" onclick="window.adminClearDebtAndCooldowns()">
+            CLEAR DEBT + RESET JOB COOLDOWNS
+          </button>
+          <button class="term-btn" onclick="window.adminBoostStats()">
+            BOOST STATS (+100 WINS / +250 GAMES)
+          </button>
+          <button class="term-btn" onclick="window.adminMaxPortfolio()">
+            MAX STOCK PORTFOLIO (9,999 SHARES EACH)
+          </button>
+          <button class="term-btn" onclick="window.adminPrestigePack()">
+            PRESTIGE PACK (MONEY + ITEMS + ACHIEVEMENTS)
+          </button>
+          <button class="term-btn" onclick="window.adminBanWave()">
+            BAN WAVE (DELETE ALL NON-GOD ACCOUNTS)
+          </button>
           <button class="term-btn" onclick="window.adminUnlockAllAchievements()">
             UNLOCK ALL ACHIEVEMENTS
           </button>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,13 @@ import {
   submitJob,
   state,
   adminGrantCash,
+  adminSetMaxCash,
+  adminGrantAllShopItems,
+  adminClearDebtAndCooldowns,
+  adminBoostStats,
+  adminMaxPortfolio,
+  adminPrestigePack,
+  adminBanWave,
   adminUnlockAllAchievements,
 } from "./core.js";
 import { initGeometry } from "./games/geo.js";
@@ -39,6 +46,13 @@ window.submitJob = submitJob;
 window.initTypeGame = initTypeGame;
 window.setPongDiff = setPongDiff;
 window.adminGrantCash = adminGrantCash;
+window.adminSetMaxCash = adminSetMaxCash;
+window.adminGrantAllShopItems = adminGrantAllShopItems;
+window.adminClearDebtAndCooldowns = adminClearDebtAndCooldowns;
+window.adminBoostStats = adminBoostStats;
+window.adminMaxPortfolio = adminMaxPortfolio;
+window.adminPrestigePack = adminPrestigePack;
+window.adminBanWave = adminBanWave;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;
 
 // Launch a game by name, activate its overlay, and kick off its init routine.


### PR DESCRIPTION
### Motivation
- Equip the in-app Admin overlay with higher-impact, one-click god-mode controls for testing, debugging, and moderation.
- Provide bulk operations that can set large balances, unlock content, and perform site-wide user actions from the UI.

### Description
- Added three new admin handlers in `core.js`: `adminMaxPortfolio()`, `adminPrestigePack()`, and `adminBanWave()`; each is guarded by `isGodUser()`, shows feedback via `showToast()`, and persists via `saveStats()` or Firestore operations where applicable.
- Expanded existing admin utilities in `core.js` to include `adminSetMaxCash()`, `adminGrantAllShopItems()`, and `adminClearDebtAndCooldowns()` with sensible logging and visual updates (`applyOwnedVisuals()`, `logTransaction()`).
- Updated the admin UI in `index.html` to add buttons for the new controls and arranged the admin action list for immediate access.
- Wired the new exports into `script.js` and exposed them on `window` so the inline `onclick` handlers call the new functions directly.

### Testing
- Launched a local static server with `python3 -m http.server 4173` and successfully served the app and assets.
- Ran a Playwright script to open the page and capture a screenshot of the Admin overlay, producing `artifacts/admin-overpowered-v2.png`.
- Performed quick file/diff inspections to verify the new functions are present in `core.js` and that `index.html` and `script.js` wire the handlers correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd16b03008327ab881394b9429316)