### PR TITLE
Fix overlay scrolling so full content is reachable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -365,7 +365,7 @@ body::before {
   display: none;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   z-index: 1000;
   overflow-y: auto;
   padding: 20px;


### PR DESCRIPTION
### Motivation
- Centered overlay content prevented the page from scrolling to the very top or bottom for long overlays, so users couldn't reach all content.

### Description
- Updated `styles.css` to change the `.overlay` rule from `justify-content: center` to `justify-content: flex-start` so overlay content is top-aligned and fully scrollable.

### Testing
- Launched a local server with `python3 -m http.server 4173` and ran a Playwright script to open `overlayJobs` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce25bfce48327a70f850edc11b04c)