### PR TITLE
Bonk Arena: switch to side-view bouncy physics + client prediction

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,6 +1151,13 @@
       <div id="baLobby" class="menu-box" style="display: none">
         <h2>ROOM: <span id="baRoomId">----</span></h2>
         <div id="baPList" style="text-align: left; margin: 16px 0"></div>
+        <label for="baModeSelect" style="font-size: 10px; opacity: 0.9">GAME MODE</label>
+        <select id="baModeSelect" class="term-input" style="width: 180px; text-align: center; margin-bottom: 10px">
+          <option value="classic">CLASSIC</option>
+          <option value="arrows">ARROWS</option>
+          <option value="grapple">GRAPPLE</option>
+        </select>
+        <div id="baModeLabel" style="font-size: 10px; margin-bottom: 10px">MODE: CLASSIC</div>
         <button class="term-btn" id="baStartBtn" style="display: none">
           START ROUND
         </button>


### PR DESCRIPTION
### Motivation
- Convert the Bonk Arena from a top-down dash game to a front/side-view platform-style brawler to match a Mario/Bonk-like perspective.
- Make collisions and movement feel more bouncy and impactful so knocking players around is more satisfying.
- Reduce perceived input delay for non-host players by predicting the local player's motion between snapshot updates.

### Description
- Introduced side-view arena geometry and spawns by adding `FLOOR_Y`, `CEIL_Y`, `LEFT_WALL`, `RIGHT_WALL` and changing `makeSpawn`/`arenaCenter` to produce side-view positions, and added a `grounded` flag to player state.
- Reworked physics by adding `GRAVITY`, `JUMP_FORCE`, `BOUNCE_RESTITUTION`, `AIR_CONTROL`, increasing `BUMP_FORCE`, and moving per-player movement into a new `simulatePlayerStep` helper used by the host sim.
- Tuned pacing and responsiveness by increasing host tick frequency (`TICK_MS` -> 40Hz), adjusting `MOVE_ACCEL`, `FRICTION`, `START_RADIUS`, and `SHRINK_PER_SEC`.
- Updated rendering to a front/side silhouette and arena visuals, and added short client-side prediction via `getClientRenderState` using `CLIENT_PREDICTION_MS` and `lastSnapshotAt` to render the local player between Firebase snapshots.

### Testing
- Ran `node --check games/bonkarena.js` with no syntax errors (passed).
- Served the app with `python3 -m http.server 8000` and captured a Playwright screenshot of the updated Bonk overlay (screenshot artifact created, Playwright run completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df7b9f4748322a3649b94954c3e19)