### PR TITLE
Money-based Valorant-style rank tiers with badges

### DIFF
--- a/core.js
+++ b/core.js
@@ -1572,34 +1572,50 @@ function getComparableMoney(value) {
   return 0;
 }
 
+const RANK_TIERS = [
+  { key: "iron", label: "IRON", min: 0, max: 1500, badge: "⬢", className: "rank-iron" },
+  { key: "bronze", label: "BRONZE", min: 1500, max: 5000, badge: "⬡", className: "rank-bronze" },
+  { key: "silver", label: "SILVER", min: 5000, max: 15000, badge: "◈", className: "rank-silver" },
+  { key: "gold", label: "GOLD", min: 15000, max: 40000, badge: "✦", className: "rank-gold" },
+  { key: "platinum", label: "PLATINUM", min: 40000, max: 90000, badge: "✧", className: "rank-platinum" },
+  { key: "diamond", label: "DIAMOND", min: 90000, max: 175000, badge: "💎", className: "rank-diamond" },
+  { key: "ascendant", label: "ASCENDANT", min: 175000, max: 300000, badge: "⬣", className: "rank-ascendant" },
+  { key: "immortal", label: "IMMORTAL", min: 300000, max: 500000, badge: "👑", className: "rank-immortal" },
+  { key: "radiant", label: "RADIANT", min: 500000, max: Infinity, badge: "☀", className: "rank-radiant" },
+];
+
+function getRankTier(money) {
+  return RANK_TIERS.find((tier) => money >= tier.min && money < tier.max) || RANK_TIERS[0];
+}
+
+function getRankData(money, name = myName) {
+  if (isGodUser(name)) {
+    return {
+      label: "GOD",
+      badge: "⚡",
+      className: "rank-god",
+      min: Number.MAX_SAFE_INTEGER,
+      max: Number.MAX_SAFE_INTEGER,
+    };
+  }
+  return getRankTier(Number(money) || 0);
+}
+
 function getRank(money, name = myName) {
-  if (isGodUser(name)) return "GOD";
-  if (money < 500) return "RAT";
-  if (money < 2000) return "SCRIPT KIDDIE";
-  if (money < 5000) return "HACKER";
-  if (money < 10000) return "GOONER";
-  if (money < 50000) return "CYBER LORD";
-  return "KINGPIN";
+  return getRankData(money, name).label;
 }
 
 function getRankProgress(money) {
-  const tiers = [
-    { label: "RAT", min: 0, max: 500 },
-    { label: "SCRIPT KIDDIE", min: 500, max: 2000 },
-    { label: "HACKER", min: 2000, max: 5000 },
-    { label: "GOONER", min: 5000, max: 10000 },
-    { label: "CYBER LORD", min: 10000, max: 50000 },
-    { label: "KINGPIN", min: 50000, max: Infinity },
-  ];
-  const currentTier = tiers.find((tier) => money >= tier.min && money < tier.max) || tiers[0];
+  const currentTier = getRankTier(Number(money) || 0);
   if (!Number.isFinite(currentTier.max)) {
-    return { label: "MAX RANK UNLOCKED", pct: 100 };
+    return { label: "RADIANT // MAX RANK", pct: 100 };
   }
+  const nextTier = RANK_TIERS[RANK_TIERS.indexOf(currentTier) + 1];
   const span = currentTier.max - currentTier.min;
   const earned = money - currentTier.min;
   const pct = Math.max(0, Math.min(100, Math.round((earned / span) * 100)));
   return {
-    label: `$${Math.max(0, currentTier.max - money)} TO ${tiers[tiers.indexOf(currentTier) + 1].label}`,
+    label: `$${Math.max(0, currentTier.max - money).toLocaleString()} TO ${nextTier.label}`,
     pct,
   };
 }
