### PR TITLE
Refactor core engine kernel and rebuild runner with data-oriented systems

### DIFF
--- a/core.js
+++ b/core.js
@@ -160,12 +160,20 @@ const LOCAL_USER_STORAGE_KEY = "goonerLocalUsers";
 const LOCAL_CREW_STORAGE_KEY = "goonerCrewData";
 const LOCAL_SEASON_STORAGE_KEY = "goonerSeasonData";
 let hasAdminClaim = false;
+let permissionMask = 0;
 const CHAT_BLOCKLIST_KEY = "goonerChatBlocklist";
 const CHAT_MUTED_KEY = "goonerChatMuted";
 const CHAT_BAD_WORDS = ["slur1", "slur2", "idiot", "stupid"];
 
 // Audio context for simple synth effects.
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+export const PermissionBits = Object.freeze({
+  ADMIN: 1 << 0,
+  GOD_MODE: 1 << 1,
+  ECONOMY_WRITE: 1 << 2,
+  MODERATE_CHAT: 1 << 3,
+});
 
 // Register per-game cleanup hooks (each game adds a stop function).
 const gameStops = [];
@@ -302,30 +310,141 @@ export function dispatch(action) {
   }
 }
 
+export class EngineKernel {
+  constructor({ fixedHz = 60, maxCatchupTicks = 5 } = {}) {
+    this.fixedHz = fixedHz;
+    this.fixedDt = 1 / fixedHz;
+    this.maxCatchupTicks = maxCatchupTicks;
+    this.accumulator = 0;
+    this.lastTs = 0;
+    this.rafId = 0;
+    this.running = false;
+    this.onTick = null;
+    this.onRender = null;
+  }
+
+  start(onTick, onRender) {
+    this.stop();
+    this.onTick = onTick;
+    this.onRender = onRender;
+    this.accumulator = 0;
+    this.lastTs = 0;
+    this.running = true;
+    const frame = (ts) => {
+      if (!this.running) return;
+      if (!this.lastTs) this.lastTs = ts;
+      const frameDt = Math.min((ts - this.lastTs) / 1000, 0.1);
+      this.lastTs = ts;
+      this.accumulator += frameDt;
+      let ticks = 0;
+      while (this.accumulator >= this.fixedDt && ticks < this.maxCatchupTicks) {
+        this.onTick?.(this.fixedDt, ts);
+        this.accumulator -= this.fixedDt;
+        ticks += 1;
+      }
+      if (this.accumulator > this.fixedDt * this.maxCatchupTicks) {
+        this.accumulator = this.fixedDt;
+      }
+      this.onRender?.(this.accumulator / this.fixedDt, ts);
+      this.rafId = requestAnimationFrame(frame);
+    };
+    this.rafId = requestAnimationFrame(frame);
+  }
+
+  stop() {
+    this.running = false;
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.rafId = 0;
+  }
+}
+
+export class InputBuffer {
+  constructor(maxEntries = 64) {
+    this.maxEntries = maxEntries;
+    this.entries = [];
+  }
+
+  push(command, ts = performance.now(), payload = null) {
+    this.entries.push({ command, ts, payload });
+    if (this.entries.length > this.maxEntries) this.entries.shift();
+  }
+
+  consume(command, sinceTs = -Infinity) {
+    const idx = this.entries.findIndex((entry) => entry.command === command && entry.ts >= sinceTs);
+    if (idx === -1) return null;
+    return this.entries.splice(idx, 1)[0];
+  }
+
+  clear() {
+    this.entries.length = 0;
+  }
+}
+
+export class DrawSystem {
+  constructor(ctx) {
+    this.ctx = ctx;
+    this.commands = [];
+  }
+
+  clear(color, x, y, w, h) {
+    this.commands.push({ kind: "clear", color, x, y, w, h });
+  }
+
+  rect(color, x, y, w, h) {
+    this.commands.push({ kind: "rect", color, x, y, w, h });
+  }
+
+  line(color, width, x1, y1, x2, y2) {
+    this.commands.push({ kind: "line", color, width, x1, y1, x2, y2 });
+  }
+
+  flush() {
+    const ctx = this.ctx;
+    let fillStyle = "";
+    let strokeStyle = "";
+    let lineWidth = 1;
+    for (const cmd of this.commands) {
+      if (cmd.kind === "clear" || cmd.kind === "rect") {
+        if (fillStyle !== cmd.color) {
+          fillStyle = cmd.color;
+          ctx.fillStyle = fillStyle;
+        }
+        ctx.fillRect(cmd.x, cmd.y, cmd.w, cmd.h);
+        continue;
+      }
+      if (strokeStyle !== cmd.color) {
+        strokeStyle = cmd.color;
+        ctx.strokeStyle = strokeStyle;
+      }
+      if (lineWidth !== cmd.width) {
+        lineWidth = cmd.width;
+        ctx.lineWidth = lineWidth;
+      }
+      ctx.beginPath();
+      ctx.moveTo(cmd.x1, cmd.y1);
+      ctx.lineTo(cmd.x2, cmd.y2);
+      ctx.stroke();
+    }
+    this.commands.length = 0;
+  }
+}
+
 const loopSubscribers = new Map();
