### PR TITLE
Add 10 new quick-play terminal games

### DIFF
--- a/games/terminaltrials.js
+++ b/games/terminaltrials.js
@@ -1,0 +1,162 @@
+import { state, updateHighScore, setText, showToast } from "../core.js";
+
+const TRIALS = {
+  byteblitz: {
+    title: "BYTE BLITZ",
+    actionLabel: "COLLECT BYTE",
+    minGain: 6,
+    maxGain: 18,
+    burstChance: 0.2,
+    burstBonus: 22,
+    durationMs: 18000,
+  },
+  ciphercrack: {
+    title: "CIPHER CRACK",
+    actionLabel: "DECODE TOKEN",
+    minGain: 5,
+    maxGain: 16,
+    burstChance: 0.25,
+    burstBonus: 25,
+    durationMs: 20000,
+  },
+  astrohop: {
+    title: "ASTRO HOP",
+    actionLabel: "BOOST JET",
+    minGain: 7,
+    maxGain: 14,
+    burstChance: 0.22,
+    burstBonus: 20,
+    durationMs: 17000,
+  },
+  pulsestack: {
+    title: "PULSE STACK",
+    actionLabel: "STACK PULSE",
+    minGain: 4,
+    maxGain: 20,
+    burstChance: 0.18,
+    burstBonus: 28,
+    durationMs: 19000,
+  },
+  glitchgate: {
+    title: "GLITCH GATE",
+    actionLabel: "PATCH GLITCH",
+    minGain: 6,
+    maxGain: 17,
+    burstChance: 0.24,
+    burstBonus: 24,
+    durationMs: 18000,
+  },
+  orbweaver: {
+    title: "ORB WEAVER",
+    actionLabel: "WEAVE ORB",
+    minGain: 5,
+    maxGain: 15,
+    burstChance: 0.26,
+    burstBonus: 26,
+    durationMs: 21000,
+  },
+  laserlock: {
+    title: "LASER LOCK",
+    actionLabel: "LOCK TARGET",
+    minGain: 7,
+    maxGain: 16,
+    burstChance: 0.21,
+    burstBonus: 23,
+    durationMs: 18000,
+  },
+  metromaze: {
+    title: "METRO MAZE",
+    actionLabel: "ADVANCE NODE",
+    minGain: 5,
+    maxGain: 17,
+    burstChance: 0.23,
+    burstBonus: 24,
+    durationMs: 20000,
+  },
+  stacksmash: {
+    title: "STACK SMASH",
+    actionLabel: "SMASH STACK",
+    minGain: 6,
+    maxGain: 19,
+    burstChance: 0.19,
+    burstBonus: 27,
+    durationMs: 17000,
+  },
+  quantumflip: {
+    title: "QUANTUM FLIP",
+    actionLabel: "FLIP STATE",
+    minGain: 4,
+    maxGain: 21,
+    burstChance: 0.2,
+    burstBonus: 30,
+    durationMs: 21000,
+  },
+};
+
+const runtime = new Map();
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function clearTrial(id) {
+  const trial = runtime.get(id);
+  if (!trial) return;
+  window.clearInterval(trial.tick);
+  runtime.delete(id);
+}
+
+function initTrial(id) {
+  const config = TRIALS[id];
+  if (!config) return;
+  clearTrial(id);
+  state.currentGame = id;
+
+  const actionBtn = document.getElementById(`${id}Action`);
+  if (!actionBtn) return;
+
+  const scoreId = `${id}Score`;
+  const timerId = `${id}Timer`;
+
+  let score = 0;
+  let remainingMs = config.durationMs;
+  setText(scoreId, `SCORE: ${score}`);
+  setText(timerId, `TIME: ${(remainingMs / 1000).toFixed(1)}s`);
+  actionBtn.textContent = config.actionLabel;
+  actionBtn.disabled = false;
+
+  const tick = window.setInterval(() => {
+    remainingMs -= 100;
+    const remaining = Math.max(0, remainingMs);
+    setText(timerId, `TIME: ${(remaining / 1000).toFixed(1)}s`);
+    if (remaining > 0) return;
+    window.clearInterval(tick);
+    runtime.delete(id);
+    actionBtn.disabled = true;
+    actionBtn.textContent = "ROUND COMPLETE";
+    updateHighScore(id, score);
+    showToast(`${config.title}: ${score} PTS`);
+  }, 100);
+
+  actionBtn.onclick = () => {
+    if (remainingMs <= 0) return;
+    const gain = randomInt(config.minGain, config.maxGain);
+    const burst = Math.random() < config.burstChance ? config.burstBonus : 0;
+    score += gain + burst;
+    setText(scoreId, `SCORE: ${score}`);
+    updateHighScore(id, score);
+  };
+
+  runtime.set(id, { tick });
+}
+
+export const initByteBlitz = () => initTrial("byteblitz");
+export const initCipherCrack = () => initTrial("ciphercrack");
+export const initAstroHop = () => initTrial("astrohop");
+export const initPulseStack = () => initTrial("pulsestack");
+export const initGlitchGate = () => initTrial("glitchgate");
+export const initOrbWeaver = () => initTrial("orbweaver");
+export const initLaserLock = () => initTrial("laserlock");
+export const initMetroMaze = () => initTrial("metromaze");
+export const initStackSmash = () => initTrial("stacksmash");
+export const initQuantumFlip = () => initTrial("quantumflip");