@@ -1688,9 +1704,18 @@ function updateUI() {
   renderSeasonPanel();
   renderLiveOps();
   const rank = getRank(myMoney);
+  const rankData = getRankData(myMoney);
   setText("displayRank", "[" + rank + "]");
+  setText("displayRankBadge", rankData.badge);
   setText("profRank", rank);
+  setText("profRankBadge", rankData.badge);
   setText("profSummaryRank", "[" + rank + "]");
+  const rankBadgeEls = [document.getElementById("displayRankBadge"), document.getElementById("profRankBadge")];
+  rankBadgeEls.forEach((el) => {
+    if (!el) return;
+    el.className = `rank-badge ${rankData.className}`;
+    el.title = `${rankData.label} RANK BADGE`;
+  });
   const rankProgress = getRankProgress(myMoney);
   setText("profProgressLabel", rankProgress.label);
   const progressFill = document.getElementById("profProgressFill");
@@ -3314,6 +3339,14 @@ const renderLeaderboardRows = (
     const name = document.createElement("span");
     name.innerText = row.name;
 
+    if (row.rankData) {
+      const badge = document.createElement("span");
+      badge.className = `rank-badge inline ${row.rankData.className}`;
+      badge.innerText = row.rankData.badge;
+      badge.title = row.rankData.label;
+      name.prepend(badge);
+    }
+
     const value = document.createElement("span");
     value.innerText = `${valuePrefix}${row.score}`;
 
@@ -3362,6 +3395,7 @@ function loadLeaderboard(game) {
         rows.push({
           name: playerName,
           score: data.rank || getRank(Number(data.money) || 0, playerName),
+          rankData: getRankData(Number(data.money) || 0, playerName),
           canRemove: playerName !== myName && !isGodUser(playerName),
         });
       });

--- a/index.html
+++ b/index.html
@@ -206,10 +206,11 @@
       <div class="subtitle">TERMINAL ONLINE</div>
       <div style="margin-top: 20px; font-size: 10px">
         OPERATOR: <span id="displayUser">ANON</span>
+        <span id="displayRankBadge" class="rank-badge rank-iron">⬢</span>
         <span
           id="displayRank"
           style="color: #fff; background: var(--accent-dim); padding: 2px 5px"
-          >[RAT]</span
+          >[IRON]</span
         >
       </div>
       <section class="update-log" aria-label="Update log">
@@ -273,10 +274,10 @@
       <div class="score-box">
         <h2 style="text-align: center">OPERATOR PROFILE</h2>
         <div class="profile-summary">
-          <div class="profile-summary-rank" id="profSummaryRank">[RAT]</div>
+          <div class="profile-summary-rank" id="profSummaryRank">[IRON]</div>
           <div class="profile-progress-wrap">
             <div class="profile-progress-label" id="profProgressLabel">
-              $0 TO SCRIPT KIDDIE
+              $0 TO BRONZE
             </div>
             <div class="profile-progress-track">
               <div class="profile-progress-fill" id="profProgressFill"></div>
@@ -288,7 +289,7 @@
             <span>CODENAME</span><span id="profName">...</span>
           </div>
           <div class="stat-row">
-            <span>RANK</span><span id="profRank">...</span>
+            <span>RANK</span><span><span id="profRankBadge" class="rank-badge rank-iron">⬢</span><span id="profRank">...</span></span>
           </div>
           <div class="stat-row">
             <span>NET WORTH</span><span id="profBank">$0</span>

--- a/styles.css
+++ b/styles.css
@@ -1042,6 +1042,34 @@ canvas {
   margin-bottom: 8px;
   font-size: 11px;
 }
+
+.rank-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin: 0 4px;
+  border-radius: 4px;
+  font-size: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.rank-badge.inline {
+  margin-right: 6px;
+}
+
+.rank-iron { color: #9aa0a6; }
+.rank-bronze { color: #cd7f32; }
+.rank-silver { color: #d4d7dd; }
+.rank-gold { color: #ffd447; }
+.rank-platinum { color: #6ce4df; }
+.rank-diamond { color: #7aa6ff; }
+.rank-ascendant { color: #7b5cff; }
+.rank-immortal { color: #ff5d89; }
+.rank-radiant { color: #ffe682; }
+.rank-god { color: #ff3d3d; }
 .profile-progress-wrap {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation
- Replace the old game-count/opaque rank labels with a clearer money-driven progression that feels like competitive tiers (Valorant-style) and surface those tiers visually with badges. 
- Make rank logic reusable and consistent across UI areas (home HUD, profile, players leaderboard) so players see the same tier everywhere.

### Description
- Introduced a centralized `RANK_TIERS` table and helper functions `getRankTier` and `getRankData` in `core.js` to map `money` to tier metadata (label, badge glyph, class name, thresholds). 
- Rewired `getRank` and `getRankProgress` to use the new tier data so progress text reports the currency needed to reach the next tier. 
- Updated UI rendering in `core.js` to display a rank badge glyph for the home HUD and profile (`displayRankBadge`, `profRankBadge`) and to apply per-tier CSS classes. 
- Added rank badge elements to `index.html` and injected rank-badge rendering for each player in the Players leaderboard, plus new per-tier styles in `styles.css` (iron → radiant and a `GOD` override). 

### Testing
- Ran static checks `node --check core.js` and `node --check script.js`, both succeeded. 
- Launched a local HTTP server and captured an updated UI screenshot with Playwright to validate badges rendered on the page; screenshot saved at `browser:/tmp/codex_browser_invocations/7801f81bbd43e5f1/artifacts/artifacts/ranked-badges.png` and rendering was observed in the server logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940704ec348331ad99dc970d3de9dc)