-let loopRafId = null;
-let loopLastTs = 0;
+const sharedKernel = new EngineKernel({ fixedHz: 60 });
 export function subscribeToGameLoop(id, callback) {
   loopSubscribers.set(id, callback);
-  if (loopRafId) return;
-  loopLastTs = 0;
-  const frame = (ts) => {
-    const rawDt = loopLastTs ? (ts - loopLastTs) / 1000 : 1 / 60;
-    const dt = Math.min(rawDt, 0.05);
-    loopLastTs = ts;
-    for (const cb of loopSubscribers.values()) cb(dt, ts);
-    loopRafId = loopSubscribers.size ? requestAnimationFrame(frame) : null;
-  };
-  loopRafId = requestAnimationFrame(frame);
+  if (loopSubscribers.size > 1) return;
+  sharedKernel.start(
+    (dt, ts) => {
+      for (const cb of loopSubscribers.values()) cb(dt, ts);
+    },
+    () => {}
+  );
 }
 
 export function unsubscribeFromGameLoop(id) {
   loopSubscribers.delete(id);
-  if (loopSubscribers.size === 0 && loopRafId) {
-    cancelAnimationFrame(loopRafId);
-    loopRafId = null;
-    loopLastTs = 0;
-  }
+  if (loopSubscribers.size === 0) sharedKernel.stop();
 }
 
 async function runFirestoreTask(task, context, fallback) {
@@ -427,15 +546,24 @@ function applyOwnedVisuals() {
 async function refreshAdminClaim() {
   try {
     const claims = await auth.currentUser?.getIdTokenResult(true);
-    hasAdminClaim = claims?.claims?.admin === true;
+    const tokenClaims = claims?.claims || {};
+    const tokenMask = Number(tokenClaims.perms ?? tokenClaims.permissionMask ?? 0) || 0;
+    const godByClaim = tokenClaims.admin === true || tokenClaims.godMode === true;
+    permissionMask = tokenMask | (godByClaim ? PermissionBits.ADMIN | PermissionBits.GOD_MODE : 0);
+    hasAdminClaim = (permissionMask & PermissionBits.ADMIN) !== 0;
   } catch {
     hasAdminClaim = false;
+    permissionMask = 0;
   }
+}
+
+export function hasPermission(bit) {
+  return (permissionMask & bit) === bit;
 }
 
 function isGodUser(name = myName) {
   if (String(name || "").toUpperCase() !== String(myName || "").toUpperCase()) return false;
-  return hasAdminClaim;
+  return hasPermission(PermissionBits.GOD_MODE) || hasAdminClaim;
 }
 
 function updateAdminMenu() {
@@ -1117,19 +1245,36 @@ export function stopAllGames() {
   window.removeEventListener("keydown", quickRestartListener);
 }
 
+export class Synth {
+  constructor(context) {
+    this.context = context;
+    this.master = context.createGain();
+    this.master.gain.value = 0.8;
+    this.master.connect(context.destination);
+  }
+
+  play({ freq = 440, type = "square", len = 0.1, attack = 0.002, decay = 0.08 } = {}) {
+    if (this.context.state === "suspended") this.context.resume();
+    const now = this.context.currentTime;
+    const osc = this.context.createOscillator();
+    const env = this.context.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, now);
+    env.gain.setValueAtTime(0.0001, now);
+    env.gain.exponentialRampToValueAtTime(0.07 * globalVol, now + attack);
+    env.gain.exponentialRampToValueAtTime(0.0001, now + Math.max(attack + decay, len));
+    osc.connect(env);
+    env.connect(this.master);
+    osc.start(now);
+    osc.stop(now + Math.max(attack + decay, len));
+  }
+}
+
+const synth = new Synth(audioCtx);
+
 // Simple synth beep helper used across the UI for feedback.
 export function beep(freq = 440, type = "square", len = 0.1) {
-  if (audioCtx.state === "suspended") audioCtx.resume();
-  const o = audioCtx.createOscillator();
-  const g = audioCtx.createGain();
-  o.type = type;
-  o.frequency.setValueAtTime(freq, audioCtx.currentTime);
-  g.gain.setValueAtTime(0.05 * globalVol, audioCtx.currentTime);
-  g.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + len);
-  o.connect(g);
-  g.connect(audioCtx.destination);
-  o.start();
-  o.stop(audioCtx.currentTime + len);
+  synth.play({ freq, type, len });
 }
 
 // "Success" melody used after achievements or purchases.

--- a/games/runner.js
+++ b/games/runner.js
@@ -1,4 +1,4 @@
-// Endless runner with obstacles, jump physics, and speed scaling.
+// Endless runner rebuilt around a data-oriented kernel with fixed-step simulation.
 import {
   registerGameStop,
   checkLossStreak,
@@ -11,113 +11,203 @@ import {
   consumeShield,
   state,
   hasActiveItem,
+  EngineKernel,
+  DrawSystem,
+  InputBuffer,
 } from "../core.js";
 
-let rCtx;
-let rCv;
-let player = {};
-let rObs = [];
-let rSpeed = 5;
-let rScore = 0;
-let rAnim;
-let rSpawnTimer = 0;
-let rLastTime = 0;
+const WIDTH = 800;
+const HEIGHT = 400;
+const GROUND_Y = 350;
+const PLAYER_W = 30;
+const PLAYER_H = 50;
+const PLAYER_X = 50;
+const PLAYER_START_Y = 300;
+const PLAYER_JUMP_FORCE = 12;
+const PLAYER_GRAVITY = 0.6;
+const MAX_OBSTACLES = 96;
 
-const BASE_FRAME_MS = 1000 / 60;
-const MAX_DT_FRAMES = 2.5;
+const obstacleX = new Float32Array(MAX_OBSTACLES);
+const obstacleY = new Float32Array(MAX_OBSTACLES);
+const obstacleW = new Float32Array(MAX_OBSTACLES);
+const obstacleH = new Float32Array(MAX_OBSTACLES);
+const obstacleActive = new Uint8Array(MAX_OBSTACLES);
+const obstaclePrevX = new Float32Array(MAX_OBSTACLES);
 
-export function initRunner() {
-  state.currentGame = "runner";
-  loadHighScores();
-  rCv = document.getElementById("runnerCanvas");
-  rCtx = rCv.getContext("2d");
-  player = { x: 50, y: 300, w: 30, h: 50, dy: 0, grounded: true, jumpForce: 12, gravity: 0.6 };
-  rObs = [];
-  rSpeed = 5;
-  rScore = 0;
-  rSpawnTimer = 0;
-  rLastTime = 0;
-  setText("runnerScoreBoard", "SCORE: 0");
-  loopRunner(performance.now());
+const freeList = new Uint16Array(MAX_OBSTACLES);
+let freeTop = 0;
+
+const player = {
+  y: PLAYER_START_Y,
+  prevY: PLAYER_START_Y,
+  dy: 0,
+  grounded: 1,
+};
+
+let ctx;
+let drawSystem;
+let kernel;
+let inputBuffer;
+let score = 0;
+let speed = 5;
+let spawnTicks = 0;
+let groundColor = "#0f0";
+
+function resetPool() {
+  freeTop = MAX_OBSTACLES;
+  for (let i = 0; i < MAX_OBSTACLES; i++) {
+    obstacleActive[i] = 0;
+    freeList[i] = MAX_OBSTACLES - 1 - i;
+  }
 }
 
-// Main runner loop: update physics, spawn obstacles, render, and score.
-function loopRunner(now) {
+function allocObstacle() {
+  if (freeTop <= 0) return -1;
+  const idx = freeList[--freeTop];
+  obstacleActive[idx] = 1;
+  return idx;
+}
+
+function freeObstacle(i) {
+  obstacleActive[i] = 0;
+  freeList[freeTop++] = i;
+}
+
+function queueJump(now = performance.now()) {
+  inputBuffer.push("JUMP", now);
+}
+
+function spawnObstacle() {
+  const idx = allocObstacle();
+  if (idx === -1) return;
+  const tall = Math.random() > 0.7;
+  const h = tall ? 60 : 30;
+  obstacleX[idx] = WIDTH;
+  obstaclePrevX[idx] = WIDTH;
+  obstacleY[idx] = GROUND_Y - h;
+  obstacleW[idx] = 20;
+  obstacleH[idx] = h;
+}
+
+function intersects(x, y, w, h, ox, oy, ow, oh) {
+  return x < ox + ow && x + w > ox && y < oy + oh && y + h > oy;
+}
+
+function onTick(dt) {
   if (state.currentGame !== "runner") return;
-  const dtFrames = rLastTime
-    ? Math.min((now - rLastTime) / BASE_FRAME_MS, MAX_DT_FRAMES)
-    : 1;
-  rLastTime = now;
-  rCtx.fillStyle = "#000";
-  rCtx.fillRect(0, 0, 800, 400);
-  rCtx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
-  rCtx.lineWidth = 2;
-  rCtx.beginPath();
-  rCtx.moveTo(0, 350);
-  rCtx.lineTo(800, 350);
-  rCtx.stroke();
-  const currentSpeed = rSpeed * (hasActiveItem("item_slowmo") ? 0.8 : 1);
-  if ((state.keysPressed[" "] || state.keysPressed.ArrowUp) && player.grounded) {
-    player.dy = -player.jumpForce;
-    player.grounded = false;
+
+  spawnTicks += 1;
+  const currentSpeed = speed * (hasActiveItem("item_slowmo") ? 0.8 : 1);
+  const spawnIntervalTicks = Math.max(24, Math.floor(60 / currentSpeed));
+
+  const bufferedJump = inputBuffer.consume("JUMP", performance.now() - 120);
+  if (bufferedJump && player.grounded) {
+    player.dy = -PLAYER_JUMP_FORCE;
+    player.grounded = 0;
   }
-  player.dy += player.gravity * dtFrames;
-  player.y += player.dy * dtFrames;
-  if (player.y > 300) {
-    player.y = 300;
+
+  player.prevY = player.y;
+  player.dy += PLAYER_GRAVITY;
+  player.y += player.dy;
+  if (player.y > PLAYER_START_Y) {
+    player.y = PLAYER_START_Y;
     player.dy = 0;
-    player.grounded = true;
+    player.grounded = 1;
   }
-  rCtx.fillStyle = "#fff";
-  rCtx.fillRect(player.x, player.y, player.w, player.h);
-  rSpawnTimer += dtFrames;
-  const spawnInterval = Math.max(40, Math.floor(1000 / currentSpeed));
-  while (rSpawnTimer >= spawnInterval) {
-    rSpawnTimer -= spawnInterval;
-    const height = Math.random() > 0.7 ? 60 : 30;
-    rObs.push({ x: 800, y: 350 - height, w: 20, h: height });
+
+  if (spawnTicks >= spawnIntervalTicks) {
+    spawnTicks = 0;
+    spawnObstacle();
   }
-  for (let i = rObs.length - 1; i >= 0; i--) {
-    const o = rObs[i];
-    o.x -= currentSpeed * dtFrames;
-    rCtx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent");
-    rCtx.fillRect(o.x, o.y, o.w, o.h);
+
+  for (let i = 0; i < MAX_OBSTACLES; i++) {
+    if (!obstacleActive[i]) continue;
+    obstaclePrevX[i] = obstacleX[i];
+    obstacleX[i] -= currentSpeed * (dt * 60);
+
     if (
-      player.x < o.x + o.w &&
-      player.x + player.w > o.x &&
-      player.y < o.y + o.h &&
-      player.y + player.h > o.y
+      intersects(
+        PLAYER_X,
+        player.y,
+        PLAYER_W,
+        PLAYER_H,
+        obstacleX[i],
+        obstacleY[i],
+        obstacleW[i],
+        obstacleH[i]
+      )
     ) {
       if (consumeShield()) {
-        rObs.splice(i, 1);
+        freeObstacle(i);
         showToast("SHIELD USED", "🛡️");
         continue;
       }
       checkLossStreak();
-      showGameOver("runner", Math.floor(rScore));
+      showGameOver("runner", Math.floor(score));
       return;
     }
-    if (o.x < -30) {
-      rObs.splice(i, 1);
-      rScore += 1;
-      updateHighScore("runner", rScore);
-      setText("runnerScoreBoard", "SCORE: " + rScore);
-      if (rScore % 5 === 0) rSpeed += 0.5;
+
+    if (obstacleX[i] < -30) {
+      freeObstacle(i);
+      score += 1;
+      updateHighScore("runner", score);
+      setText("runnerScoreBoard", `SCORE: ${score}`);
+      if (score % 5 === 0) speed += 0.5;
       resetLossStreak();
     }
   }
-  rAnim = requestAnimationFrame(loopRunner);
 }
 
-// Mouse/tap jump support on the canvas.
-document.getElementById("runnerCanvas").onclick = () => {
-  if (state.currentGame === "runner" && player.grounded) {
-    player.dy = -player.jumpForce;
-    player.grounded = false;
+function onRender(alpha) {
+  if (state.currentGame !== "runner") return;
+  drawSystem.clear("#000", 0, 0, WIDTH, HEIGHT);
+  drawSystem.line(groundColor, 2, 0, GROUND_Y, WIDTH, GROUND_Y);
+
+  const py = player.prevY + (player.y - player.prevY) * alpha;
+  drawSystem.rect("#fff", PLAYER_X, py, PLAYER_W, PLAYER_H);
+
+  for (let i = 0; i < MAX_OBSTACLES; i++) {
+    if (!obstacleActive[i]) continue;
+    const ox = obstaclePrevX[i] + (obstacleX[i] - obstaclePrevX[i]) * alpha;
+    drawSystem.rect(groundColor, ox, obstacleY[i], obstacleW[i], obstacleH[i]);
   }
+
+  drawSystem.flush();
+}
+
+export function initRunner() {
+  state.currentGame = "runner";
+  loadHighScores();
+
+  const canvas = document.getElementById("runnerCanvas");
+  ctx = canvas.getContext("2d");
+  drawSystem = new DrawSystem(ctx);
+  kernel = new EngineKernel({ fixedHz: 60 });
+  inputBuffer = new InputBuffer(32);
+
+  score = 0;
+  speed = 5;
+  spawnTicks = 0;
+  player.y = PLAYER_START_Y;
+  player.prevY = PLAYER_START_Y;
+  player.dy = 0;
+  player.grounded = 1;
+  groundColor = getComputedStyle(document.documentElement).getPropertyValue("--accent") || "#0f0";
+  resetPool();
+
+  setText("runnerScoreBoard", "SCORE: 0");
+  kernel.start(onTick, onRender);
+}
+
+document.getElementById("runnerCanvas").onclick = () => {
+  if (state.currentGame === "runner") queueJump();
 };
 
-// Stop the animation when leaving the game.
+document.addEventListener("keydown", (event) => {
+  if (state.currentGame !== "runner") return;
+  if (event.key === " " || event.key === "ArrowUp") queueJump();
+});
+
 registerGameStop(() => {
-  if (rAnim) cancelAnimationFrame(rAnim);
+  kernel?.stop();
 });


### PR DESCRIPTION
### Motivation
- Convert the ad-hoc game code into a small engine kernel that enforces a deterministic fixed-step simulation and enables data-oriented, high-performance game modules. 
- Reduce GC pressure and canvas state churn by introducing pooled SoA storage for game entities and a centralized draw/interrupt path. 
- Harden admin checks by deriving permissions from JWT custom claims using a bitmask model and upgrade the simple UI synth into a lightweight envelope-based synth.

### Description
- Add `EngineKernel` to `core.js` which runs a fixed-step update loop (default 60Hz) with interpolation for render frames and a shared kernel path for existing `subscribeToGameLoop` users. 
- Introduce `DrawSystem`, `InputBuffer`, and `Synth` in `core.js` to centralize batched canvas commands, timestamped command-style inputs, and procedural audio respectively, and replace the legacy `beep()` implementation to use the `Synth`. 
- Implement bitmask permissions (`PermissionBits`, `permissionMask`, `hasPermission`) and update `refreshAdminClaim`/`isGodUser` to derive privileges from JWT custom claims (`perms`/`permissionMask` plus `admin`/`godMode` fallback). 
- Replace `games/runner.js` with a data-oriented implementation using TypedArrays for obstacle storage, a freelist-based static pool, `InputBuffer`-backed jump buffering, deterministic `EngineKernel` tick handling, and rendering via `DrawSystem` (interpolated rendering between ticks). 

### Testing
- Ran syntax checks with `node --check /workspace/webstie/core.js` and `node --check /workspace/webstie/games/runner.js`, both succeeded. 
- Attempted to launch a static server and capture a browser screenshot via an automated Playwright step, but the Playwright navigation failed with `ERR_EMPTY_RESPONSE` in this environment (investigation pending). 
- Per-file runtime checks (module parse) completed and no syntax errors were reported by the automated checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948cef51d0832bb694c8f40eda10d5)