### PR TITLE
Switch default UI palette from red/black to white/black

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,7 +802,7 @@
         </h2>
         <div class="config-row">
           <span>THEME</span
-          ><input type="color" id="themeColor" value="#ff0606" />
+          ><input type="color" id="themeColor" value="#ffffff" />
         </div>
         <div class="config-row">
           <span>MATRIX</span

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,9 @@
 /* --- 1. CORE VARIABLES --- */
 :root {
   --bg: #050505;
-  --accent: #ff0606;
-  --accent-dim: rgba(255, 6, 6, 0.2);
-  --accent-glow: rgba(255, 6, 6, 0.6);
+  --accent: #ffffff;
+  --accent-dim: rgba(255, 255, 255, 0.2);
+  --accent-glow: rgba(255, 255, 255, 0.6);
   --scanline-opacity: 0.5;
   --common: #b0b0b0;
   --rare: #00ccff;


### PR DESCRIPTION
### Motivation
- Change the site’s default accent from red to white so the main UI uses a white-on-black palette as requested.

### Description
- Updated the root CSS variables in `styles.css` to set `--accent`, `--accent-dim`, and `--accent-glow` to white variants, and updated the theme color picker default in `index.html` to `#ffffff`.

### Testing
- Ran `git diff` to verify changes and committed the updates; served the site with `python3 -m http.server 4173` and captured a Playwright screenshot of `index.html`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e8ce2724832781fe8b96e34f0640)