### PR TITLE
Add in-browser assembler to CPU emulator and publish docs page

### DIFF
--- a/cpu-emulator-docs.html
+++ b/cpu-emulator-docs.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CPU Emulator Docs</title>
+    <link rel="stylesheet" href="styles.css" />
+    <style>
+      body { padding: 20px; }
+      .doc-wrap { max-width: 900px; margin: 0 auto; }
+      .doc-wrap h1, .doc-wrap h2 { color: var(--accent); }
+      .doc-wrap code { color: #7fffd4; }
+      .doc-card { border: 1px solid var(--accent); background: rgba(0,0,0,.65); padding: 14px; margin-bottom: 14px; }
+      table { width: 100%; border-collapse: collapse; font-size: 11px; }
+      th, td { border: 1px solid #245; padding: 6px; text-align: left; vertical-align: top; }
+      th { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <div class="doc-wrap">
+      <h1>CPU Emulator + Assembler Documentation</h1>
+      <div class="doc-card">
+        <h2>Quick Start</h2>
+        <ol>
+          <li>Open <code>CPU EMULATOR</code> from the GAMES menu.</li>
+          <li>Write assembly in the <code>ASSEMBLY SOURCE</code> panel.</li>
+          <li>Click <code>ASSEMBLE + LOAD</code>.</li>
+          <li>Use <code>STEP</code> or <code>RUN</code> to execute from <code>0x0500</code>.</li>
+        </ol>
+      </div>
+      <div class="doc-card">
+        <h2>Assembly Syntax</h2>
+        <ul>
+          <li>Registers: <code>R0</code> to <code>RF</code>.</li>
+          <li>Immediates: decimal (<code>42</code>) or hex (<code>0x002A</code>).</li>
+          <li>Comments: start with <code>;</code> or <code>#</code>.</li>
+          <li>Labels: <code>LOOP:</code> on their own line or before an instruction.</li>
+          <li>Instruction formats:
+            <ul>
+              <li><code>OP</code></li>
+              <li><code>OP Rn</code></li>
+              <li><code>OP Rn, Rm</code></li>
+              <li><code>OP Rn, imm</code></li>
+              <li><code>OP imm</code></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="doc-card">
+        <h2>Example Program</h2>
+<pre class="emu-output">START:
+  LFI R1, 0x0005
+  LFI R2, 0x0003
+  ADD R1, R2
+  HALT</pre>
+      </div>
+      <div class="doc-card">
+        <h2>Instruction Set</h2>
+        <table>
+          <thead><tr><th>Opcode</th><th>Mnemonic</th><th>Operands</th></tr></thead>
+          <tbody>
+            <tr><td>0x00</td><td>NOOP</td><td>-</td></tr><tr><td>0x01</td><td>LFI</td><td>Rn, imm</td></tr><tr><td>0x02</td><td>LFA</td><td>Rn, Rm</td></tr><tr><td>0x03</td><td>LFAL</td><td>Rn, Rm</td></tr><tr><td>0x04</td><td>LFAH</td><td>Rn, Rm</td></tr><tr><td>0x05</td><td>STO</td><td>Rn, Rm</td></tr><tr><td>0x06</td><td>STOL</td><td>Rn, Rm</td></tr><tr><td>0x07</td><td>STOH</td><td>Rn, Rm</td></tr><tr><td>0x08</td><td>MVR</td><td>Rn, Rm</td></tr><tr><td>0x09</td><td>SWR</td><td>Rn, Rm</td></tr><tr><td>0x0A</td><td>SWP</td><td>Rn, Rm</td></tr><tr><td>0x0B</td><td>NOT</td><td>Rn, Rm</td></tr><tr><td>0x0C</td><td>AND</td><td>Rn, Rm</td></tr><tr><td>0x0D</td><td>OR</td><td>Rn, Rm</td></tr><tr><td>0x0E</td><td>XOR</td><td>Rn, Rm</td></tr><tr><td>0x0F</td><td>NOR</td><td>Rn, Rm</td></tr><tr><td>0x10</td><td>SHR</td><td>Rn, Rm</td></tr><tr><td>0x11</td><td>SHL</td><td>Rn, Rm</td></tr><tr><td>0x12</td><td>ROR</td><td>Rn, Rm</td></tr><tr><td>0x13</td><td>ROL</td><td>Rn, Rm</td></tr><tr><td>0x14</td><td>ADD</td><td>Rn, Rm</td></tr><tr><td>0x15</td><td>SUB</td><td>Rn, Rm</td></tr><tr><td>0x16</td><td>MUL</td><td>Rn, Rm</td></tr><tr><td>0x17</td><td>DEV</td><td>Rn, Rm</td></tr><tr><td>0x18</td><td>EVE</td><td>Rn, Rm</td></tr><tr><td>0x19</td><td>EVGT</td><td>Rn, Rm</td></tr><tr><td>0x1A</td><td>EVLT</td><td>Rn, Rm</td></tr><tr><td>0x1B</td><td>EVGTE</td><td>Rn, Rm</td></tr><tr><td>0x1C</td><td>EVLTE</td><td>Rn, Rm</td></tr><tr><td>0x1D</td><td>EVNOT</td><td>-</td></tr><tr><td>0x1E</td><td>EVST</td><td>-</td></tr><tr><td>0x1F</td><td>EVSF</td><td>-</td></tr><tr><td>0x20</td><td>EVOF</td><td>-</td></tr><tr><td>0x21</td><td>EVZF</td><td>-</td></tr><tr><td>0x22</td><td>EVCA</td><td>-</td></tr><tr><td>0x23</td><td>JMP</td><td>Rn, Rm</td></tr><tr><td>0x24</td><td>JMPC</td><td>Rn, Rm</td></tr><tr><td>0x25</td><td>JRA</td><td>Rn, Rm</td></tr><tr><td>0x26</td><td>JRS</td><td>Rn, Rm</td></tr><tr><td>0x27</td><td>JRAC</td><td>Rn, Rm</td></tr><tr><td>0x28</td><td>JRSC</td><td>Rn, Rm</td></tr><tr><td>0x29</td><td>JRIA</td><td>imm</td></tr><tr><td>0x2A</td><td>JRIS</td><td>imm</td></tr><tr><td>0x2B</td><td>JRIAC</td><td>imm</td></tr><tr><td>0x2C</td><td>JRISC</td><td>imm</td></tr><tr><td>0x2D</td><td>JTSR</td><td>Rn, Rm</td></tr><tr><td>0x2E</td><td>JTSRC</td><td>Rn, Rm</td></tr><tr><td>0x2F</td><td>RFSR</td><td>-</td></tr><tr><td>0x30</td><td>RFSRC</td><td>-</td></tr><tr><td>0x31</td><td>HALT</td><td>-</td></tr><tr><td>0x32</td><td>INT</td><td>Rn, Rm</td></tr><tr><td>0x33</td><td>INTI</td><td>imm</td></tr><tr><td>0x34</td><td>RFI</td><td>-</td></tr><tr><td>0x35</td><td>SBI</td><td>-</td></tr><tr><td>0x36</td><td>CBI</td><td>-</td></tr><tr><td>0x37</td><td>SPF</td><td>-</td></tr><tr><td>0x38</td><td>CPF</td><td>-</td></tr><tr><td>0x39</td><td>SLMB</td><td>Rn, Rm</td></tr><tr><td>0x3A</td><td>SLME</td><td>Rn, Rm</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/games/emulator.js
+++ b/games/emulator.js
@@ -65,6 +65,34 @@ const OPCODE_META = {
   0x3a: { rr: true, im: false, name: "SLME" },
 };
 
+
+const MNEMONIC_TO_OPCODE = Object.fromEntries(
+  Object.entries(OPCODE_META).map(([opcode, meta]) => [meta.name, Number(opcode)]),
+);
+
+function splitAssemblerOperands(rawOperands) {
+  if (!rawOperands) return [];
+  return rawOperands
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseRegisterToken(token, lineNumber) {
+  const match = /^R([0-9A-F])$/i.exec(token);
+  if (!match) {
+    throw new Error(`Line ${lineNumber}: expected register token (R0-RF), got "${token}".`);
+  }
+  return Number.parseInt(match[1], 16);
+}
+
+function parseImmediateToken(token, labels, lineNumber) {
+  if (token in labels) return labels[token];
+  if (/^0x[\da-f]+$/i.test(token)) return Number.parseInt(token.slice(2), 16) & WORD_MASK;
+  if (/^-?\d+$/.test(token)) return Number.parseInt(token, 10) & WORD_MASK;
+  throw new Error(`Line ${lineNumber}: invalid immediate/label token "${token}".`);
+}
+
 class Emulator {
   constructor() {
     this.registers = new Uint16Array(16);
@@ -106,6 +134,90 @@ class Emulator {
     for (let i = 0; i < cleaned.length; i += 2) {
       bytes.push(Number.parseInt(cleaned.slice(i, i + 2), 16));
     }
+    return bytes;
+  }
+
+  bytesToHex(bytes) {
+    return bytes.map((value) => value.toString(16).toUpperCase().padStart(2, "0")).join(" ");
+  }
+
+  assembleProgram(assemblyText) {
+    const lines = assemblyText.split(/\r?\n/);
+    const parsed = [];
+    const labels = {};
+    let address = PROGRAM_START;
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const lineNumber = index + 1;
+      const noComment = lines[index].replace(/[#;].*$/, "").trim();
+      if (!noComment) continue;
+
+      let working = noComment;
+      while (working.includes(":")) {
+        const labelMatch = /^([A-Za-z_][\w]*):\s*(.*)$/.exec(working);
+        if (!labelMatch) break;
+        const label = labelMatch[1];
+        if (labels[label] !== undefined) {
+          throw new Error(`Line ${lineNumber}: duplicate label "${label}".`);
+        }
+        labels[label] = address & WORD_MASK;
+        working = labelMatch[2].trim();
+        if (!working) break;
+      }
+      if (!working) continue;
+
+      const firstSpace = working.search(/\s/);
+      const mnemonic = (firstSpace === -1 ? working : working.slice(0, firstSpace)).toUpperCase();
+      const rawOperands = firstSpace === -1 ? "" : working.slice(firstSpace + 1).trim();
+      const operands = splitAssemblerOperands(rawOperands);
+      const opcode = MNEMONIC_TO_OPCODE[mnemonic];
+      if (opcode === undefined) {
+        throw new Error(`Line ${lineNumber}: unknown opcode "${mnemonic}".`);
+      }
+
+      const size = this.instructionSize(opcode);
+      parsed.push({ lineNumber, opcode, mnemonic, operands, address: address & WORD_MASK });
+      address = (address + size) & WORD_MASK;
+    }
+
+    const bytes = [];
+    for (const instruction of parsed) {
+      const meta = OPCODE_META[instruction.opcode];
+      const { operands, lineNumber } = instruction;
+      let r1 = 0;
+      let r2 = 0;
+      let immediate;
+
+      if (meta.rr && meta.im) {
+        if (operands.length < 2 || operands.length > 3) {
+          throw new Error(`Line ${lineNumber}: ${instruction.mnemonic} expects Rn, imm (optional second register).`);
+        }
+        r1 = parseRegisterToken(operands[0], lineNumber);
+        immediate = parseImmediateToken(operands[1], labels, lineNumber);
+        if (operands[2]) r2 = parseRegisterToken(operands[2], lineNumber);
+      } else if (meta.rr) {
+        if (operands.length < 1 || operands.length > 2) {
+          throw new Error(`Line ${lineNumber}: ${instruction.mnemonic} expects Rn or Rn, Rm.`);
+        }
+        r1 = parseRegisterToken(operands[0], lineNumber);
+        if (operands[1]) r2 = parseRegisterToken(operands[1], lineNumber);
+      } else if (meta.im) {
+        if (operands.length !== 1) {
+          throw new Error(`Line ${lineNumber}: ${instruction.mnemonic} expects one immediate operand.`);
+        }
+        immediate = parseImmediateToken(operands[0], labels, lineNumber);
+      } else if (operands.length !== 0) {
+        throw new Error(`Line ${lineNumber}: ${instruction.mnemonic} takes no operands.`);
+      }
+
+      bytes.push(instruction.opcode & 0xff);
+      if (meta.rr) bytes.push(((r1 & 0xf) << 4) | (r2 & 0xf));
+      if (meta.im) {
+        const value = immediate & WORD_MASK;
+        bytes.push((value >> 8) & 0xff, value & 0xff);
+      }
+    }
+
     return bytes;
   }
 
@@ -429,11 +541,13 @@ export function initEmulator() {
   }
 
   const loadBtn = document.getElementById("emuLoad");
+  const assembleBtn = document.getElementById("emuAssemble");
   const stepBtn = document.getElementById("emuStep");
   const runBtn = document.getElementById("emuRun");
   const stopBtn = document.getElementById("emuStop");
   const resetBtn = document.getElementById("emuReset");
   const programInput = document.getElementById("emuProgram");
+  const assemblyInput = document.getElementById("emuAssembly");
 
   loadBtn.onclick = () => {
     try {
@@ -441,6 +555,21 @@ export function initEmulator() {
       renderState();
     } catch (error) {
       emulator.log(`Load error: ${error.message}`);
+      renderState();
+    }
+  };
+
+
+  assembleBtn.onclick = () => {
+    try {
+      const bytes = emulator.assembleProgram(assemblyInput.value);
+      const hexProgram = emulator.bytesToHex(bytes);
+      programInput.value = hexProgram;
+      emulator.loadProgram(hexProgram);
+      emulator.log(`Assembled ${bytes.length} bytes successfully.`);
+      renderState();
+    } catch (error) {
+      emulator.log(`Assembler error: ${error.message}`);
       renderState();
     }
   };
@@ -465,7 +594,13 @@ export function initEmulator() {
     renderState();
   };
 
-  programInput.value = "01 10 05 00 01 20 00 03 14 12 31";
+  assemblyInput.value = `START:
+  LFI R1, 0x0005
+  LFI R2, 0x0003
+  ADD R1, R2
+  HALT`;
+  const bootBytes = emulator.assembleProgram(assemblyInput.value);
+  programInput.value = emulator.bytesToHex(bootBytes);
   emulator.loadProgram(programInput.value);
   renderState();
   initialized = true;

--- a/index.html
+++ b/index.html
@@ -1369,11 +1369,20 @@
           ></textarea>
           <div class="emu-controls">
             <button class="term-btn" id="emuLoad">LOAD</button>
+            <button class="term-btn" id="emuAssemble">ASSEMBLE + LOAD</button>
             <button class="term-btn" id="emuStep">STEP</button>
             <button class="term-btn" id="emuRun">RUN</button>
             <button class="term-btn" id="emuStop">STOP</button>
             <button class="term-btn" id="emuReset">RESET</button>
+            <a class="term-btn emu-doc-link" href="cpu-emulator-docs.html" target="_blank" rel="noopener noreferrer">DOCS</a>
           </div>
+          <p class="emu-label" style="margin-top: 12px">ASSEMBLY SOURCE</p>
+          <textarea
+            id="emuAssembly"
+            class="emu-program"
+            spellcheck="false"
+            placeholder="START:\n  LFI R1, 0x0005\n  LFI R2, 0x0003\n  ADD R1, R2\n  HALT"
+          ></textarea>
         </div>
         <div class="emu-panel">
           <p class="emu-label">REGISTERS</p>

--- a/styles.css
+++ b/styles.css
@@ -2166,6 +2166,12 @@ canvas {
   gap: 8px;
   margin-top: 10px;
 }
+.emu-doc-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
 .emu-output {
   margin: 0 0 8px;
   border: 1px solid var(--accent-dim);


### PR DESCRIPTION
### Motivation
- Provide an integrated assembly workflow so users can write human-readable assembly, assemble it in-browser, and load the resulting program into the existing CPU emulator.
- Ship lightweight documentation so users understand syntax, directives, and the emulator instruction set.

### Description
- Implemented assembler support in `games/emulator.js` including `MNEMONIC_TO_OPCODE`, operand splitting, `parseRegisterToken`, `parseImmediateToken`, `assembleProgram`, and `bytesToHex` to produce machine bytes from assembly source.
- Added an `ASSEMBLE + LOAD` button, an `ASSEMBLY SOURCE` textarea, a docs link in the emulator overlay, and wired the assemble flow to populate the program hex and load it at `0x0500` with a boot-time sample program in `index.html`.
- Added minimal styles for the docs link in `styles.css` and improved emulator UI integration (error logging on assembler failures and successful-assembly messages).
- Created a new `cpu-emulator-docs.html` page that contains quick start steps, syntax rules, an example program, and an instruction reference table.

### Testing
- Ran `node --check games/emulator.js` which reported no syntax errors and succeeded.
- Ran `node --check script.js && node --check games/emulator.js` which succeeded with no syntax errors reported.
- Attempted to capture a rendered docs screenshot with Playwright, but the Chromium process crashed in this environment (SIGSEGV), so no browser-rendered artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699496be182c832babcc6ae5f6ca4054)