### PR TITLE
Expand admin menu with extra economy controls

### DIFF
--- a/core.js
+++ b/core.js
@@ -1055,6 +1055,15 @@ export async function adminGrantCash(amount) {
   await saveStats();
 }
 
+export async function adminInjectJackpot() {
+  if (!isGodUser()) return;
+  const jackpot = 5000000;
+  myMoney += jackpot;
+  logTransaction("ADMIN JACKPOT", jackpot);
+  showToast(`JACKPOT INJECTED: +$${jackpot.toLocaleString()}`, "🎰");
+  await saveStats();
+}
+
 export async function adminSetMaxCash() {
   if (!isGodUser()) return;
   const previous = Math.floor(Number(myMoney) || 0);
@@ -1115,6 +1124,31 @@ export async function adminMaxPortfolio() {
   });
   stockData.selected = marketState.stocks[0]?.symbol || stockData.selected;
   showToast("PORTFOLIO MAXED OUT", "📊");
+  await saveStats();
+}
+
+function setMarketShift(multiplier) {
+  marketState.stocks.forEach((stock) => {
+    const next = Math.max(3, Number((stock.price * multiplier).toFixed(2)));
+    stock.lastMove = (next - stock.price) / (stock.price || 1);
+    stock.price = next;
+    stock.history.push(next);
+    if (stock.history.length > 80) stock.history.shift();
+  });
+  renderStockMarket();
+}
+
+export async function adminMarketMoonshot() {
+  if (!isGodUser()) return;
+  setMarketShift(1.35);
+  showToast("MARKET SENT TO THE MOON", "🚀");
+  await saveStats();
+}
+
+export async function adminMarketMeltdown() {
+  if (!isGodUser()) return;
+  setMarketShift(0.55);
+  showToast("MARKET MELTDOWN TRIGGERED", "💥");
   await saveStats();
 }
 

--- a/index.html
+++ b/index.html
@@ -102,6 +102,12 @@
           <button class="term-btn" onclick="window.adminGrantCash(10000)">
             GRANT +$10,000
           </button>
+          <button class="term-btn" onclick="window.adminGrantCash(100000)">
+            GRANT +$100,000
+          </button>
+          <button class="term-btn" onclick="window.adminInjectJackpot()">
+            INJECT JACKPOT (+$5,000,000)
+          </button>
           <button class="term-btn" onclick="window.adminSetMaxCash()">
             SET BANK TO $999,999,999
           </button>
@@ -116,6 +122,12 @@
           </button>
           <button class="term-btn" onclick="window.adminMaxPortfolio()">
             MAX STOCK PORTFOLIO (9,999 SHARES EACH)
+          </button>
+          <button class="term-btn" onclick="window.adminMarketMoonshot()">
+            MARKET MOONSHOT (+35% ALL STOCKS)
+          </button>
+          <button class="term-btn" onclick="window.adminMarketMeltdown()">
+            MARKET MELTDOWN (-45% ALL STOCKS)
           </button>
           <button class="term-btn" onclick="window.adminPrestigePack()">
             PRESTIGE PACK (MONEY + ITEMS + ACHIEVEMENTS)

--- a/script.js
+++ b/script.js
@@ -14,11 +14,14 @@ import {
   submitJob,
   state,
   adminGrantCash,
+  adminInjectJackpot,
   adminSetMaxCash,
   adminGrantAllShopItems,
   adminClearDebtAndCooldowns,
   adminBoostStats,
   adminMaxPortfolio,
+  adminMarketMoonshot,
+  adminMarketMeltdown,
   adminPrestigePack,
   adminBanWave,
   adminUnlockAllAchievements,
@@ -46,11 +49,14 @@ window.submitJob = submitJob;
 window.initTypeGame = initTypeGame;
 window.setPongDiff = setPongDiff;
 window.adminGrantCash = adminGrantCash;
+window.adminInjectJackpot = adminInjectJackpot;
 window.adminSetMaxCash = adminSetMaxCash;
 window.adminGrantAllShopItems = adminGrantAllShopItems;
 window.adminClearDebtAndCooldowns = adminClearDebtAndCooldowns;
 window.adminBoostStats = adminBoostStats;
 window.adminMaxPortfolio = adminMaxPortfolio;
+window.adminMarketMoonshot = adminMarketMoonshot;
+window.adminMarketMeltdown = adminMarketMeltdown;
 window.adminPrestigePack = adminPrestigePack;
 window.adminBanWave = adminBanWave;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;


### PR DESCRIPTION
### Motivation
- Provide additional operator/admin tools to manipulate player economy and market state for testing and moderation.
- Offer high-impact actions (large cash grant, jackpot, market up/down) accessible from the existing ADMIN overlay.

### Description
- Added new admin functions in `core.js`: `adminInjectJackpot()` (+$5,000,000), `adminMarketMoonshot()` (+35% all stocks), and `adminMarketMeltdown()` (-45% all stocks). 
- Introduced a shared helper `setMarketShift(multiplier)` in `core.js` to update `marketState.stocks` prices, `lastMove`, and history before calling `renderStockMarket()`.
- Wired new exports into `script.js` and exposed them on `window.*` so inline HTML handlers can invoke them (`adminInjectJackpot`, `adminMarketMoonshot`, `adminMarketMeltdown`).
- Expanded the ADMIN overlay in `index.html` with buttons for `GRANT +$100,000`, `INJECT JACKPOT (+$5,000,000)`, `MARKET MOONSHOT (+35% ALL STOCKS)`, and `MARKET MELTDOWN (-45% ALL STOCKS)`.

### Testing
- Ran `node --check core.js && node --check script.js` to validate there are no syntax errors, which succeeded. 
- Launched a local HTTP server and used a Playwright script to load the app and capture a screenshot of the expanded admin menu, which completed successfully. 
- Verified the app served assets without errors during the automated UI load and no runtime exceptions were observed during the checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd8965dac83278392441d989b2f6e)