### PR TITLE
Fix season scoreboard live updates

### DIFF
--- a/core.js
+++ b/core.js
@@ -1184,7 +1184,7 @@ function renderSeasonBoard() {
   }
 
   if (activeSeasonTab === String(seasonData.id || "").toUpperCase()) {
-    const rows = cachedSeasonBoards[activeSeasonSubTab] || [];
+    const rows = getLiveSeasonBoardRows(activeSeasonSubTab);
     boardList.innerHTML = rows.length
       ? rows
           .map((row, idx) => activeSeasonSubTab === "gang"
@@ -1219,6 +1219,41 @@ function renderSeasonBoard() {
   boardList.innerHTML = archivedEntries.length
     ? archivedEntries.map((entry, idx) => `<div class="score-item">#${idx + 1} ${escapeHtml(entry.name)} <span style="opacity:.7">${escapeHtml(String(entry.crewTag || "SOLO").toUpperCase())}</span> // $${Math.round(Number(entry.money || entry.xp) || 0)}</div>`).join("")
     : '<div class="score-item">NO ARCHIVED SOLO SCORES FOR THIS SEASON</div>';
+}
+
+function getLiveSeasonBoardRows(mode = "solo") {
+  const normalizedName = String(myName || "ANON").toUpperCase();
+  const normalizedCrewTag = normalizeCrewTag(crewData.tag) || "SOLO";
+  const localMoney = Math.max(0, Number(myMoney) || 0);
+
+  if (mode === "gang") {
+    const gangTotals = {};
+    (cachedSeasonBoards.gang || []).forEach((row) => {
+      const tag = normalizeCrewTag(row.tag);
+      if (!tag) return;
+      gangTotals[tag] = {
+        tag,
+        money: Math.max(0, Number(row.money) || 0),
+        members: Math.max(0, Math.floor(Number(row.members) || 0)),
+      };
+    });
+
+    if (normalizedCrewTag !== "SOLO") {
+      const existing = gangTotals[normalizedCrewTag];
+      if (existing) {
+        existing.money = Math.max(existing.money, localMoney);
+        existing.members = Math.max(existing.members, 1);
+      } else {
+        gangTotals[normalizedCrewTag] = { tag: normalizedCrewTag, money: localMoney, members: 1 };
+      }
+    }
+
+    return Object.values(gangTotals).sort((a, b) => b.money - a.money).slice(0, 10);
+  }
+
+  const soloRows = (cachedSeasonBoards.solo || []).filter((row) => String(row.name || "").toUpperCase() !== normalizedName);
+  soloRows.push({ name: normalizedName, money: localMoney, crewTag: normalizedCrewTag });
+  return soloRows.sort((a, b) => b.money - a.money).slice(0, 10);
 }
 
 function renderSeasonPanel() {


### PR DESCRIPTION
### Motivation
- The season leaderboard did not reflect the local player's in-session balance/crew changes until a Firestore snapshot update, causing a poor live-update experience.

### Description
- Changed the current-season render path in `renderSeasonBoard` to use a live row builder `getLiveSeasonBoardRows` instead of relying only on `cachedSeasonBoards`.
- Implemented `getLiveSeasonBoardRows(mode)` to merge local in-memory state (`myMoney`, `myName`, `crewData`) with snapshot-derived `cachedSeasonBoards` for both `solo` and `gang` views.
- For `gang` mode the function reconciles crew totals and inserts/updates the local crew entry; for `solo` it ensures the local player row is present and re-sorts the list.
- Left archived-season rendering unchanged so historical boards still use `seasonData.hall` as before.

### Testing
- Ran `node --check core.js` to validate syntax and module integrity, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994090be75483319d4ab8dd7bd31f38)