--- a/index.html
+++ b/index.html
@@ -119,6 +119,16 @@
         <button class="game-card" data-game="bonk" data-tags="pvp arcade" onclick="window.launchGame('bonk')"><span>🥊</span><strong>BONK ARENA (PVP)</strong><small>Fast arena knockouts and dodges.</small></button>
         <button class="game-card" data-game="drift" data-tags="pvp arcade skill" onclick="window.launchGame('drift')"><span>🏎️</span><strong>NEON DRIFT (PVP)</strong><small>Slide corners and chain clean laps.</small></button>
         <button class="game-card" data-game="emulator" data-tags="skill" onclick="window.launchGame('emulator')"><span>🖥️</span><strong>CPU EMULATOR</strong><small>Program-like puzzle sandbox challenge.</small></button>
+        <button class="game-card" data-game="byteblitz" data-tags="arcade skill" onclick="window.launchGame('byteblitz')"><span>💾</span><strong>BYTE BLITZ</strong><small>Spam collect packets before the clock dies.</small></button>
+        <button class="game-card" data-game="ciphercrack" data-tags="skill" onclick="window.launchGame('ciphercrack')"><span>🔐</span><strong>CIPHER CRACK</strong><small>Rapid-fire decrypt actions for score bursts.</small></button>
+        <button class="game-card" data-game="astrohop" data-tags="arcade skill" onclick="window.launchGame('astrohop')"><span>🛰️</span><strong>ASTRO HOP</strong><small>Chain thruster taps to build momentum points.</small></button>
+        <button class="game-card" data-game="pulsestack" data-tags="arcade skill" onclick="window.launchGame('pulsestack')"><span>📶</span><strong>PULSE STACK</strong><small>Stack reactor pulses under hard time pressure.</small></button>
+        <button class="game-card" data-game="glitchgate" data-tags="arcade" onclick="window.launchGame('glitchgate')"><span>🧩</span><strong>GLITCH GATE</strong><small>Patch unstable sectors and chase combo bonus.</small></button>
+        <button class="game-card" data-game="orbweaver" data-tags="skill" onclick="window.launchGame('orbweaver')"><span>🟣</span><strong>ORB WEAVER</strong><small>Weave energy orbs to push a high-score run.</small></button>
+        <button class="game-card" data-game="laserlock" data-tags="arcade skill" onclick="window.launchGame('laserlock')"><span>🔴</span><strong>LASER LOCK</strong><small>Acquire locks fast to farm precision points.</small></button>
+        <button class="game-card" data-game="metromaze" data-tags="skill" onclick="window.launchGame('metromaze')"><span>🚇</span><strong>METRO MAZE</strong><small>Advance nodes at speed through digital tunnels.</small></button>
+        <button class="game-card" data-game="stacksmash" data-tags="arcade" onclick="window.launchGame('stacksmash')"><span>🪨</span><strong>STACK SMASH</strong><small>Break layered stacks for big spike payouts.</small></button>
+        <button class="game-card" data-game="quantumflip" data-tags="skill" onclick="window.launchGame('quantumflip')"><span>⚛️</span><strong>QUANTUM FLIP</strong><small>Flip unstable states and fish for mega bursts.</small></button>
         <button class="game-card" id="btnFlappy" data-game="flappy" data-tags="arcade skill" onclick="window.launchGame('flappy')" style="display: none"><span>🐤</span><strong>FLAPPY GOON</strong><small>Secret bonus mode: tap to survive.</small></button>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
@@ -1462,6 +1472,97 @@
           <pre id="emuTerminalOutput" class="emu-output"></pre>
         </div>
       </div>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+
