### PR TITLE
Add Bonk.io multiplayer entry and overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
       <button onclick="window.launchGame('snake')">SNAKE</button>
       <button onclick="window.launchGame('runner')">RUNNER (V2)</button>
       <button onclick="window.launchGame('dodge')">DODGE GRID</button>
+      <button onclick="window.launchGame('bonk')">BONK.IO (MULTIPLAYER)</button>
       <button onclick="window.launchGame('roulette')">ROULETTE</button>
       <button
         onclick="window.launchGame('blackjack')"
@@ -812,6 +813,31 @@
       <canvas id="dodgeCanvas" width="700" height="450"></canvas>
       <div class="mobile-hint active" style="margin-top: 20px">
         ARROWS OR WASD TO EVADE
+      </div>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">
+        EXIT SYSTEM
+      </button>
+    </div>
+
+    <!-- Bonk.io multiplayer launcher overlay. -->
+    <div class="overlay" id="overlayBonk">
+      <h1>BONK.IO MULTIPLAYER</h1>
+      <p style="max-width: 700px; text-align: center; margin-bottom: 16px; font-size: 10px">
+        USE THIS TERMINAL PORTAL TO JOIN LIVE BONK.IO LOBBIES. IF THE EMBED IS BLOCKED,
+        OPEN THE GAME IN A NEW TAB.
+      </p>
+      <div style="width: min(100%, 960px); border: 2px solid var(--accent); box-shadow: 0 0 18px rgba(0, 255, 0, 0.25)">
+        <iframe
+          title="Bonk.io Multiplayer"
+          src="https://bonk.io/"
+          style="display: block; width: 100%; height: 70vh; min-height: 420px; border: 0; background: #000"
+          referrerpolicy="strict-origin-when-cross-origin"
+        ></iframe>
+      </div>
+      <div style="margin-top: 16px; display: flex; gap: 12px; flex-wrap: wrap; justify-content: center">
+        <button class="term-btn" onclick="window.open('https://bonk.io/', '_blank', 'noopener')">
+          OPEN BONK.IO IN NEW TAB
+        </button>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">
         EXIT SYSTEM


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to join Bonk.io lobbies from the arcade menu as a multiplayer option. 
- Offer an embedded launcher with a one-click fallback to open the game in a new tab if embedding is blocked.

### Description
- Added a new games dropdown button that calls `window.launchGame('bonk')` to the existing menu. 
- Introduced `overlayBonk` in `index.html` which embeds `https://bonk.io/` in an `iframe` and includes a fallback button that calls `window.open('https://bonk.io/', '_blank', 'noopener')`. 
- Kept styling consistent with other overlays and used the existing overlay/close controls so the change only touches `index.html`.

### Testing
- Served the site locally with `python3 -m http.server 4173 --bind 0.0.0.0` and confirmed the page and assets loaded successfully. 
- Opened the games menu and verified the new `BONK.IO (MULTIPLAYER)` entry and `overlayBonk` markup are present in `index.html`. 
- Attempted to capture an automated screenshot of the overlay via the headless browser tool, but the browser process crashed (SIGSEGV) in this environment so the visual snapshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df377723483228307eebba0191a48)