### PR TITLE
Fix Shadow Assassin scaling, add fullscreen controls, and improve homepage stacking

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -26,9 +26,11 @@
             box-shadow: 0 0 30px rgba(139, 69, 19, 0.5);
             image-rendering: pixelated;
             image-rendering: crisp-edges;
-            width: min(100vw, 1200px);
+            width: min(calc(100vw - 24px), calc((100vh - 24px) * 1.7143), 1200px);
+            max-width: 1200px;
+            aspect-ratio: 1200 / 700;
             height: auto;
-            max-height: 100vh;
+            max-height: calc(100vh - 24px);
         }
 
         #ui {

--- a/index.html
+++ b/index.html
@@ -930,6 +930,7 @@
         class="embedded-game-frame"
         src="games/shadow-assassin-safe-rooms.html"
         title="Shadow Assassin"
+        allowfullscreen
       ></iframe>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">
         EXIT SYSTEM

--- a/script.js
+++ b/script.js
@@ -106,6 +106,75 @@ window.launchGame = (game) => {
   unlockAchievement("noob");
 };
 
+
+const GAME_OVERLAY_IDS = [
+  "overlayGeo",
+  "overlayType",
+  "overlayPong",
+  "overlaySnake",
+  "overlayRunner",
+  "overlayCorebreaker",
+  "overlayNeondefender",
+  "overlayVoidminer",
+  "overlayShadowassassin",
+  "overlayDodge",
+  "overlayRoulette",
+  "overlayTTT",
+  "overlayHangman",
+  "overlayBlackjack",
+  "overlayBonk",
+  "overlayFlappy",
+  "overlayDrift",
+  "overlayEmulator",
+];
+
+function getFullscreenTarget(overlay) {
+  return overlay.querySelector("canvas, iframe") || overlay;
+}
+
+async function toggleGameFullscreen(overlay, button) {
+  const target = getFullscreenTarget(overlay);
+  if (!document.fullscreenElement) {
+    await target.requestFullscreen();
+  } else {
+    await document.exitFullscreen();
+  }
+  button.textContent = document.fullscreenElement ? "EXIT FULLSCREEN" : "FULLSCREEN";
+}
+
+function initGameFullscreenControls() {
+  const overlays = GAME_OVERLAY_IDS
+    .map((id) => document.getElementById(id))
+    .filter(Boolean);
+
+  overlays.forEach((overlay) => {
+    const exitBtn = overlay.querySelector(".exit-btn-fixed");
+    if (!exitBtn || overlay.querySelector(".fullscreen-btn-fixed")) return;
+
+    const fsButton = document.createElement("button");
+    fsButton.className = "fullscreen-btn-fixed";
+    fsButton.type = "button";
+    fsButton.textContent = "FULLSCREEN";
+    fsButton.addEventListener("click", async () => {
+      try {
+        await toggleGameFullscreen(overlay, fsButton);
+      } catch (error) {
+        console.warn("Fullscreen toggle failed", error);
+      }
+    });
+    exitBtn.insertAdjacentElement("beforebegin", fsButton);
+  });
+
+  document.addEventListener("fullscreenchange", () => {
+    const isFullscreen = Boolean(document.fullscreenElement);
+    document.querySelectorAll(".fullscreen-btn-fixed").forEach((button) => {
+      button.textContent = isFullscreen ? "EXIT FULLSCREEN" : "FULLSCREEN";
+    });
+  });
+}
+
+initGameFullscreenControls();
+
 // Restart the last game from the game-over modal.
 document.getElementById("goRestart").onclick = () => {
   document.getElementById("modalGameOver").classList.remove("active");

--- a/styles.css
+++ b/styles.css
@@ -170,15 +170,16 @@ body::before {
 /* --- 3. LAYOUT & UI --- */
 /* Central landing layout. */
 .wrap {
-  height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   position: relative;
   z-index: 10;
-  padding: 20px;
+  padding: 90px 20px 260px;
   width: 100%;
+  gap: 12px;
 }
 
 /* Sticky top navigation bar with system status. */
@@ -570,12 +571,34 @@ canvas {
 }
 
 .embedded-game-frame {
-  width: min(95vw, 1200px);
-  height: min(78vh, 800px);
+  width: min(95vw, calc((100vh - 210px) * 1.7143), 1200px);
+  aspect-ratio: 1200 / 700;
+  height: auto;
   max-height: calc(100vh - 210px);
   border: 3px solid var(--accent);
   background: #000;
   box-shadow: 0 0 20px var(--accent-dim);
+}
+
+.fullscreen-btn-fixed {
+  position: sticky;
+  bottom: 82px;
+  margin: 0 0 10px;
+  width: 200px;
+  border: 2px solid var(--accent);
+  background: #000;
+  color: var(--accent);
+  padding: 12px;
+  font-family: inherit;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: 0.2s;
+  z-index: 1001;
+}
+
+.fullscreen-btn-fixed:hover {
+  background: var(--accent);
+  color: #000;
 }
 
 .exit-btn-fixed {
@@ -1442,6 +1465,34 @@ canvas {
   }
   .hangman-figure {
     transform: scale(0.9);
+  }
+
+  .wrap {
+    padding: 76px 12px 24px;
+    gap: 10px;
+  }
+
+  #globalChat {
+    position: static;
+    width: min(92vw, 420px);
+    height: 220px;
+    margin: 10px auto 16px;
+  }
+
+  .top-bar {
+    height: auto;
+    min-height: 50px;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .sys-info {
+    width: 100%;
+    order: 3;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 }
 /* Game Over Modal */


### PR DESCRIPTION
### Motivation
- Prevent the Shadow Assassin game canvas/iframe from stretching horizontally by preserving its native 1200×700 aspect ratio when the viewport changes.
- Provide a consistent fullscreen toggle for all game overlays so players can expand and collapse any game using the standard Fullscreen API.
- Resolve homepage layout overlapping where fixed/top elements could cover landing content on smaller viewports.

### Description
- Constrain the Shadow Assassin game surface by updating the canvas CSS in `games/shadow-assassin-safe-rooms.html` to use `aspect-ratio: 1200 / 700` and a width bounded by both viewport width and height so the surface scales proportionally.
- Update the embedded iframe sizing in `styles.css` (`.embedded-game-frame`) to the same aspect ratio and add mobile-aware max-height constraints to avoid horizontal stretching.
- Add a reusable fullscreen control flow in `script.js` that injects a `FULLSCREEN` / `EXIT FULLSCREEN` button before each overlay's exit button, targets the overlay's `canvas` or `iframe`, and toggles using `requestFullscreen()` / `exitFullscreen()` while tracking `fullscreenchange` to keep labels in sync.
- Add `allowfullscreen` to the Shadow Assassin iframe in `index.html` and introduce `.fullscreen-btn-fixed` styles in `styles.css` for the new button, plus homepage layout tweaks (`.wrap`, top-bar and `#globalChat` responsive rules) to avoid stacking/overlap on small screens.

### Testing
- Ran static checks with `node --check script.js` and `node --check core.js`, both succeeded.
- Served the site locally with `python -m http.server 4173` and validated UI in a headless browser; screenshots were captured for the homepage and Shadow Assassin pages to confirm layout and aspect-ratio behavior (success).
- Manual runtime validation confirmed the injected fullscreen buttons appear for game overlays and toggle the game surface into and out of fullscreen using the Fullscreen API (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949affa94883228dd164620f559231)