### PR TITLE
Add terminal I/O to CPU emulator overlay

### DIFF
--- a/cpu-emulator-docs.html
+++ b/cpu-emulator-docs.html
@@ -62,6 +62,7 @@
           <li>Click <code>ASSEMBLE + LOAD</code> (program loads at <code>0x0500</code>).</li>
           <li>Use <code>STEP</code> for single-instruction execution or <code>RUN</code> for continuous execution.</li>
           <li>Use <code>STOP</code> to halt the run loop and <code>RESET</code> to reset CPU/memory state.</li>
+          <li>Use <code>TERMINAL I/O</code> to queue keyboard input for memory-mapped reads and inspect character output.</li>
         </ol>
       </div>
 
@@ -97,6 +98,10 @@
           </thead>
           <tbody>
             <tr><td><code>0x0001</code></td><td>JSR software-stack pointer byte (stack base is <code>0x0200</code>).</td></tr>
+            <tr><td><code>0x00F0</code></td><td>Terminal input status register (<code>1</code> when input bytes are queued).</td></tr>
+            <tr><td><code>0x00F1</code></td><td>Terminal input data register (read pops one queued byte).</td></tr>
+            <tr><td><code>0x00F2</code></td><td>Terminal output register (write byte/ASCII char to append terminal output).</td></tr>
+            <tr><td><code>0x00F3</code></td><td>Terminal output clear register (write any value to clear output).</td></tr>
             <tr><td><code>0x0100-0x01FF</code></td><td>Interrupt vector table; each vector entry is a 16-bit handler address.</td></tr>
             <tr><td><code>0x0200-0x02FF</code></td><td>Internal JSR return-address stack storage.</td></tr>
             <tr><td><code>0x0400-0x042A</code></td><td>Saved execution context during interrupt handling.</td></tr>

--- a/games/emulator.js
+++ b/games/emulator.js
@@ -2,6 +2,10 @@ const WORD_MASK = 0xffff;
 const MEMORY_SIZE = 0x10000;
 const PROGRAM_START = 0x0500;
 const CONTEXT_BASE = 0x0400;
+const IO_INPUT_STATUS = 0x00f0;
+const IO_INPUT_DATA = 0x00f1;
+const IO_OUTPUT_DATA = 0x00f2;
+const IO_OUTPUT_CLEAR = 0x00f3;
 
 const OPCODE_META = {
   0x00: { rr: false, im: false, name: "NOOP" },
@@ -116,6 +120,8 @@ class Emulator {
     this.localMemoryEnd = WORD_MASK;
     this.halted = false;
     this.logs = [];
+    this.terminalOutput = "";
+    this.inputQueue = [];
     this.memory[0x0001] = 0;
   }
 
@@ -234,11 +240,32 @@ class Emulator {
     return (value & WORD_MASK).toString(16).toUpperCase().padStart(width, "0");
   }
 
+  appendTerminalOutput(value) {
+    const char = String.fromCharCode(value & 0xff);
+    this.terminalOutput = (this.terminalOutput + char).slice(-1200);
+  }
+
+  enqueueTerminalInput(text) {
+    if (!text) return;
+    for (const char of text) {
+      this.inputQueue.push(char.charCodeAt(0) & 0xff);
+    }
+    this.inputQueue.push(0x0a);
+    this.log(`TERM IN <= "${text}"`);
+  }
+
   readByte(address, privilegedBypass = false) {
     const addr = address & WORD_MASK;
     if (!privilegedBypass && !this.canAccess(addr)) {
       this.handleInterrupt(0x00);
       throw new Error(`Memory access violation @0x${this.hex(addr)}`);
+    }
+
+    if (addr === IO_INPUT_STATUS) {
+      return this.inputQueue.length > 0 ? 1 : 0;
+    }
+    if (addr === IO_INPUT_DATA) {
+      return this.inputQueue.length > 0 ? this.inputQueue.shift() : 0;
     }
     return this.memory[addr];
   }
@@ -249,6 +276,16 @@ class Emulator {
       this.handleInterrupt(0x00);
       throw new Error(`Memory access violation @0x${this.hex(addr)}`);
     }
+
+    if (addr === IO_OUTPUT_DATA) {
+      this.appendTerminalOutput(value);
+      return;
+    }
+    if (addr === IO_OUTPUT_CLEAR) {
+      this.terminalOutput = "";
+      return;
+    }
+
     this.memory[addr] = value & 0xff;
   }
 