+    <div class="overlay" id="overlayByteblitz">
+      <h1>BYTE BLITZ</h1>
+      <div class="high-score-display">HIGH: <span id="hsByteblitz">0</span></div>
+      <div style="margin-bottom: 10px" id="byteblitzTimer">TIME: 18.0s</div>
+      <div style="margin-bottom: 14px" id="byteblitzScore">SCORE: 0</div>
+      <button class="term-btn" id="byteblitzAction">COLLECT BYTE</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayCiphercrack">
+      <h1>CIPHER CRACK</h1>
+      <div class="high-score-display">HIGH: <span id="hsCiphercrack">0</span></div>
+      <div style="margin-bottom: 10px" id="ciphercrackTimer">TIME: 20.0s</div>
+      <div style="margin-bottom: 14px" id="ciphercrackScore">SCORE: 0</div>
+      <button class="term-btn" id="ciphercrackAction">DECODE TOKEN</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayAstrohop">
+      <h1>ASTRO HOP</h1>
+      <div class="high-score-display">HIGH: <span id="hsAstrohop">0</span></div>
+      <div style="margin-bottom: 10px" id="astrohopTimer">TIME: 17.0s</div>
+      <div style="margin-bottom: 14px" id="astrohopScore">SCORE: 0</div>
+      <button class="term-btn" id="astrohopAction">BOOST JET</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayPulsestack">
+      <h1>PULSE STACK</h1>
+      <div class="high-score-display">HIGH: <span id="hsPulsestack">0</span></div>
+      <div style="margin-bottom: 10px" id="pulsestackTimer">TIME: 19.0s</div>
+      <div style="margin-bottom: 14px" id="pulsestackScore">SCORE: 0</div>
+      <button class="term-btn" id="pulsestackAction">STACK PULSE</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayGlitchgate">
+      <h1>GLITCH GATE</h1>
+      <div class="high-score-display">HIGH: <span id="hsGlitchgate">0</span></div>
+      <div style="margin-bottom: 10px" id="glitchgateTimer">TIME: 18.0s</div>
+      <div style="margin-bottom: 14px" id="glitchgateScore">SCORE: 0</div>
+      <button class="term-btn" id="glitchgateAction">PATCH GLITCH</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayOrbweaver">
+      <h1>ORB WEAVER</h1>
+      <div class="high-score-display">HIGH: <span id="hsOrbweaver">0</span></div>
+      <div style="margin-bottom: 10px" id="orbweaverTimer">TIME: 21.0s</div>
+      <div style="margin-bottom: 14px" id="orbweaverScore">SCORE: 0</div>
+      <button class="term-btn" id="orbweaverAction">WEAVE ORB</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayLaserlock">
+      <h1>LASER LOCK</h1>
+      <div class="high-score-display">HIGH: <span id="hsLaserlock">0</span></div>
+      <div style="margin-bottom: 10px" id="laserlockTimer">TIME: 18.0s</div>
+      <div style="margin-bottom: 14px" id="laserlockScore">SCORE: 0</div>
+      <button class="term-btn" id="laserlockAction">LOCK TARGET</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayMetromaze">
+      <h1>METRO MAZE</h1>
+      <div class="high-score-display">HIGH: <span id="hsMetromaze">0</span></div>
+      <div style="margin-bottom: 10px" id="metromazeTimer">TIME: 20.0s</div>
+      <div style="margin-bottom: 14px" id="metromazeScore">SCORE: 0</div>
+      <button class="term-btn" id="metromazeAction">ADVANCE NODE</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayStacksmash">
+      <h1>STACK SMASH</h1>
+      <div class="high-score-display">HIGH: <span id="hsStacksmash">0</span></div>
+      <div style="margin-bottom: 10px" id="stacksmashTimer">TIME: 17.0s</div>
+      <div style="margin-bottom: 14px" id="stacksmashScore">SCORE: 0</div>
+      <button class="term-btn" id="stacksmashAction">SMASH STACK</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay" id="overlayQuantumflip">
+      <h1>QUANTUM FLIP</h1>
+      <div class="high-score-display">HIGH: <span id="hsQuantumflip">0</span></div>
+      <div style="margin-bottom: 10px" id="quantumflipTimer">TIME: 21.0s</div>
+      <div style="margin-bottom: 14px" id="quantumflipScore">SCORE: 0</div>
+      <button class="term-btn" id="quantumflipAction">FLIP STATE</button>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -49,6 +49,18 @@ import { initCoreBreaker } from "./games/corebreaker.js";
 import { initNeonDefender } from "./games/neondefender.js";
 import { initVoidMiner } from "./games/voidminer.js";
 import { initEmulator } from "./games/emulator.js";
