### PR TITLE
Fix roulette wheel marker offset and landing alignment

### DIFF
--- a/games/roulette.js
+++ b/games/roulette.js
@@ -136,7 +136,7 @@ function spin() {
   const winningNumber = ROULETTE_NUMBERS[winningIndex];
   const winningColor = getNumberColor(winningNumber);
   const sliceAngle = 360 / ROULETTE_NUMBERS.length;
-  const targetAngle = -(winningIndex * sliceAngle);
+  const targetAngle = -((winningIndex + 0.5) * sliceAngle);
   const currentBase = Math.floor(wheelRotation / 360) * 360;
   wheelRotation = currentBase - 1800 + targetAngle;
 
@@ -155,10 +155,11 @@ function bindWheelNumbers() {
   const ring = document.getElementById("rouletteWheelNumbers");
   if (!ring) return;
   ring.innerHTML = "";
+  const sliceAngle = 360 / ROULETTE_NUMBERS.length;
   ROULETTE_NUMBERS.forEach((num, idx) => {
     const marker = document.createElement("div");
     marker.className = "roulette-marker";
-    marker.style.transform = `rotate(${(idx * 360) / ROULETTE_NUMBERS.length}deg)`;
+    marker.style.transform = `rotate(${(idx + 0.5) * sliceAngle}deg)`;
     marker.innerHTML = `<span>${num}</span>`;
     ring.appendChild(marker);
   });


### PR DESCRIPTION
### Motivation

- Users reported roulette numbers appearing offset from their colored wheel segments, causing a visual mismatch with the pointer. 
- The intent is to center each number inside its slice and make spins stop with the winning slice centered under the pointer.

### Description

- Adjusted spin landing calculation in `games/roulette.js` to use a half-slice offset so the wheel stops with the winning slice centered (`targetAngle = -((winningIndex + 0.5) * sliceAngle)`).
- Centered marker labels by computing a `sliceAngle` and rotating markers to `(idx + 0.5) * sliceAngle` when building `#rouletteWheelNumbers`.
- Kept existing payout, betting, and wheel behavior unchanged; only visual/rotation math was modified.

### Testing

- Inspected the modified region with `nl -ba games/roulette.js | sed -n '128,176p'` and reviewed the `git diff -- games/roulette.js`, both succeeded.
- Started a local server with `python3 -m http.server 8000 --directory /workspace/webstie` and captured the updated UI with a Playwright script that navigated to the page and took a screenshot, which completed successfully.
- Committed changes to the repo; automated checks used during development all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6fd102f883278ce6276cb7653f89)