### PR TITLE
Make each Terminal Trials variant a standalone game with unique mechanics

### DIFF
--- a/games/glitchgate.js
+++ b/games/glitchgate.js
@@ -1,3 +1,121 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initGlitchGate = createTrialInit("glitchgate");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 30000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function spawnGate() {
+  return {
+    x: 80 + Math.random() * 640,
+    y: 70 + Math.random() * 250,
+    w: 80 + Math.random() * 60,
+    h: 26 + Math.random() * 24,
+    hp: 3,
+    decay: 0.15 + Math.random() * 0.2,
+  };
+}
+
+export function initGlitchGate() {
+  stop();
+  state.currentGame = "glitchgate";
+  const canvas = document.getElementById("glitchgateCanvas");
+  const action = document.getElementById("glitchgateAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remainingMs = DURATION_MS;
+  let integrity = 100;
+  let gates = [spawnGate(), spawnGate()];
+
+  setText("glitchgateScore", "SCORE: 0");
+  setText("glitchgateTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("glitchgateHud", "PATCH GATES BEFORE THEY FULLY CORRUPT");
+
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    let hit = false;
+    for (const gate of gates) {
+      if (x >= gate.x && x <= gate.x + gate.w && y >= gate.y && y <= gate.y + gate.h) {
+        gate.hp -= 1;
+        score += 12;
+        hit = true;
+        if (gate.hp <= 0) {
+          score += 18;
+          Object.assign(gate, spawnGate());
+        }
+        break;
+      }
+    }
+    if (!hit) {
+      score = Math.max(0, score - 8);
+      integrity = Math.max(0, integrity - 2);
+    }
+    setText("glitchgateScore", `SCORE: ${Math.floor(score)}`);
+    setText("glitchgateHud", `INTEGRITY: ${Math.floor(integrity)}% | ACTIVE GATES: ${gates.length}`);
+    updateHighScore("glitchgate", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    if (remainingMs % 2500 === 0 && gates.length < 5) gates.push(spawnGate());
+    setText("glitchgateTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    if (remainingMs <= 0 || integrity <= 0) {
+      const finalScore = Math.floor(score + integrity * 2);
+      stop();
+      updateHighScore("glitchgate", finalScore);
+      showToast(`GLITCH GATE: ${finalScore} PTS`, "🧩");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initGlitchGate;
+    }
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+
+    ctx.fillStyle = "#090909";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    for (const gate of gates) {
+      gate.hp -= gate.decay * dt;
+      if (gate.hp <= 0) {
+        integrity = Math.max(0, integrity - 8);
+        Object.assign(gate, spawnGate());
+      }
+
+      const fill = Math.max(0, gate.hp / 3);
+      ctx.fillStyle = `rgba(255,77,77,${0.2 + (1 - fill) * 0.6})`;
+      ctx.fillRect(gate.x - 4, gate.y - 4, gate.w + 8, gate.h + 8);
+      ctx.fillStyle = "#f5f5f5";
+      ctx.fillRect(gate.x, gate.y, gate.w * fill, gate.h);
+      ctx.strokeStyle = "#ff4d4d";
+      ctx.strokeRect(gate.x, gate.y, gate.w, gate.h);
+    }
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/laserlock.js
+++ b/games/laserlock.js
@@ -1,3 +1,116 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initLaserLock = createTrialInit("laserlock");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 28000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function newTarget() {
+  return {
+    x: 80 + Math.random() * 640,
+    y: 70 + Math.random() * 280,
+    age: 0,
+    lockAt: 0.75 + Math.random() * 0.35,
+  };
+}
+
+export function initLaserLock() {
+  stop();
+  state.currentGame = "laserlock";
+
+  const canvas = document.getElementById("laserlockCanvas");
+  const action = document.getElementById("laserlockAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let streak = 0;
+  let remainingMs = DURATION_MS;
+  let target = newTarget();
+
+  setText("laserlockScore", "SCORE: 0");
+  setText("laserlockTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("laserlockHud", "WAIT FOR FULL LOCK RING, THEN FIRE");
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+    const dist = Math.hypot(target.x - x, target.y - y);
+    const lockValue = Math.min(1, target.age / target.lockAt);
+
+    if (dist <= 28 && lockValue > 0.92) {
+      streak += 1;
+      score += 18 + streak * 4;
+      target = newTarget();
+    } else {
+      streak = 0;
+      score = Math.max(0, score - 10);
+    }
+
+    setText("laserlockScore", `SCORE: ${Math.floor(score)}`);
+    setText("laserlockHud", `LOCK STREAK: ${streak}`);
+    updateHighScore("laserlock", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    setText("laserlockTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score + streak * 8);
+      stop();
+      updateHighScore("laserlock", finalScore);
+      showToast(`LASER LOCK: ${finalScore} PTS`, "🔴");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initLaserLock;
+    }
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+
+    target.age += dt;
+    if (target.age > target.lockAt + 0.5) {
+      score = Math.max(0, score - 6);
+      streak = 0;
+      target = newTarget();
+      setText("laserlockScore", `SCORE: ${Math.floor(score)}`);
+    }
+
+    ctx.fillStyle = "#17090a";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    const lockValue = Math.min(1, target.age / target.lockAt);
+    ctx.strokeStyle = "#ffd166";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.arc(target.x, target.y, 45 - lockValue * 25, 0, Math.PI * 2);
+    ctx.stroke();
+
+    ctx.fillStyle = "#ff6b6b";
+    ctx.beginPath();
+    ctx.arc(target.x, target.y, 13, 0, Math.PI * 2);
+    ctx.fill();
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/metromaze.js
+++ b/games/metromaze.js
@@ -1,3 +1,121 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initMetroMaze = createTrialInit("metromaze");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 32000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function spawnNode(lane) {
+  return {
+    lane,
+    x: WIDTH + 30,
+    y: 95 + lane * 115,
+    speed: 170 + Math.random() * 90,
+  };
+}
+
+export function initMetroMaze() {
+  stop();
+  state.currentGame = "metromaze";
+
+  const canvas = document.getElementById("metromazeCanvas");
+  const action = document.getElementById("metromazeAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remainingMs = DURATION_MS;
+  let route = [0, 1, 2, 1, 0, 2];
+  let routeIndex = 0;
+  let nodes = [spawnNode(0), spawnNode(1), spawnNode(2)];
+
+  setText("metromazeScore", "SCORE: 0");
+  setText("metromazeTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("metromazeHud", "FOLLOW ROUTE ORDER: CLICK NEXT LANE NODE");
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    const hit = nodes.find((node) => Math.hypot(node.x - x, node.y - y) <= 24);
+    if (!hit) {
+      score = Math.max(0, score - 8);
+    } else if (hit.lane === route[routeIndex]) {
+      score += 16;
+      routeIndex = (routeIndex + 1) % route.length;
+      hit.x = WIDTH + 20;
+      hit.speed += 6;
+    } else {
+      score = Math.max(0, score - 12);
+      routeIndex = 0;
+    }
+
+    setText("metromazeScore", `SCORE: ${Math.floor(score)}`);
+    setText("metromazeHud", `NEXT LANE: ${route[routeIndex] + 1}`);
+    updateHighScore("metromaze", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    setText("metromazeTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score + routeIndex * 6);
+      stop();
+      updateHighScore("metromaze", finalScore);
+      showToast(`METRO MAZE: ${finalScore} PTS`, "🚇");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initMetroMaze;
+    }
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+
+    ctx.fillStyle = "#091219";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    for (let i = 0; i < 3; i++) {
+      const y = 95 + i * 115;
+      ctx.strokeStyle = i === route[routeIndex] ? "#f9ff9e" : "#2f5872";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(WIDTH, y);
+      ctx.stroke();
+    }
+
+    for (const node of nodes) {
+      node.x -= node.speed * dt;
+      if (node.x < -30) {
+        score = Math.max(0, score - 5);
+        node.x = WIDTH + 20;
+      }
+      ctx.fillStyle = "#8bcfff";
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, 18, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/orbweaver.js
+++ b/games/orbweaver.js
@@ -1,3 +1,118 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initOrbWeaver = createTrialInit("orbweaver");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 32000;
+const ORB_COUNT = 7;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function makeOrb() {
+  return {
+    x: 60 + Math.random() * 680,
+    y: 60 + Math.random() * 300,
+    r: 18 + Math.random() * 16,
+  };
+}
+
+export function initOrbWeaver() {
+  stop();
+  state.currentGame = "orbweaver";
+  const canvas = document.getElementById("orbweaverCanvas");
+  const action = document.getElementById("orbweaverAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remainingMs = DURATION_MS;
+  let path = [];
+  let orbs = Array.from({ length: ORB_COUNT }, makeOrb);
+  let nextIdx = Math.floor(Math.random() * ORB_COUNT);
+
+  setText("orbweaverScore", "SCORE: 0");
+  setText("orbweaverTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("orbweaverHud", "WEAVE A CHAIN: HIT THE GLOWING ORB, THEN FOLLOW THE NEXT LINK");
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    const hitIdx = orbs.findIndex((o) => Math.hypot(o.x - x, o.y - y) <= o.r + 4);
+    if (hitIdx === -1) {
+      path = [];
+      score = Math.max(0, score - 8);
+    } else if (hitIdx === nextIdx) {
+      path.push({ x: orbs[hitIdx].x, y: orbs[hitIdx].y });
+      const bonus = 10 + path.length * 4;
+      score += bonus;
+      orbs[hitIdx] = makeOrb();
+      nextIdx = Math.floor(Math.random() * ORB_COUNT);
+      if (path.length >= 6) {
+        score += 35;
+        path = [];
+      }
+    } else {
+      path = [];
+      score = Math.max(0, score - 4);
+      nextIdx = hitIdx;
+    }
+
+    setText("orbweaverScore", `SCORE: ${Math.floor(score)}`);
+    setText("orbweaverHud", `CURRENT WEAVE: ${path.length} LINKS`);
+    updateHighScore("orbweaver", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    setText("orbweaverTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score + path.length * 10);
+      stop();
+      updateHighScore("orbweaver", finalScore);
+      showToast(`ORB WEAVER: ${finalScore} PTS`, "🟣");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initOrbWeaver;
+    }
+  }, 100);
+
+  function frame(now) {
+    if (!run) return;
+    ctx.fillStyle = "#07140f";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    if (path.length > 1) {
+      ctx.strokeStyle = "#74ffa5";
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.moveTo(path[0].x, path[0].y);
+      for (let i = 1; i < path.length; i++) ctx.lineTo(path[i].x, path[i].y);
+      ctx.stroke();
+    }
+
+    orbs.forEach((orb, i) => {
+      const pulse = 1 + Math.sin(now * 0.004 + i) * 0.08;
+      ctx.fillStyle = i === nextIdx ? "#a6f3ff" : "#74ffa5";
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * pulse, 0, Math.PI * 2);
+      ctx.fill();
+    });
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/pulsestack.js
+++ b/games/pulsestack.js
@@ -1,3 +1,124 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initPulseStack = createTrialInit("pulsestack");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 28000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function draw(ctx, pulseX, stackHeight, remainingMs, score) {
+  ctx.fillStyle = "#0f0716";
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  ctx.strokeStyle = "#3b205e";
+  for (let y = 0; y < HEIGHT; y += 35) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(WIDTH, y);
+    ctx.stroke();
+  }
+
+  const zoneW = 120;
+  const zoneX = WIDTH * 0.5 - zoneW * 0.5;
+  ctx.fillStyle = "#77ffe033";
+  ctx.fillRect(zoneX, 30, zoneW, HEIGHT - 60);
+
+  ctx.fillStyle = "#bf7cff";
+  ctx.beginPath();
+  ctx.arc(pulseX, HEIGHT - 28, 16, 0, Math.PI * 2);
+  ctx.fill();
+
+  for (let i = 0; i < stackHeight; i++) {
+    const w = 44;
+    const h = 10;
+    const x = WIDTH * 0.5 - w * 0.5;
+    const y = HEIGHT - 14 - i * (h + 3);
+    ctx.fillStyle = i % 2 ? "#b586ff" : "#77ffe0";
+    ctx.fillRect(x, y - h, w, h);
+  }
+
+  ctx.fillStyle = "#d7cbff";
+  ctx.font = "bold 15px monospace";
+  ctx.textAlign = "left";
+  ctx.fillText(`STACK: ${stackHeight}`, 14, 26);
+  ctx.fillText(`SCORE: ${Math.floor(score)}`, 14, 48);
+  ctx.textAlign = "right";
+  ctx.fillText(`TIME: ${(remainingMs / 1000).toFixed(1)}s`, WIDTH - 14, 26);
+}
+
+export function initPulseStack() {
+  stop();
+  state.currentGame = "pulsestack";
+
+  const canvas = document.getElementById("pulsestackCanvas");
+  const action = document.getElementById("pulsestackAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let stackHeight = 0;
+  let combo = 1;
+  let pulseX = WIDTH * 0.5;
+  let dir = 1;
+  let remainingMs = DURATION_MS;
+
+  setText("pulsestackHud", "TIME YOUR TAP INSIDE THE CENTER ZONE TO BUILD THE STACK");
+  setText("pulsestackScore", "SCORE: 0");
+  setText("pulsestackTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = () => {
+    const centerDist = Math.abs(pulseX - WIDTH * 0.5);
+    if (centerDist <= 48) {
+      combo = Math.min(10, combo + 1);
+      stackHeight += 1;
+      score += 8 + combo * 2;
+    } else {
+      combo = 1;
+      stackHeight = Math.max(0, stackHeight - 2);
+      score = Math.max(0, score - 10);
+    }
+    setText("pulsestackScore", `SCORE: ${Math.floor(score)}`);
+    setText("pulsestackHud", `STACK: ${stackHeight} | COMBO: ${combo}x`);
+    updateHighScore("pulsestack", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score + stackHeight * 5);
+      stop();
+      updateHighScore("pulsestack", finalScore);
+      showToast(`PULSE STACK: ${finalScore} PTS`, "📶");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initPulseStack;
+      return;
+    }
+    setText("pulsestackTimer", `TIME: ${(remainingMs / 1000).toFixed(1)}s`);
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+    pulseX += dir * dt * 380;
+    if (pulseX < 25 || pulseX > WIDTH - 25) dir *= -1;
+    draw(ctx, pulseX, stackHeight, remainingMs, score);
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/quantumflip.js
+++ b/games/quantumflip.js
@@ -1,3 +1,122 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initQuantumFlip = createTrialInit("quantumflip");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 34000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function spawnParticle() {
+  return {
+    x: 40 + Math.random() * 720,
+    y: -20,
+    r: 12 + Math.random() * 10,
+    vy: 90 + Math.random() * 65,
+    phase: Math.random() < 0.5 ? 0 : 1,
+  };
+}
+
+export function initQuantumFlip() {
+  stop();
+  state.currentGame = "quantumflip";
+
+  const canvas = document.getElementById("quantumflipCanvas");
+  const action = document.getElementById("quantumflipAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remainingMs = DURATION_MS;
+  let worldPhase = 0;
+  let flipInMs = 3800;
+  let particles = Array.from({ length: 7 }, spawnParticle);
+
+  setText("quantumflipScore", "SCORE: 0");
+  setText("quantumflipTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("quantumflipHud", "ONLY COLLAPSE PARTICLES THAT MATCH THE CURRENT PHASE");
+
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    const hitIdx = particles.findIndex((p) => Math.hypot(p.x - x, p.y - y) <= p.r + 5);
+    if (hitIdx === -1) {
+      score = Math.max(0, score - 7);
+    } else {
+      const p = particles[hitIdx];
+      if (p.phase === worldPhase) {
+        score += 14;
+      } else {
+        score = Math.max(0, score - 12);
+      }
+      particles[hitIdx] = spawnParticle();
+    }
+
+    setText("quantumflipScore", `SCORE: ${Math.floor(score)}`);
+    updateHighScore("quantumflip", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    flipInMs -= 100;
+    if (flipInMs <= 0) {
+      worldPhase = worldPhase ? 0 : 1;
+      flipInMs = 3800;
+      showToast("QUANTUM FLIP", "⚛️");
+    }
+
+    setText("quantumflipTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    setText("quantumflipHud", `PHASE: ${worldPhase ? "POSITIVE" : "NEGATIVE"}`);
+
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score);
+      stop();
+      updateHighScore("quantumflip", finalScore);
+      showToast(`QUANTUM FLIP: ${finalScore} PTS`, "⚛️");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initQuantumFlip;
+    }
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+
+    ctx.fillStyle = worldPhase ? "#24124d" : "#0b0720";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    particles.forEach((p, i) => {
+      p.y += p.vy * dt;
+      if (p.y > HEIGHT + 30) particles[i] = spawnParticle();
+      ctx.fillStyle = p.phase ? "#7fffd4" : "#9b8cff";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#0a0f17";
+      ctx.font = "bold 12px monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(p.phase ? "+" : "-", p.x, p.y + 4);
+    });
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/stacksmash.js
+++ b/games/stacksmash.js
@@ -1,3 +1,116 @@
-import { createTrialInit } from "./terminaltrials-engine.js";
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
 
-export const initStackSmash = createTrialInit("stacksmash");
+const WIDTH = 800;
+const HEIGHT = 420;
+const DURATION_MS = 30000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function spawnBlock(col) {
+  return {
+    col,
+    x: 80 + col * 130,
+    y: -40,
+    w: 90,
+    h: 28,
+    hp: 1 + Math.floor(Math.random() * 3),
+    vy: 70 + Math.random() * 35,
+  };
+}
+
+export function initStackSmash() {
+  stop();
+  state.currentGame = "stacksmash";
+
+  const canvas = document.getElementById("stacksmashCanvas");
+  const action = document.getElementById("stacksmashAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remainingMs = DURATION_MS;
+  let blocks = [0, 1, 2, 3, 4].map(spawnBlock);
+
+  setText("stacksmashScore", "SCORE: 0");
+  setText("stacksmashTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
+  setText("stacksmashHud", "SMASH FALLING STACKS BEFORE THEY REACH THE FLOOR");
+
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    const hit = blocks.find((b) => x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h);
+    if (!hit) {
+      score = Math.max(0, score - 6);
+    } else {
+      hit.hp -= 1;
+      score += 6;
+      if (hit.hp <= 0) {
+        score += 14;
+        Object.assign(hit, spawnBlock(hit.col));
+      }
+    }
+
+    setText("stacksmashScore", `SCORE: ${Math.floor(score)}`);
+    updateHighScore("stacksmash", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    remainingMs -= 100;
+    setText("stacksmashTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
+    if (remainingMs <= 0) {
+      const finalScore = Math.floor(score);
+      stop();
+      updateHighScore("stacksmash", finalScore);
+      showToast(`STACK SMASH: ${finalScore} PTS`, "🪨");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initStackSmash;
+    }
+  }, 100);
+
+  let last = performance.now();
+  function frame(now) {
+    if (!run) return;
+    const dt = Math.min(0.04, (now - last) / 1000);
+    last = now;
+
+    ctx.fillStyle = "#1a1208";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = "#4c3116";
+    ctx.fillRect(0, HEIGHT - 34, WIDTH, 34);
+
+    for (const block of blocks) {
+      block.y += block.vy * dt;
+      if (block.y + block.h >= HEIGHT - 34) {
+        score = Math.max(0, score - 15);
+        Object.assign(block, spawnBlock(block.col));
+      }
+
+      ctx.fillStyle = block.hp === 1 ? "#ffc06b" : block.hp === 2 ? "#ff9a3c" : "#ff6a3c";
+      ctx.fillRect(block.x, block.y, block.w, block.h);
+      ctx.fillStyle = "#1a1208";
+      ctx.font = "bold 14px monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(String(block.hp), block.x + block.w / 2, block.y + 19);
+    }
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { timer, raf: 0, canvas };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/games/terminaltrials-engine.js
+++ b/games/terminaltrials-engine.js
@@ -61,6 +61,7 @@ const GAME_CONFIG = {
     scoreBase: 10,
     missPenalty: 4,
     comboBoost: 0.35,
+    mode: "stack",
     bg: ["#0f0716", "#2a1042"],
     accent: "#bf7cff",
     secondary: "#77ffe0",
@@ -74,6 +75,7 @@ const GAME_CONFIG = {
     speed: [100, 165],
     scoreBase: 12,
     missPenalty: 8,
+    mode: "glitch",
     bg: ["#0a0a0a", "#2b2b2b"],
     accent: "#f5f5f5",
     secondary: "#ff4d4d",
@@ -88,6 +90,7 @@ const GAME_CONFIG = {
     scoreBase: 15,
     missPenalty: 3,
     chainRadius: 85,
+    mode: "weave",
     bg: ["#08150f", "#163d2b"],
     accent: "#74ffa5",
     secondary: "#a6f3ff",
@@ -101,6 +104,7 @@ const GAME_CONFIG = {
     speed: [115, 180],
     scoreBase: 13,
     missPenalty: 6,
+    mode: "lock",
     bg: ["#17090a", "#4b1016"],
     accent: "#ff6b6b",
     secondary: "#ffd166",
@@ -115,6 +119,7 @@ const GAME_CONFIG = {
     scoreBase: 12,
     missPenalty: 5,
     lateral: true,
+    mode: "lane",
     bg: ["#091219", "#123248"],
     accent: "#8bcfff",
     secondary: "#f9ff9e",
@@ -129,6 +134,7 @@ const GAME_CONFIG = {
     scoreBase: 11,
     missPenalty: 5,
     armoredChance: 0.25,
+    mode: "smash",
     bg: ["#1a1208", "#4c3116"],
     accent: "#ffc06b",
     secondary: "#fff1c9",
@@ -143,6 +149,7 @@ const GAME_CONFIG = {
     scoreBase: 12,
     missPenalty: 4,
     flipInterval: 3800,
+    mode: "quantum",
     bg: ["#0b0720", "#24124d"],
     accent: "#9b8cff",
     secondary: "#7fffd4",
@@ -176,7 +183,8 @@ function stopTrial(id) {
 
 function spawnTarget(cfg, flipped) {
   const r = rand(cfg.targetRadius[0], cfg.targetRadius[1]);
-  return {
+  const lane = randInt(0, 2);
+  const target = {
     x: rand(r + 8, WIDTH - r - 8),
     y: flipped ? rand(220, HEIGHT - r - 8) : -r - rand(0, 80),
     vx: cfg.lateral ? rand(-50, 50) : rand(-18, 18),
@@ -184,7 +192,40 @@ function spawnTarget(cfg, flipped) {
     r,
     life: 1,
     armored: !!cfg.armoredChance && Math.random() < cfg.armoredChance,
+    born: performance.now(),
+    lane,
   };
+
+  if (cfg.mode === "stack") {
+    target.y = HEIGHT + r + rand(0, 36);
+    target.vy = -rand(cfg.speed[0] * 0.65, cfg.speed[1] * 0.75);
+    target.vx = rand(-10, 10);
+  }
+
+  if (cfg.mode === "glitch") {
+    target.integrity = rand(0.65, 1);
+  }
+
+  if (cfg.mode === "lock") {
+    target.lock = 0;
+  }
+
+  if (cfg.mode === "lane") {
+    target.y = 95 + lane * 115 + rand(-18, 18);
+    target.vx = rand(cfg.speed[0], cfg.speed[1]) * (Math.random() < 0.5 ? -1 : 1);
+    target.vy = rand(-8, 8);
+  }
+
+  if (cfg.mode === "smash") {
+    target.life = randInt(1, 3);
+    target.armored = target.life > 1;
+  }
+
+  if (cfg.mode === "quantum") {
+    target.phase = Math.random() < 0.5 ? -1 : 1;
+  }
+
+  return target;
 }
 
 function drawBackground(ctx, cfg, remainingMs, flipped) {
@@ -212,6 +253,30 @@ function drawTarget(ctx, cfg, target, t) {
   const pulse = 1 + Math.sin(t * 0.01 + target.x * 0.05) * 0.08;
   const r = target.r * pulse;
 
+  if (cfg.mode === "smash") {
+    const w = r * 2.2;
+    const h = r * 1.2;
+    ctx.fillStyle = `${cfg.accent}22`;
+    ctx.fillRect(target.x - w / 2 - 3, target.y - h / 2 - 3, w + 6, h + 6);
+    ctx.fillStyle = cfg.accent;
+    ctx.fillRect(target.x - w / 2, target.y - h / 2, w, h);
+    ctx.fillStyle = "#071017";
+    ctx.font = "bold 14px monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(String(target.life), target.x, target.y + 5);
+    return;
+  }
+
+  if (cfg.mode === "glitch") {
+    const jitter = rand(-2.5, 2.5);
+    const size = r * 1.65;
+    ctx.fillStyle = `${cfg.secondary}${target.integrity < 0.35 ? "aa" : "44"}`;
+    ctx.fillRect(target.x - size / 2 + jitter, target.y - size / 2 - jitter, size, size);
+    ctx.fillStyle = cfg.accent;
+    ctx.fillRect(target.x - r / 1.8, target.y - r / 1.8, r * 1.1, r * 1.1);
+    return;
+  }
+
   ctx.beginPath();
   ctx.fillStyle = `${cfg.accent}25`;
   ctx.arc(target.x, target.y, r + 6, 0, Math.PI * 2);
@@ -234,6 +299,21 @@ function drawTarget(ctx, cfg, target, t) {
   ctx.beginPath();
   ctx.arc(target.x, target.y, Math.max(3, r * 0.35), 0, Math.PI * 2);
   ctx.fill();
+
+  if (cfg.mode === "quantum") {
+    ctx.fillStyle = target.phase > 0 ? cfg.secondary : "#111";
+    ctx.font = "bold 12px monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(target.phase > 0 ? "+" : "−", target.x, target.y + 4);
+  }
+
+  if (cfg.mode === "lock") {
+    ctx.strokeStyle = target.lock > 0.72 ? cfg.secondary : `${cfg.secondary}66`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(target.x, target.y, r + 10 + (1 - target.lock) * 12, 0, Math.PI * 2);
+    ctx.stroke();
+  }
 }
 
 function updateHud(id, score, combo, remainingMs) {
@@ -277,6 +357,9 @@ function initTrial(id) {
   let spawnBudget = 0;
   let flipped = false;
   let flipAt = cfg.flipInterval || Infinity;
+  let lastHitAt = 0;
+  let stackChain = 0;
+  let nextLane = 0;
   let last = performance.now();
   let targets = [];
 
@@ -292,8 +375,27 @@ function initTrial(id) {
     const x = (event.clientX - rect.left) * scaleX;
     const y = (event.clientY - rect.top) * scaleY;
 
-    const hitIdx = targets.findIndex((target) => Math.hypot(target.x - x, target.y - y) <= target.r + 5);
+    const hitIdx = targets.findIndex((target) => Math.hypot(target.x - x, target.y - y) <= target.r + 8);
     if (hitIdx === -1) {
+      score -= cfg.missPenalty;
+      combo = 1;
+      streak = 0;
+      stackChain = 0;
+      updateHud(id, score, combo, remainingMs);
+      return;
+    }
+
+    const target = targets[hitIdx];
+
+    if (cfg.mode === "lane" && target.lane !== nextLane) {
+      score -= cfg.missPenalty + 2;
+      combo = 1;
+      streak = 0;
+      updateHud(id, score, combo, remainingMs);
+      return;
+    }
+
+    if (cfg.mode === "quantum" && (flipped ? 1 : -1) !== target.phase) {
       score -= cfg.missPenalty;
       combo = 1;
       streak = 0;
@@ -301,11 +403,23 @@ function initTrial(id) {
       return;
     }
 
-    const target = targets[hitIdx];
+    if (cfg.mode === "lock" && target.lock < 0.72) {
+      score -= Math.ceil(cfg.missPenalty * 0.5);
+      updateHud(id, score, combo, remainingMs);
+      return;
+    }
+
     if (target.armored && target.life === 1) {
       target.life = 0;
       target.armored = false;
       score += 4;
+      return;
+    }
+
+    if (cfg.mode === "smash" && target.life > 1) {
+      target.life -= 1;
+      score += 3;
+      updateHud(id, score, combo, remainingMs);
       return;
     }
 
@@ -327,6 +441,22 @@ function initTrial(id) {
         return true;
       });
       gain += chain * 8;
+    }
+
+    if (cfg.mode === "stack") {
+      const now = performance.now();
+      stackChain = now - lastHitAt < 900 ? stackChain + 1 : 1;
+      lastHitAt = now;
+      gain += stackChain * 3;
+    }
+
+    if (cfg.mode === "glitch") {
+      gain += Math.floor((1.1 - (target.integrity || 1)) * 16);
+    }
+
+    if (cfg.mode === "lane") {
+      nextLane = (nextLane + 1) % 3;
+      gain += 5;
     }
 
     score += gain;
@@ -363,6 +493,11 @@ function initTrial(id) {
       target.y += target.vy * dt;
       if (target.x - target.r < 0 || target.x + target.r > WIDTH) target.vx *= -1;
       if (cfg.gravity) target.vy += cfg.gravity * dt;
+      if (cfg.mode === "glitch") target.integrity = Math.max(0, target.integrity - dt * 0.2);
+      if (cfg.mode === "lock") {
+        const phase = ((now - target.born) % 1200) / 1200;
+        target.lock = Math.sin(phase * Math.PI);
+      }
     });
 
     const missTop = -40;
@@ -370,10 +505,12 @@ function initTrial(id) {
     const survivors = [];
     for (const target of targets) {
       const missed = flipped ? target.y < missTop : target.y > missBottom;
-      if (missed) {
+      const breached = cfg.mode === "glitch" && target.integrity <= 0;
+      if (missed || breached) {
         score -= cfg.missPenalty;
         combo = 1;
         streak = 0;
+        if (cfg.mode === "stack") stackChain = 0;
       } else {
         survivors.push(target);
       }
@@ -381,6 +518,19 @@ function initTrial(id) {
     targets = survivors;
 
     drawBackground(ctx, cfg, remainingMs, flipped);
+    if (cfg.mode === "lane") {
+      ctx.strokeStyle = `${cfg.secondary}33`;
+      [95, 210, 325].forEach((y, i) => {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(WIDTH, y);
+        ctx.stroke();
+        if (i === nextLane) {
+          ctx.fillStyle = `${cfg.secondary}66`;
+          ctx.fillRect(0, y - 18, 14, 36);
+        }
+      });
+    }
     const t = performance.now();
     targets.forEach((target) => drawTarget(ctx, cfg, target, t));
 


### PR DESCRIPTION
### Motivation
- Players reported the Terminal Trials variants felt mechanically identical and should play differently to match their names and themes. 
- The goal was to give each variant its own loop, scoring and interaction model rather than routing all variants through a single shared initializer. 
- This change improves clarity for future tuning and extension by separating per-title logic into individual modules. 

### Description
- Replaced the thin `createTrialInit` wrappers with full standalone implementations in `games/pulsestack.js`, `games/glitchgate.js`, `games/orbweaver.js`, `games/laserlock.js`, `games/metromaze.js`, `games/stacksmash.js`, and `games/quantumflip.js`, each owning its own game loop, input handlers, rendering and scoring. 
- Enhanced `games/terminaltrials-engine.js` by adding a `mode` field to `GAME_CONFIG` and making `spawnTarget`, `drawTarget`, and hit/penalty logic mode-aware so the legacy engine supports mode-specific behavior when used. 
- Key mechanics added: timing/stack combos (`Pulse Stack`), decaying breach/integrity (`Glitch Gate`), ordered orb chaining (`Orb Weaver`), lock-window precision (`Laser Lock`), lane route sequencing (`Metro Maze`), multi-HP falling stacks (`Stack Smash`), and phase-matching flips (`Quantum Flip`). 

### Testing
- Ran static checks with `node --check` for each new module and the main `script.js`, which completed without errors. 
- Served the site with `python3 -m http.server` and attempted a Playwright-driven screenshot of `index.html`; an artifact was produced but the forwarded environment page prevented a meaningful in-browser gameplay capture. 
- Committed the changes (7 files modified, new standalone logic added) and opened this PR for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f99be2448327a64609e9931ba7b6)