### PR TITLE
Improve CPU emulator speed and terminal input UX

### DIFF
--- a/games/emulator.js
+++ b/games/emulator.js
@@ -530,6 +530,9 @@ const emulator = new Emulator();
 let runTimer = null;
 let initialized = false;
 
+const RUN_INTERVAL_MS = 16;
+const RUN_STEPS_PER_TICK = 40;
+
 function renderState() {
   const regText = Array.from(emulator.registers)
     .map((value, idx) => `R${idx.toString(16).toUpperCase()}: 0x${emulator.hex(value)}`)
@@ -572,9 +575,27 @@ function safeStep() {
   }
 }
 
+function runBurst() {
+  try {
+    for (let i = 0; i < RUN_STEPS_PER_TICK; i += 1) {
+      const result = emulator.step();
+      if (result.halted) {
+        stopRunLoop();
+        break;
+      }
+    }
+    renderState();
+  } catch (error) {
+    emulator.log(`ERR: ${error.message}`);
+    renderState();
+    stopRunLoop();
+  }
+}
+
 export function initEmulator() {
   if (initialized) {
     renderState();
+    document.getElementById("emuTerminalInput")?.focus();
     return;
   }
 
@@ -621,7 +642,7 @@ export function initEmulator() {
 
   runBtn.onclick = () => {
     if (runTimer) return;
-    runTimer = window.setInterval(safeStep, 75);
+    runTimer = window.setInterval(runBurst, RUN_INTERVAL_MS);
   };
 
   stopBtn.onclick = () => {
@@ -635,13 +656,15 @@ export function initEmulator() {
   };
 
   terminalSendBtn.onclick = () => {
-    emulator.enqueueTerminalInput(terminalInput.value.trim());
+    const message = terminalInput.value.replace(/\r/g, "").trim();
+    emulator.enqueueTerminalInput(message);
     terminalInput.value = "";
+    terminalInput.focus();
     renderState();
   };
 
   terminalInput.addEventListener("keydown", (event) => {
-    if (event.key !== "Enter") return;
+    if (event.key !== "Enter" || event.shiftKey) return;
     event.preventDefault();
     terminalSendBtn.click();
   });
@@ -655,5 +678,6 @@ export function initEmulator() {
   programInput.value = emulator.bytesToHex(bootBytes);
   emulator.loadProgram(programInput.value);
   renderState();
+  terminalInput.focus();
   initialized = true;
 }

--- a/index.html
+++ b/index.html
@@ -1415,13 +1415,13 @@
           <pre id="emuLog" class="emu-output"></pre>
           <p class="emu-label" style="margin-top: 12px">TERMINAL I/O</p>
           <div class="emu-terminal-controls">
-            <input
-              type="text"
+            <textarea
               id="emuTerminalInput"
-              class="term-input"
+              class="emu-terminal-input"
               maxlength="120"
-              placeholder="TYPE INPUT AND PRESS SEND"
-            />
+              placeholder="TYPE INPUT (PRESS ENTER TO SEND, SHIFT+ENTER FOR NEW LINE)"
+              rows="2"
+            ></textarea>
             <button class="term-btn" id="emuTerminalSend">SEND</button>
           </div>
           <pre id="emuTerminalOutput" class="emu-output"></pre>

--- a/styles.css
+++ b/styles.css
@@ -2278,12 +2278,27 @@ canvas {
 .emu-terminal-controls {
   display: flex;
   gap: 8px;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 8px;
 }
 
-.emu-terminal-controls .term-input {
+.emu-terminal-input {
   flex: 1;
+  margin: 0;
+  min-height: 56px;
+  padding: 8px;
+  border: 1px solid var(--accent);
+  background: #000;
+  color: var(--accent);
+  font-family: var(--font-type);
+  font-size: 12px;
+  text-align: left;
+  resize: vertical;
+}
+
+.emu-terminal-controls .term-btn {
+  width: auto;
+  min-width: 110px;
 }
 
 .emu-output {


### PR DESCRIPTION
### Motivation

- Make the CPU emulator RUN mode much faster for smoother execution while keeping single-step behavior unchanged.
- Replace the one-line input with a real multiline textbox and improve terminal UX for easier interactive testing.

### Description

- Increased emulator throughput by adding `RUN_INTERVAL_MS` and `RUN_STEPS_PER_TICK` and executing a `runBurst()` loop that performs multiple `emulator.step()` calls per timer tick (batching instead of one-step-per-tick). (`games/emulator.js`)
- Kept existing `STEP` behavior intact and switched the `RUN` timer to call `runBurst` for higher instruction-per-second throughput. (`games/emulator.js`)
- Reworked terminal I/O input from `<input>` to a `<textarea>` and added styling for a dedicated terminal text box. (`index.html`, `styles.css`)
- Improved terminal behavior: `Enter` sends the input, `Shift+Enter` inserts a newline, carriage returns are cleaned before enqueueing, and focus is preserved after send/open. (`games/emulator.js`, `index.html`, `styles.css`)

### Testing

- Ran `node --check games/emulator.js` with no syntax errors (success).
- Launched a local static server with `python -m http.server 4173` and used Playwright to open the app, open the emulator overlay and fill the new textarea, which produced a screenshot showing the updated terminal UI (Playwright capture succeeded).
- Manual smoke interactions were performed in-browser to verify `STEP`, `RUN`, `STOP`, send-on-Enter, Shift+Enter newline, and that focus is retained after sending (observed working).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a4c4fb38832b9ce91f4d6c653e6f)