### PR TITLE
Fix Blackjack Ace scoring by counting hidden cards

### DIFF
--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -514,7 +514,6 @@ function calcHand(h) {
   let s = 0;
   let a = 0;
   h.forEach((c) => {
-    if (c.h) return;
     if (["J", "Q", "K"].includes(c.v)) s += 10;
     else if (c.v === "A") {
       s += 11;


### PR DESCRIPTION
### Motivation
- Multiplayer hands were showing incorrect totals because cards marked as hidden for UI (`c.h`) were being skipped during scoring, causing Ace values to be adjusted incorrectly.
- The goal is to ensure `calcHand` computes the true numeric value of a hand (including hidden cards) so Ace soft/hard logic applies correctly.

### Description
- Updated `calcHand` in `games/blackjack.js` to stop skipping cards with the `h` flag so all cards are included in the score computation.
- Kept the existing Ace handling (count A as 11 then reduce by 10 while over 21) so the soft/hard Ace adjustment now runs against the full hand value.
- No UI or multiplayer flow changes beyond ensuring the score calculation reflects the actual dealt cards.

### Testing
- Ran a syntax check with `node --check games/blackjack.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3992722c832bb412ce81cd618bef)