### PR TITLE
Add 24h Trending Games panel to home terminal

### DIFF
--- a/core.js
+++ b/core.js
@@ -1401,6 +1401,100 @@ function renderLiveOps() {
   setText("liveOpsRoom", item.room);
 }
 
+
+const TRENDING_GAME_LABELS = {
+  pong: "PONG",
+  snake: "SNAKE",
+  runner: "RUNNER",
+  geo: "GEOMETRY",
+  type: "TYPE RUNNER",
+  blackjack: "BLACKJACK",
+  ttt: "TIC-TAC-TOE",
+  hangman: "HANGMAN",
+  flappy: "FLAPPY",
+  dodge: "DODGE",
+  roulette: "ROULETTE",
+  bonk: "BONK ARENA",
+  drift: "NEON DRIFT",
+  corebreaker: "COREBREAKER",
+  neondefender: "NEON DEFENDER",
+  voidminer: "VOID MINER",
+  emulator: "CPU EMULATOR",
+};
+
+function formatTrendingWindowLabel() {
+  const now = new Date();
+  return `LAST REFRESH ${now.toLocaleTimeString("en-GB")} // WINDOW 24H`;
+}
+
+async function refreshTrendingGames() {
+  const wrap = document.getElementById("trendingGamesList");
+  const meta = document.getElementById("trendingGamesMeta");
+  if (!wrap || !meta) return;
+  const since = Date.now() - 24 * 60 * 60 * 1000;
+
+  try {
+    const snap = await getDocs(query(collection(db, "gooner_game_plays"), where("ts", ">=", since), limit(800)));
+    const counts = new Map();
+    snap.forEach((entry) => {
+      const data = entry.data() || {};
+      const key = String(data.game || "").toLowerCase().trim();
+      if (!key) return;
+      counts.set(key, (counts.get(key) || 0) + 1);
+    });
+
+    const rows = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+
+    if (!rows.length) {
+      wrap.innerHTML = '<div class="trending-empty">NO GAME PLAYS IN THE LAST 24H.</div>';
+      meta.innerText = formatTrendingWindowLabel();
+      return;
+    }
+
+    wrap.innerHTML = rows
+      .map(([game, plays], idx) => {
+        const label = TRENDING_GAME_LABELS[game] || game.toUpperCase();
+        return `<button class="trending-game-btn" type="button" data-game="${escapeHtml(game)}"><span class="trending-rank">#${idx + 1}</span><span>${escapeHtml(label)}</span><span class="trending-count">${plays} PLAYS</span></button>`;
+      })
+      .join("");
+
+    meta.innerText = formatTrendingWindowLabel();
+  } catch (error) {
+    meta.innerText = "TRENDING SIGNAL OFFLINE";
+    wrap.innerHTML = '<div class="trending-empty">UNABLE TO LOAD TRENDING GAMES.</div>';
+  }
+}
+
+function initTrendingGamesPanel() {
+  const wrap = document.getElementById("trendingGamesList");
+  if (!wrap || wrap.dataset.ready === "1") return;
+  wrap.dataset.ready = "1";
+
+  wrap.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-game]");
+    const game = button?.dataset.game;
+    if (!game) return;
+    if (typeof window.launchGame === "function") {
+      window.launchGame(game);
+    }
+  });
+
+  refreshTrendingGames();
+  setInterval(refreshTrendingGames, 60000);
+}
+
+export function trackGamePlay(game) {
+  const normalized = String(game || "").toLowerCase().trim();
+  if (!normalized) return;
+  addDoc(collection(db, "gooner_game_plays"), {
+    game: normalized,
+    name: myName || "ANON",
+    ts: Date.now(),
+  }).catch(() => {});
+}
+
 function getAvailableSeasonIds() {
   const ids = [String(seasonData.id || "").toUpperCase(), ...(seasonData.hall || []).map((entry) => String(entry.id || "").toUpperCase())]
     .filter(Boolean);
@@ -1749,6 +1843,7 @@ initAuth();
 loadCrewData();
 loadSeasonData();
 renderLiveOps();
+initTrendingGamesPanel();
 setupBankTransferUX();
 setupLoanUX();
 setupStockMarketUX();
@@ -1762,6 +1857,7 @@ onAuthStateChanged(auth, async (u) => {
     await ensureGlobalMarket();
     subscribeToGlobalMarket();
     initChat();
+    refreshTrendingGames();
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -222,6 +222,13 @@
       <div style="margin-top: 12px; font-size: 10px">
         <a class="menu-btn" href="instruction-system-docs.html" target="_blank" rel="noopener">INSTRUCTION DOCS</a>
       </div>
+      <section class="trending-games" aria-label="Trending games">
+        <h2>TRENDING GAMES // LAST 24H</h2>
+        <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>
+        <div class="trending-games-list" id="trendingGamesList">
+          <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
+        </div>
+      </section>
       <section class="update-log" aria-label="Update log">
         <h2>UPDATE LOG</h2>
         <ul>

--- a/script.js
+++ b/script.js
@@ -29,6 +29,7 @@ import {
   adminGrantCashToUser,
   adminForgiveInterestForUser,
   adminUnlockAllAchievements,
+  trackGamePlay,
 } from "./core.js";
 import { initGeometry } from "./games/geo.js";
 import { initFlappy } from "./games/flappy.js";
@@ -104,6 +105,7 @@ window.launchGame = (game) => {
   if (game === "voidminer") initVoidMiner();
   if (game === "emulator") initEmulator();
   resizeAllGameCanvases();
+  trackGamePlay(game);
   unlockAchievement("noob");
 };
 

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,73 @@ body::before {
   text-align: center;
 }
 
+.trending-games {
+  margin-top: 24px;
+  width: min(90vw, 680px);
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.75);
+  padding: 14px 16px;
+  box-shadow: 0 0 16px rgba(0, 255, 136, 0.12);
+  text-align: left;
+}
+
+.trending-games h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #fff;
+}
+
+.trending-meta {
+  font-size: 8px;
+  color: var(--accent);
+  opacity: 0.9;
+  margin-bottom: 10px;
+}
+
+.trending-games-list {
+  display: grid;
+  gap: 8px;
+}
+
+.trending-game-btn {
+  width: 100%;
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 1px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+  transition: 0.18s ease;
+}
+
+.trending-game-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 12px rgba(0, 255, 136, 0.2);
+}
+
+.trending-rank {
+  color: var(--accent);
+}
+
+.trending-count {
+  opacity: 0.86;
+}
+
+.trending-empty {
+  border: 1px dashed var(--accent-dim);
+  padding: 10px;
+  font-size: 9px;
+  opacity: 0.75;
+}
+
 .update-log {
   margin-top: 24px;
   width: min(90vw, 680px);


### PR DESCRIPTION
### Motivation
- Surface the most-played games from the past 24 hours on the home terminal so operators can quickly jump into hot games.
- Use existing telemetry (lightweight plays) to build a fast client-side trending view without changing core game UX.

### Description
- Added a new `TRENDING GAMES // LAST 24H` section to the home landing above the update log and styled it to match the terminal theme. (`index.html`, `styles.css`).
- Implemented aggregation and rendering logic that queries the Firestore collection `gooner_game_plays` for entries with `ts` within the last 24h, sorts by play count, and renders the top results. (`core.js`).
- Hooked click-to-launch behavior into the panel so clicking a trending row calls the existing `launchGame(game)` to open the selected game. (`core.js`).
- Added lightweight play tracking by calling `trackGamePlay(game)` when games are launched so the `gooner_game_plays` collection is populated with `{ game, name, ts }`. (`script.js`, `core.js`).
- Panel auto-refreshes on a 60s interval and is initialized during startup and after auth is established. (`core.js`).

### Testing
- Ran JavaScript syntax checks with `node --check core.js && node --check script.js` and the checks succeeded. 
- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot to validate layout and styles, which completed successfully.
- Verified the panel initializes and the UI renders without runtime parse errors in the modified modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a56987308322be5c9e82daf7056f)