### PR TITLE
Add homepage update log panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,14 @@
           >[RAT]</span
         >
       </div>
+      <section class="update-log" aria-label="Update log">
+        <h2>UPDATE LOG</h2>
+        <ul>
+          <li><span>v32.1</span> Added home-screen update log for patch tracking.</li>
+          <li><span>v32.0</span> Stabilized PVP modes and performance tuning pass.</li>
+          <li><span>v31.8</span> Added stock market controls and transfer quality-of-life upgrades.</li>
+        </ul>
+      </section>
     </div>
 
     <!-- Login overlay shown on initial load or when logged out. -->

--- a/styles.css
+++ b/styles.css
@@ -356,6 +356,36 @@ body::before {
   text-align: center;
 }
 
+.update-log {
+  margin-top: 24px;
+  width: min(90vw, 680px);
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.75);
+  padding: 14px 16px;
+  box-shadow: 0 0 16px rgba(0, 255, 136, 0.12);
+  text-align: left;
+}
+
+.update-log h2 {
+  margin: 0 0 10px;
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #fff;
+}
+
+.update-log ul {
+  margin: 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 8px;
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.update-log li span {
+  color: var(--accent);
+}
+
 /* --- 6. OVERLAYS & MODALS --- */
 /* Overlay container for modals and game screens. */
 .overlay {


### PR DESCRIPTION
### Motivation
- Provide a visible changelog on the landing area so players can quickly see recent patches and release notes.
- Keep update information consistent with the site’s terminal-style UI and make it discoverable without navigating to another page.

### Description
- Added a new `section` with class `update-log` inside the landing `.wrap` in `index.html` containing initial entries for `v32.1`, `v32.0`, and `v31.8` and an `aria-label` for accessibility.
- Added themed styles for the update log in `styles.css` including `.update-log`, `.update-log h2`, `.update-log ul`, and `.update-log li span` to match the existing terminal aesthetic and ensure readability.
- Kept markup minimal and non-invasive so the new panel integrates with existing layout and responsive rules.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it completed successfully.
- Served the site with `python3 -m http.server 8000` and manually verified the update log rendering in a browser session successfully.
- Captured a Playwright screenshot as visual verification (`artifacts/update-log-home.png`) which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dee2faf8c8327b17c3ff6cbf7149a)