### PR TITLE
Replace Ban Wave with Targeted Admin Actions (grant money & forgive interest)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,25 @@
         </p>
         <div class="admin-actions">
           <div class="admin-section">
+            <p class="admin-section-title">TARGETED ACTIONS</p>
+            <select class="term-input" id="adminTargetUser">
+              <option value="">SELECT USER</option>
+            </select>
+            <button class="term-btn" onclick="window.adminRefreshTargetUsers()">
+              REFRESH USER LIST
+            </button>
+            <button class="term-btn" onclick="window.adminGrantCashToUser(1000)">
+              GIVE SELECTED USER +$1,000
+            </button>
+            <button class="term-btn" onclick="window.adminGrantCashToUser(10000)">
+              GIVE SELECTED USER +$10,000
+            </button>
+            <button class="term-btn" onclick="window.adminForgiveInterestForUser()">
+              FORGIVE INTEREST (SELECTED USER)
+            </button>
+          </div>
+
+          <div class="admin-section">
             <p class="admin-section-title">ECONOMY</p>
             <button class="term-btn" onclick="window.adminGrantCash(1000)">
               GRANT +$1,000
@@ -155,12 +174,6 @@
             </button>
           </div>
 
-          <div class="admin-section admin-section-danger">
-            <p class="admin-section-title">ACCOUNT ENFORCEMENT</p>
-            <button class="term-btn" onclick="window.adminBanWave()">
-              BAN WAVE (DELETE ALL NON-GOD ACCOUNTS)
-            </button>
-          </div>
         </div>
         <button class="term-btn" style="margin-top: 20px" onclick="window.closeOverlays()">
           CLOSE

--- a/script.js
+++ b/script.js
@@ -25,7 +25,9 @@ import {
   adminMarketCrashToZero,
   adminMarketTimesThousand,
   adminPrestigePack,
-  adminBanWave,
+  adminRefreshTargetUsers,
+  adminGrantCashToUser,
+  adminForgiveInterestForUser,
   adminUnlockAllAchievements,
 } from "./core.js";
 import { initGeometry } from "./games/geo.js";
@@ -64,7 +66,9 @@ window.adminMarketMeltdown = adminMarketMeltdown;
 window.adminMarketCrashToZero = adminMarketCrashToZero;
 window.adminMarketTimesThousand = adminMarketTimesThousand;
 window.adminPrestigePack = adminPrestigePack;
-window.adminBanWave = adminBanWave;
+window.adminRefreshTargetUsers = adminRefreshTargetUsers;
+window.adminGrantCashToUser = adminGrantCashToUser;
+window.adminForgiveInterestForUser = adminForgiveInterestForUser;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;
 
 // Launch a game by name, activate its overlay, and kick off its init routine.


### PR DESCRIPTION
### Motivation
- Remove the dangerous global "ban wave" admin action and provide safer, targeted admin controls for individual users.  
- Allow god users to grant money or clear loan interest for a specific player instead of performing broad destructive operations.  

### Description
- Added a new `TARGETED ACTIONS` area in the admin overlay UI in `index.html` with a `select` for choosing a user and buttons to `REFRESH USER LIST`, `GIVE SELECTED USER +$1,000`, `GIVE SELECTED USER +$10,000`, and `FORGIVE INTEREST (SELECTED USER)`.  
- Implemented `getAdminTargetUser`, `adminRefreshTargetUsers`, `adminGrantCashToUser`, and `adminForgiveInterestForUser` in `core.js`, using Firestore transactions to safely update the selected user's `money` or loan fields, and updating local state when the target is the current user.  
- Removed the previous `adminBanWave` implementation from `core.js`.  
- Wired new functions into the global bindings and imports so inline handlers work by exporting them and exposing `window.adminRefreshTargetUsers`, `window.adminGrantCashToUser`, and `window.adminForgiveInterestForUser` from `script.js`.  
- Auto-refreshes the target user list when opening the admin overlay by calling `adminRefreshTargetUsers()` from `openGame('overlayAdmin')` in `core.js`.  

### Testing
- Ran syntax checks with `node --check script.js && node --check core.js`, which completed successfully.  
- Served the app locally with `python3 -m http.server 4173 --directory /workspace/webstie` and validated the admin overlay visually by capturing a screenshot, which showed the new controls.  
- Ran code searches (`rg`) to verify the new symbols are referenced in `index.html`, `core.js`, and `script.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df99df094832ba12e2e6c23c9c21f)