+import {
+  initAstroHop,
+  initByteBlitz,
+  initCipherCrack,
+  initGlitchGate,
+  initLaserLock,
+  initMetroMaze,
+  initOrbWeaver,
+  initPulseStack,
+  initQuantumFlip,
+  initStackSmash,
+} from "./games/terminaltrials.js";
 
 // Expose select helpers globally for inline HTML event handlers.
 window.openGame = openGame;
@@ -106,6 +118,16 @@ window.launchGame = (game) => {
   if (game === "neondefender") initNeonDefender();
   if (game === "voidminer") initVoidMiner();
   if (game === "emulator") initEmulator();
+  if (game === "byteblitz") initByteBlitz();
+  if (game === "ciphercrack") initCipherCrack();
+  if (game === "astrohop") initAstroHop();
+  if (game === "pulsestack") initPulseStack();
+  if (game === "glitchgate") initGlitchGate();
+  if (game === "orbweaver") initOrbWeaver();
+  if (game === "laserlock") initLaserLock();
+  if (game === "metromaze") initMetroMaze();
+  if (game === "stacksmash") initStackSmash();
+  if (game === "quantumflip") initQuantumFlip();
   resizeAllGameCanvases();
   trackGamePlay(game);
   updateRecentGames(game);
@@ -133,6 +155,16 @@ const GAME_OVERLAY_IDS = [
   "overlayFlappy",
   "overlayDrift",
   "overlayEmulator",
+  "overlayByteblitz",
+  "overlayCiphercrack",
+  "overlayAstrohop",
+  "overlayPulsestack",
+  "overlayGlitchgate",
+  "overlayOrbweaver",
+  "overlayLaserlock",
+  "overlayMetromaze",
+  "overlayStacksmash",
+  "overlayQuantumflip",
 ];
 
 
@@ -392,6 +424,16 @@ document.getElementById("goRestart").onclick = () => {
   if (state.currentGame === "corebreaker") initCoreBreaker();
   if (state.currentGame === "neondefender") initNeonDefender();
   if (state.currentGame === "voidminer") initVoidMiner();
+  if (state.currentGame === "byteblitz") initByteBlitz();
+  if (state.currentGame === "ciphercrack") initCipherCrack();
+  if (state.currentGame === "astrohop") initAstroHop();
+  if (state.currentGame === "pulsestack") initPulseStack();
+  if (state.currentGame === "glitchgate") initGlitchGate();
+  if (state.currentGame === "orbweaver") initOrbWeaver();
+  if (state.currentGame === "laserlock") initLaserLock();
+  if (state.currentGame === "metromaze") initMetroMaze();
+  if (state.currentGame === "stacksmash") initStackSmash();
+  if (state.currentGame === "quantumflip") initQuantumFlip();
   if (state.currentGame === "roulette") {
     initRoulette();
     document.getElementById("overlayRoulette").classList.add("active");


### PR DESCRIPTION
### Motivation
- Expand the games library with a set of short, input-driven "terminal trial" mini-games for quick-play scoring runs. 
- Provide consistent UI and lifecycle parity with existing games (overlay, timer, high score, restart behavior). 

### Description
- Added a new module `games/terminaltrials.js` that defines 10 trials via a `TRIALS` config and exports per-game init functions (`initByteBlitz`, `initCipherCrack`, `initAstroHop`, `initPulseStack`, `initGlitchGate`, `initOrbWeaver`, `initLaserLock`, `initMetroMaze`, `initStackSmash`, `initQuantumFlip`) that manage timers, scoring, bursts, and high-score updates. 
- Wired the new games into the app by importing the init functions in `script.js` and adding launch routing, overlay id registration (`GAME_OVERLAY_IDS`), and restart handlers so they behave like first-class games. 
- Updated `index.html` to add game cards in the Games Directory grid and to add dedicated overlays for each new game including high score, timer, score label, action button, and exit button to match existing UX. 

### Testing
- Syntax checks passed: ran `node --check script.js` and `node --check games/terminaltrials.js`, both succeeded. 
- Served the app locally with `python -m http.server 4173` and verified the page loaded and game assets were served successfully. 
- Automated browser validation executed (Playwright script) to register a test user, open the Games menu and capture a screenshot of the updated Games Directory; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f557a1508327b26caaa7b4a8d951)