### PR TITLE
Add Games Directory overlay and make game viewports responsive

### DIFF
--- a/core.js
+++ b/core.js
@@ -1794,7 +1794,8 @@ export function closeOverlays() {
   document
     .querySelectorAll(".overlay")
     .forEach((o) => o.classList.remove("active"));
-  document.getElementById("menuDropdown").classList.remove("show");
+  const menuDropdown = document.getElementById("menuDropdown");
+  if (menuDropdown) menuDropdown.classList.remove("show");
 }
 
 function normalizeUsername(username) {
@@ -3240,15 +3241,24 @@ document.getElementById("btnLogout").onclick = () => {
   localStorage.clear();
   location.reload();
 };
-// Toggle the hamburger menu dropdown.
-document.getElementById("menuToggle").onclick = (e) => {
-  e.stopPropagation();
-  document.getElementById("menuDropdown").classList.toggle("show");
-  registerMenuMash();
-};
-// Click outside closes the dropdown menu.
+// Open the games directory from top navigation and keep menu-mash tracking.
+const menuToggleBtn = document.getElementById("menuToggle");
+const menuDropdownEl = document.getElementById("menuDropdown");
+if (menuToggleBtn) {
+  menuToggleBtn.onclick = (e) => {
+    e.stopPropagation();
+    registerMenuMash();
+    if (menuDropdownEl && menuDropdownEl.children.length) {
+      menuDropdownEl.classList.toggle("show");
+      return;
+    }
+    openGame("overlayGames");
+  };
+}
+// Click outside closes the dropdown menu if the legacy dropdown exists.
 document.addEventListener("click", (e) => {
-  if (!e.target.closest("#menuToggle")) document.getElementById("menuDropdown").classList.remove("show");
+  if (!menuDropdownEl || !menuDropdownEl.children.length) return;
+  if (!e.target.closest("#menuToggle")) menuDropdownEl.classList.remove("show");
 });
 // Enable/disable matrix canvas rendering.
 function setMatrixMode(enabled) {

--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -26,6 +26,9 @@
             box-shadow: 0 0 30px rgba(139, 69, 19, 0.5);
             image-rendering: pixelated;
             image-rendering: crisp-edges;
+            width: min(100vw, 1200px);
+            height: auto;
+            max-height: 100vh;
         }
 
         #ui {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+      content="width=device-width, initial-scale=1"
     />
     <meta name="app-version" content="dev" />
     <title>GOONER TERMINAL V32 [PVP FIX]</title>
@@ -65,43 +65,36 @@
         >
           ADMIN
         </button>
-        <button class="menu-btn" id="menuToggle">GAMES ▼</button>
+        <button class="menu-btn" id="menuToggle">GAMES</button>
       </div>
     </div>
 
-    <!-- Dropdown game menu (toggled from the top bar). -->
-    <div class="dropdown-content" id="menuDropdown">
-      <button onclick="window.launchGame('geo')">GEO DASH</button>
-      <button onclick="window.launchGame('type')">TYPE RUNNER</button>
-      <button onclick="window.launchGame('pong')">PONG</button>
-      <button onclick="window.launchGame('snake')">SNAKE</button>
-      <button onclick="window.launchGame('runner')">RUNNER (V2)</button>
-      <button onclick="window.launchGame('corebreaker')">CORE BREAKER</button>
-      <button onclick="window.launchGame('neondefender')">NEON DEFENDER</button>
-      <button onclick="window.launchGame('voidminer')">VOID MINER</button>
-      <button onclick="window.launchGame('shadowassassin')">SHADOW ASSASSIN</button>
-      <button onclick="window.launchGame('dodge')">DODGE GRID</button>
-      <button onclick="window.launchGame('roulette')">ROULETTE</button>
-      <button
-        onclick="window.launchGame('blackjack')"
-        style="border-top: 1px solid #444"
-      >
-        BLACKJACK (PVP)
-      </button>
-      <button onclick="window.launchGame('ttt')">TIC TAC TOE</button>
-      <button onclick="window.launchGame('hangman')">HANGMAN (PVP)</button>
-      <button onclick="window.launchGame('bonk')">BONK ARENA (PVP)</button>
-      <button onclick="window.launchGame('drift')">NEON DRIFT (PVP)</button>
-      <button onclick="window.launchGame('emulator')" style="border-top: 1px solid #444">
-        CPU EMULATOR
-      </button>
-      <button
-        onclick="window.launchGame('flappy')"
-        id="btnFlappy"
-        style="display: none; color: gold"
-      >
-        FLAPPY GOON
-      </button>
+    <div class="dropdown-content" id="menuDropdown"></div>
+
+    <!-- Dedicated games directory overlay. -->
+    <div class="overlay" id="overlayGames">
+      <h1>GAMES DIRECTORY</h1>
+      <div class="games-grid">
+        <button class="game-card" onclick="window.launchGame('geo')"><span>🟨</span><strong>GEO DASH</strong><small>Dodge spikes and survive speed ramps.</small></button>
+        <button class="game-card" onclick="window.launchGame('type')"><span>⌨️</span><strong>TYPE RUNNER</strong><small>Type fast to outrun incoming threats.</small></button>
+        <button class="game-card" onclick="window.launchGame('pong')"><span>🏓</span><strong>PONG</strong><small>Retro paddle battle with adjustable difficulty.</small></button>
+        <button class="game-card" onclick="window.launchGame('snake')"><span>🐍</span><strong>SNAKE</strong><small>Grow longer while avoiding walls and yourself.</small></button>
+        <button class="game-card" onclick="window.launchGame('runner')"><span>🏃</span><strong>RUNNER V2</strong><small>Endless sprint with jump timing focus.</small></button>
+        <button class="game-card" onclick="window.launchGame('corebreaker')"><span>🧱</span><strong>CORE BREAKER</strong><small>Break glowing blocks and protect your core.</small></button>
+        <button class="game-card" onclick="window.launchGame('neondefender')"><span>🎯</span><strong>NEON DEFENDER</strong><small>Aim, auto-fire, and hold the line.</small></button>
+        <button class="game-card" onclick="window.launchGame('voidminer')"><span>🚀</span><strong>VOID MINER</strong><small>Thrust through deep space for score.</small></button>
+        <button class="game-card" onclick="window.launchGame('shadowassassin')"><span>🗡️</span><strong>SHADOW ASSASSIN</strong><small>Castle infiltration with boss encounters.</small></button>
+        <button class="game-card" onclick="window.launchGame('dodge')"><span>⚡</span><strong>DODGE GRID</strong><small>Stay alive in a high-speed hazard field.</small></button>
+        <button class="game-card" onclick="window.launchGame('roulette')"><span>🎡</span><strong>ROULETTE</strong><small>Bet, spin, and chase streaks.</small></button>
+        <button class="game-card" onclick="window.launchGame('blackjack')"><span>🂡</span><strong>BLACKJACK (PVP)</strong><small>Card table duels with live opponents.</small></button>
+        <button class="game-card" onclick="window.launchGame('ttt')"><span>❎</span><strong>TIC TAC TOE</strong><small>Classic 3x3 tactical showdown.</small></button>
+        <button class="game-card" onclick="window.launchGame('hangman')"><span>🧠</span><strong>HANGMAN (PVP)</strong><small>Guess words before the timer expires.</small></button>
+        <button class="game-card" onclick="window.launchGame('bonk')"><span>🥊</span><strong>BONK ARENA (PVP)</strong><small>Fast arena knockouts and dodges.</small></button>
+        <button class="game-card" onclick="window.launchGame('drift')"><span>🏎️</span><strong>NEON DRIFT (PVP)</strong><small>Slide corners and chain clean laps.</small></button>
+        <button class="game-card" onclick="window.launchGame('emulator')"><span>🖥️</span><strong>CPU EMULATOR</strong><small>Program-like puzzle sandbox challenge.</small></button>
+        <button class="game-card" id="btnFlappy" onclick="window.launchGame('flappy')" style="display: none"><span>🐤</span><strong>FLAPPY GOON</strong><small>Secret bonus mode: tap to survive.</small></button>
+      </div>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>
 
     <!-- God-tier operator controls. Visible only to allowlisted users. -->

--- a/styles.css
+++ b/styles.css
@@ -61,9 +61,9 @@ body {
   margin: 0;
   background-color: var(--bg);
   font-family: var(--font-main);
-  overflow: hidden;
+  overflow-x: hidden;
   color: var(--accent);
-  touch-action: none;
+  touch-action: auto;
   text-shadow: 0 0 10px var(--accent);
   transition:
     color 0.5s,
@@ -226,7 +226,7 @@ body::before {
 
 /* Games dropdown menu anchored to the top bar. */
 .dropdown-content {
-  display: none;
+  display: none !important;
   position: absolute;
   right: 20px;
   top: 50px;
@@ -562,25 +562,28 @@ canvas {
   border: 4px solid var(--accent);
   background: #000;
   box-shadow: 0 0 20px var(--accent-dim);
-  max-width: 95vw;
-  max-height: 60vh;
+  width: min(95vw, 960px);
+  height: auto;
+  max-height: calc(100vh - 230px);
   image-rendering: pixelated;
   margin-bottom: 10px;
 }
 
 .embedded-game-frame {
-  width: min(1200px, 95vw);
-  height: min(800px, 75vh);
+  width: min(95vw, 1200px);
+  height: min(78vh, 800px);
+  max-height: calc(100vh - 210px);
   border: 3px solid var(--accent);
   background: #000;
   box-shadow: 0 0 20px var(--accent-dim);
 }
 
 .exit-btn-fixed {
-  position: fixed;
-  bottom: 30px;
-  left: 50%;
-  transform: translateX(-50%);
+  position: sticky;
+  bottom: 20px;
+  left: auto;
+  transform: none;
+  margin: 16px 0 10px;
   width: 200px;
   border: 2px solid var(--accent);
   background: #000;
@@ -591,6 +594,45 @@ canvas {
   cursor: pointer;
   transition: 0.2s;
   z-index: 1001;
+}
+
+.games-grid {
+  width: min(1200px, 95vw);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.game-card {
+  border: 1px solid var(--accent);
+  background: rgba(0, 0, 0, 0.7);
+  color: var(--accent);
+  text-align: left;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: inherit;
+}
+
+.game-card span {
+  font-size: 18px;
+}
+
+.game-card strong {
+  font-size: 10px;
+}
+
+.game-card small {
+  font-size: 9px;
+  color: #ddd;
+  line-height: 1.4;
+}
+
+.game-card:hover {
+  background: var(--accent-dim);
+  box-shadow: 0 0 10px var(--accent-dim);
 }
 .exit-btn-fixed:hover {
   background: var(--accent);


### PR DESCRIPTION
### Motivation
- The games dropdown was becoming crowded and the top-bar UX needed a dedicated directory to reduce clutter. 
- Several embedded/Canvas games were being clipped when scaled (notably Shadow Assassin), so canvas/iframe sizing needed to be more responsive to preserve the playfield (floor) on smaller viewports.

### Description
- Replace the packed dropdown with an empty legacy `#menuDropdown` and add a new `#overlayGames` overlay containing icon-based game cards and short descriptions for each title, including the hidden Flappy entry. (`index.html`)
- Change the top-bar Games button behavior to open the new Games Directory when the legacy dropdown has no entries while preserving the existing `menu_mash` achievement tracking and safe dropdown-close logic. (`core.js`)
- Make global layout and game containers responsive: loosen the viewport zoom restriction, allow horizontal overflow only, set canvases to `width: min(95vw, 960px)` / `height: auto` with a viewport-based `max-height`, adjust embedded iframe sizing, and convert the exit button from a fixed overlay to sticky flow positioning so it doesn't cover game content. (`styles.css`)
- Add responsive canvas rules inside the Shadow Assassin iframe so its 1200x700 playfield scales to available space and the floor remains visible. (`games/shadow-assassin-safe-rooms.html`)

### Testing
- Ran `node --check core.js` and `node --check script.js`; both checks completed successfully.
- Executed an automated Playwright script that loaded the app, dismissed the login overlay, clicked the Games button, and captured a screenshot of the Games Directory; the script completed and produced the screenshot successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994981485608322bdfa1fa047ab83bb)