@@ -513,6 +550,7 @@ function renderState() {
   document.getElementById("emuFlags").textContent = flagsText;
   document.getElementById("emuMemory").textContent = memoryView.join("\n");
   document.getElementById("emuLog").textContent = emulator.logs.join("\n");
+  document.getElementById("emuTerminalOutput").textContent = emulator.terminalOutput || "[NO OUTPUT YET]";
 }
 
 function stopRunLoop() {
@@ -548,6 +586,8 @@ export function initEmulator() {
   const resetBtn = document.getElementById("emuReset");
   const programInput = document.getElementById("emuProgram");
   const assemblyInput = document.getElementById("emuAssembly");
+  const terminalInput = document.getElementById("emuTerminalInput");
+  const terminalSendBtn = document.getElementById("emuTerminalSend");
 
   loadBtn.onclick = () => {
     try {
@@ -593,6 +633,18 @@ export function initEmulator() {
     emulator.reset();
     renderState();
   };
+
+  terminalSendBtn.onclick = () => {
+    emulator.enqueueTerminalInput(terminalInput.value.trim());
+    terminalInput.value = "";
+    renderState();
+  };
+
+  terminalInput.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    terminalSendBtn.click();
+  });
 
   assemblyInput.value = `START:
   LFI R1, 0x0005

--- a/index.html
+++ b/index.html
@@ -1407,6 +1407,18 @@
         <div class="emu-panel">
           <p class="emu-label">EXECUTION LOG</p>
           <pre id="emuLog" class="emu-output"></pre>
+          <p class="emu-label" style="margin-top: 12px">TERMINAL I/O</p>
+          <div class="emu-terminal-controls">
+            <input
+              type="text"
+              id="emuTerminalInput"
+              class="term-input"
+              maxlength="120"
+              placeholder="TYPE INPUT AND PRESS SEND"
+            />
+            <button class="term-btn" id="emuTerminalSend">SEND</button>
+          </div>
+          <pre id="emuTerminalOutput" class="emu-output"></pre>
         </div>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>

--- a/styles.css
+++ b/styles.css
@@ -2274,6 +2274,17 @@ canvas {
   justify-content: center;
   text-decoration: none;
 }
+.emu-terminal-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.emu-terminal-controls .term-input {
+  flex: 1;
+}
+
 .emu-output {
   margin: 0 0 8px;
   border: 1px solid var(--accent-dim);


### PR DESCRIPTION
### Motivation
- Allow assembly programs running in the CPU emulator to perform interactive character I/O using memory-mapped registers so users can test programs that read keyboard input or print text. 
- Surface terminal input/output in the emulator UI to improve debugging and make I/O behavior visible without modifying the emulator core externally.

### Description
- Add a `TERMINAL I/O` panel to the emulator overlay in `index.html` with `#emuTerminalInput`, `#emuTerminalSend`, and `#emuTerminalOutput` UI elements. 
- Add layout rules for the controls via `.emu-terminal-controls` in `styles.css`. 
- Implement memory-mapped terminal registers and buffering in `games/emulator.js` by introducing `IO_INPUT_STATUS`, `IO_INPUT_DATA`, `IO_OUTPUT_DATA`, and `IO_OUTPUT_CLEAR` and internal fields `inputQueue` and `terminalOutput`. 
- Provide `enqueueTerminalInput` and `appendTerminalOutput` helpers, hook `readByte`/`writeByte` to service the new registers, update `renderState()` to display terminal output, and wire send/Enter handlers in `initEmulator()` so queued input is consumed by emulated programs. 
- Update `cpu-emulator-docs.html` to document the new terminal I/O registers and a short usage note.

### Testing
- Ran `node --check games/emulator.js` to verify the modified emulator script parses and passes a static syntax check, which succeeded. 
- Started a local static server and attempted a Playwright-driven UI verification to send input and capture a screenshot, but the headless Chromium process crashed with a SIGSEGV in this environment so the browser-based end-to-end screenshot step could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949df42428832b9fbc59bcb8df1e21)