### PR TITLE
Fix inconsistent blackjack multiplayer scoring

### DIFF
--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -423,7 +423,6 @@ document.getElementById("bjDeck").onclick = async () => {
       ns.forEach((s) => {
         if (s) {
           s.hand = [deck.pop(), deck.pop()];
-          if (s.uid === state.myUid) s.hand[1].h = true;
         }
       });
       await updateDoc(ref, { seats: ns, deck: deck, phase: "playing", activeSeat: 0 });
@@ -474,7 +473,6 @@ async function passTurn(ref, curr, seats, deck) {
   let next = curr + 1;
   while (next < 4 && seats[next] === null) next++;
   if (next >= 4) {
-    seats[0].hand[1].h = false;
     let best = 0;
     seats.forEach((s) => {
       if (s && s.status !== "bust") {
@@ -514,7 +512,6 @@ function calcHand(h) {
   let s = 0;
   let a = 0;
   h.forEach((c) => {
-    if (c.h) return;
     if (["J", "Q", "K"].includes(c.v)) s += 10;
     else if (c.v === "A") {
       s += 11;


### PR DESCRIPTION
### Motivation
- Multiplayer rounds could show mismatched totals because a persisted hidden-card flag caused the scoring logic to skip a card, leading to confusing outcomes (e.g. one player showing 21 while another appears to stand on 14 but still wins).

### Description
- Removed code that marked the dealt second card as hidden in the persisted room state so hand data no longer contains a display-only hidden flag (`games/blackjack.js`).
- Removed the end-of-round reveal line that attempted to clear that hidden flag before resolution so winner calculation uses the same visible data as display.
- Updated scoring to always count all cards by removing the early skip on `c.h` in `calcHand`, ensuring score and resolution use identical totals.

### Testing
- Ran `node --check games/blackjack.js` and it completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e63fe7950833198ba5de3e6a0f61d)