### PR TITLE
Fix bank transfer recipient resolution and raise admin market multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
               CRASH MARKET TO ZERO
             </button>
             <button class="term-btn" onclick="window.adminMarketTimesThousand()">
-              MULTIPLY MARKET x1000
+              MULTIPLY MARKET x1000000000000000000
             </button>
           </div>
 


### PR DESCRIPTION
### Motivation
- Sending money could fail when a recipient's document ID used a different case than the normalized uppercase lookup, causing spurious "PLAYER NOT FOUND" errors in transfers.
- Admins needed a much larger market manipulation multiplier than the existing x1000 action.

### Description
- Updated `tradeMoney` in `core.js` to read the raw input (`rawTarget`) and attempt to resolve both the normalized uppercase document and the raw-case document inside the same Firestore transaction, then credit whichever record exists to keep the transfer atomic.
- Adjusted transaction logic to use a `receiverRef/receiverSnap` pair and update the receiver's balance accordingly when present.
- Increased the admin market multiplier in `adminMarketTimesThousand` to `1_000_000_000_000_000_000` (10^18) and updated the toast text to match in `core.js`.
- Updated the admin panel button label in `index.html` to reflect the new multiplier value.

### Testing
- Performed static checks with `node --check core.js` and `node --check script.js`, both succeeded.
- Served the app with `python -m http.server 4173 --bind 0.0.0.0` and verified the updated admin UI via an automated Playwright screenshot capture.
- Basic runtime smoke verification completed by loading the page and ensuring no script parse errors were reported during load.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce93a506c832792029b6db6eb5e0f)