### PR TITLE
Fix bank display for non-finite balances, robust bank transfers, and raise admin market multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
               CRASH MARKET TO ZERO
             </button>
             <button class="term-btn" onclick="window.adminMarketTimesThousand()">
-              MULTIPLY MARKET x1000
+              MULTIPLY MARKET x1000000000000000000
             </button>
           </div>
 


### PR DESCRIPTION
### Motivation
- Some accounts end up with non-finite or malformed `money` values which rendered as `NaN`/`0.00` and made balances look broken. 
- Bank transfers could fail when a recipient's document used a different case than the normalized uppercase lookup, producing spurious "PLAYER NOT FOUND" errors. 
- Admins needed a much larger market manipulation multiplier than the previous x1000 action.

### Description
- Added `formatBankAmount(value)` to safely format bank values so normal numbers show two decimals while preserving non-finite and raw malformed values. 
- Added `getComparableMoney(value)` to produce a numeric comparable for color-change logic that handles `Infinity`/`-Infinity` and non-numeric values. 
- Updated `updateUI()` to use the new helpers for the top bar and overlay bank text and to base color animation on the comparable numeric value. 
- Improved `tradeMoney()` to accept a raw user input and attempt to resolve both the normalized uppercase document and the raw-case document inside the same Firestore transaction, then update whichever receiver record exists atomically. 
- Increased the admin market multiplier in `adminMarketTimesThousand()` to `1_000_000_000_000_000_000` and updated the admin panel button label in `index.html` to match.

### Testing
- Ran `node --check core.js` to validate syntax and the check succeeded. 
- Served the app locally with `python -m http.server 4173 --bind 0.0.0.0` and loaded `index.html` to verify there are no script parse errors. 
- Captured an automated browser screenshot using Playwright after loading the page to confirm the bank display and UI render (artifact created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce93a506c832792029b6db6eb5e0f)