### PR TITLE
Wait for Firebase auth readiness before login/register

### DIFF
--- a/core.js
+++ b/core.js
@@ -38,6 +38,15 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
+const authReady = new Promise((resolve) => {
+  onAuthStateChanged(
+    auth,
+    (user) => {
+      if (user) resolve(user);
+    },
+    () => resolve(null)
+  );
+});
 
 // Local player state (mirrors Firestore on sync).
 let myUid = null;
@@ -1063,6 +1072,7 @@ async function login(username, pin) {
   if (!isValidCredentials(normalized, normalizedPin)) {
     return "USE 3-10 CHAR CODENAME + 4-DIGIT PIN";
   }
+  await authReady;
   try {
     const ref = doc(db, "gooner_users", normalized);
     const snap = await getDoc(ref);
@@ -1244,6 +1254,8 @@ async function register(username, pin) {
 
   const localProfile = getLocalProfile(normalized);
   if (localProfile) return "USERNAME TAKEN";
+
+  await authReady;
 
   try {
     if (!myUid) throw new Error("OFFLINE");


### PR DESCRIPTION
### Motivation
- Users (e.g. the `NOOB` account) attempted to log in immediately after page load before anonymous Firebase auth was initialized, causing Firestore reads/writes to fail and sign-in to appear broken.
- Ensure profile operations only run after auth state is established to avoid race/permission errors.

### Description
- Added an `authReady` promise in `core.js` that resolves when `onAuthStateChanged` reports an authenticated user (or resolves null on error).
- Updated `login()` to `await authReady` before performing Firestore `getDoc` lookups.
- Updated `register()` to `await authReady` before checking/writing user documents in Firestore.

### Testing
- Ran `git diff -- core.js` to confirm the intended changes to `core.js` were present and `git show --stat --oneline HEAD` to verify the commit, both succeeded.
- Ran `git status --short` to confirm the working tree state and commit, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698def7146008327a0956f08d1f0995e)