### PR TITLE
Upgrade Metro Maze and Quantum Flip into full gameplay loops

### DIFF
--- a/games/metromaze.js
+++ b/games/metromaze.js
@@ -2,7 +2,12 @@ import { registerGameStop, setText, showToast, state, updateHighScore } from "..
 
 const WIDTH = 800;
 const HEIGHT = 420;
-const DURATION_MS = 32000;
+const MAZE_COLS = 17;
+const MAZE_ROWS = 11;
+const CELL_SIZE = 34;
+const OFFSET_X = Math.floor((WIDTH - MAZE_COLS * CELL_SIZE) * 0.5);
+const OFFSET_Y = Math.floor((HEIGHT - MAZE_ROWS * CELL_SIZE) * 0.5);
+const BASE_TIME_MS = 70000;
 
 let run = null;
 
@@ -11,16 +16,201 @@ function stop() {
   window.clearInterval(run.timer);
   window.cancelAnimationFrame(run.raf);
   if (run.canvas) run.canvas.onpointerdown = null;
+  document.removeEventListener("keydown", run.onKeyDown);
   run = null;
 }
 
-function spawnNode(lane) {
+function makeCell() {
   return {
-    lane,
-    x: WIDTH + 30,
-    y: 95 + lane * 115,
-    speed: 170 + Math.random() * 90,
+    walls: [1, 1, 1, 1],
+    visited: false,
   };
+}
+
+function cellIndex(col, row) {
+  return row * MAZE_COLS + col;
+}
+
+function carveMaze() {
+  const cells = Array.from({ length: MAZE_COLS * MAZE_ROWS }, makeCell);
+  const stack = [{ col: 0, row: 0 }];
+  cells[0].visited = true;
+
+  const dirs = [
+    { dc: 0, dr: -1, wall: 0, opposite: 2 },
+    { dc: 1, dr: 0, wall: 1, opposite: 3 },
+    { dc: 0, dr: 1, wall: 2, opposite: 0 },
+    { dc: -1, dr: 0, wall: 3, opposite: 1 },
+  ];
+
+  while (stack.length) {
+    const current = stack[stack.length - 1];
+    const options = [];
+    for (const dir of dirs) {
+      const nextCol = current.col + dir.dc;
+      const nextRow = current.row + dir.dr;
+      if (nextCol < 0 || nextRow < 0 || nextCol >= MAZE_COLS || nextRow >= MAZE_ROWS) continue;
+      const next = cells[cellIndex(nextCol, nextRow)];
+      if (next.visited) continue;
+      options.push({ ...dir, nextCol, nextRow });
+    }
+
+    if (!options.length) {
+      stack.pop();
+      continue;
+    }
+
+    const pick = options[(Math.random() * options.length) | 0];
+    const now = cells[cellIndex(current.col, current.row)];
+    const next = cells[cellIndex(pick.nextCol, pick.nextRow)];
+    now.walls[pick.wall] = 0;
+    next.walls[pick.opposite] = 0;
+    next.visited = true;
+    stack.push({ col: pick.nextCol, row: pick.nextRow });
+  }
+
+  for (const cell of cells) cell.visited = false;
+  return cells;
+}
+
+function canMove(cells, col, row, dir) {
+  if (col < 0 || row < 0 || col >= MAZE_COLS || row >= MAZE_ROWS) return false;
+  const cell = cells[cellIndex(col, row)];
+  return !cell.walls[dir];
+}
+
+function spawnRelics(cells, level) {
+  const relics = [];
+  const used = new Set(["0,0", `${MAZE_COLS - 1},${MAZE_ROWS - 1}`]);
+  const target = Math.min(14, 5 + level);
+
+  while (relics.length < target) {
+    const col = (Math.random() * MAZE_COLS) | 0;
+    const row = (Math.random() * MAZE_ROWS) | 0;
+    const key = `${col},${row}`;
+    if (used.has(key)) continue;
+    used.add(key);
+    relics.push({ col, row, taken: false, pulse: Math.random() * Math.PI * 2 });
+  }
+
+  return relics;
+}
+
+function spawnSentinels(cells, level) {
+  const sentinels = [];
+  const count = Math.min(5, 1 + ((level + 1) / 2) | 0);
+
+  for (let i = 0; i < count; i++) {
+    let col = 1;
+    let row = 1;
+    for (let attempts = 0; attempts < 40; attempts++) {
+      col = (Math.random() * MAZE_COLS) | 0;
+      row = (Math.random() * MAZE_ROWS) | 0;
+      if (col + row < 4) continue;
+      if (col === MAZE_COLS - 1 && row === MAZE_ROWS - 1) continue;
+      break;
+    }
+
+    const speed = 2.6 + Math.random() * 0.9 + level * 0.12;
+    sentinels.push({
+      col,
+      row,
+      tx: col,
+      ty: row,
+      px: col,
+      py: row,
+      speed,
+      cooldown: 0,
+    });
+  }
+
+  return sentinels;
+}
+
+function chooseSentinelTarget(cells, sentinel) {
+  const dirs = [
+    { dc: 0, dr: -1, wall: 0 },
+    { dc: 1, dr: 0, wall: 1 },
+    { dc: 0, dr: 1, wall: 2 },
+    { dc: -1, dr: 0, wall: 3 },
+  ];
+
+  const options = dirs
+    .filter((dir) => canMove(cells, sentinel.col, sentinel.row, dir.wall))
+    .map((dir) => ({ col: sentinel.col + dir.dc, row: sentinel.row + dir.dr }));
+
+  if (!options.length) return;
+  const pick = options[(Math.random() * options.length) | 0];
+  sentinel.tx = pick.col;
+  sentinel.ty = pick.row;
+}
+
+function updateHud(level, relicsLeft, runData) {
+  setText(
+    "metromazeHud",
+    `LEVEL ${level} | RELICS: ${relicsLeft} | EXIT UNLOCKS WHEN ALL RELICS ARE SECURED`,
+  );
+  setText("metromazeScore", `SCORE: ${Math.floor(runData.score)}`);
+}
+
+function loadLevel(level, runData) {
+  runData.cells = carveMaze();
+  runData.player.col = 0;
+  runData.player.row = 0;
+  runData.player.x = 0;
+  runData.player.y = 0;
+  runData.relics = spawnRelics(runData.cells, level);
+  runData.sentinels = spawnSentinels(runData.cells, level);
+  runData.level = level;
+  runData.moveCooldown = 0;
+  updateHud(level, runData.relics.length, runData);
+}
+
+function tryMovePlayer(runData, dc, dr, wallDir) {
+  if (runData.moveCooldown > 0) return;
+  const { player, cells } = runData;
+  if (!canMove(cells, player.col, player.row, wallDir)) return;
+  player.col += dc;
+  player.row += dr;
+  runData.moveCooldown = 0.09;
+
+  for (const relic of runData.relics) {
+    if (relic.taken) continue;
+    if (relic.col === player.col && relic.row === player.row) {
+      relic.taken = true;
+      runData.score += 35;
+      showToast("RELIC SECURED", "💠");
+      break;
+    }
+  }
+
+  const remaining = runData.relics.filter((item) => !item.taken).length;
+  if (!remaining && player.col === MAZE_COLS - 1 && player.row === MAZE_ROWS - 1) {
+    runData.score += 140 + runData.level * 30;
+    runData.remainingMs = Math.min(BASE_TIME_MS, runData.remainingMs + 6000);
+    loadLevel(runData.level + 1, runData);
+    showToast(`LEVEL ${runData.level}`, "🚇");
+    return;
+  }
+
+  updateHud(runData.level, remaining, runData);
+  updateHighScore("metromaze", Math.floor(runData.score));
+}
+
+function handlePointerMove(event, canvas, runData) {
+  const rect = canvas.getBoundingClientRect();
+  const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+  const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+  const playerCenterX = OFFSET_X + runData.player.x * CELL_SIZE + CELL_SIZE / 2;
+  const playerCenterY = OFFSET_Y + runData.player.y * CELL_SIZE + CELL_SIZE / 2;
+  const dx = x - playerCenterX;
+  const dy = y - playerCenterY;
+
+  if (Math.abs(dx) > Math.abs(dy)) {
+    tryMovePlayer(runData, dx > 0 ? 1 : -1, 0, dx > 0 ? 1 : 3);
+  } else {
+    tryMovePlayer(runData, 0, dy > 0 ? 1 : -1, dy > 0 ? 2 : 0);
+  }
 }
 
 export function initMetroMaze() {
@@ -32,49 +222,51 @@ export function initMetroMaze() {
   if (!canvas || !action) return;
   const ctx = canvas.getContext("2d");
 
-  let score = 0;
-  let remainingMs = DURATION_MS;
-  let route = [0, 1, 2, 1, 0, 2];
-  let routeIndex = 0;
-  let nodes = [spawnNode(0), spawnNode(1), spawnNode(2)];
-
-  setText("metromazeScore", "SCORE: 0");
-  setText("metromazeTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
-  setText("metromazeHud", "FOLLOW ROUTE ORDER: CLICK NEXT LANE NODE");
-  action.disabled = true;
-  action.textContent = "ROUND LIVE";
-
-  canvas.onpointerdown = (event) => {
-    const rect = canvas.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
-    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
-
-    const hit = nodes.find((node) => Math.hypot(node.x - x, node.y - y) <= 24);
-    if (!hit) {
-      score = Math.max(0, score - 8);
-    } else if (hit.lane === route[routeIndex]) {
-      score += 16;
-      routeIndex = (routeIndex + 1) % route.length;
-      hit.x = WIDTH + 20;
-      hit.speed += 6;
-    } else {
-      score = Math.max(0, score - 12);
-      routeIndex = 0;
-    }
-
-    setText("metromazeScore", `SCORE: ${Math.floor(score)}`);
-    setText("metromazeHud", `NEXT LANE: ${route[routeIndex] + 1}`);
-    updateHighScore("metromaze", Math.floor(score));
+  const runData = {
+    score: 0,
+    level: 1,
+    remainingMs: BASE_TIME_MS,
+    moveCooldown: 0,
+    player: { col: 0, row: 0, x: 0, y: 0 },
+    cells: [],
+    relics: [],
+    sentinels: [],
   };
 
+  loadLevel(1, runData);
+  setText("metromazeTimer", `TIME: ${(BASE_TIME_MS / 1000).toFixed(1)}s`);
+  action.disabled = true;
+  action.textContent = "RUNNING";
+
+  const onKeyDown = (event) => {
+    if (!run) return;
+    if (event.key === "ArrowUp" || event.key.toLowerCase() === "w") {
+      event.preventDefault();
+      tryMovePlayer(runData, 0, -1, 0);
+    } else if (event.key === "ArrowRight" || event.key.toLowerCase() === "d") {
+      event.preventDefault();
+      tryMovePlayer(runData, 1, 0, 1);
+    } else if (event.key === "ArrowDown" || event.key.toLowerCase() === "s") {
+      event.preventDefault();
+      tryMovePlayer(runData, 0, 1, 2);
+    } else if (event.key === "ArrowLeft" || event.key.toLowerCase() === "a") {
+      event.preventDefault();
+      tryMovePlayer(runData, -1, 0, 3);
+    }
+  };
+
+  document.addEventListener("keydown", onKeyDown);
+  canvas.onpointerdown = (event) => handlePointerMove(event, canvas, runData);
+
   const timer = window.setInterval(() => {
-    remainingMs -= 100;
-    setText("metromazeTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
-    if (remainingMs <= 0) {
-      const finalScore = Math.floor(score + routeIndex * 6);
+    runData.remainingMs -= 100;
+    setText("metromazeTimer", `TIME: ${(Math.max(0, runData.remainingMs) / 1000).toFixed(1)}s`);
+
+    if (runData.remainingMs <= 0) {
+      const finalScore = Math.floor(runData.score + runData.level * 25);
       stop();
       updateHighScore("metromaze", finalScore);
-      showToast(`METRO MAZE: ${finalScore} PTS`, "🚇");
+      showToast(`MAZE RUN COMPLETE: ${finalScore}`, "🚇");
       action.disabled = false;
       action.textContent = "PLAY AGAIN";
       action.onclick = initMetroMaze;
@@ -84,38 +276,140 @@ export function initMetroMaze() {
   let last = performance.now();
   function frame(now) {
     if (!run) return;
-    const dt = Math.min(0.04, (now - last) / 1000);
+    const dt = Math.min(0.045, (now - last) / 1000);
     last = now;
 
-    ctx.fillStyle = "#091219";
+    runData.moveCooldown = Math.max(0, runData.moveCooldown - dt);
+
+    runData.player.x += (runData.player.col - runData.player.x) * Math.min(1, dt * 18);
+    runData.player.y += (runData.player.row - runData.player.y) * Math.min(1, dt * 18);
+
+    for (const sentinel of runData.sentinels) {
+      sentinel.cooldown -= dt;
+      if (sentinel.col === sentinel.tx && sentinel.row === sentinel.ty && sentinel.cooldown <= 0) {
+        chooseSentinelTarget(runData.cells, sentinel);
+        sentinel.cooldown = 0.05;
+      }
+      const dx = sentinel.tx - sentinel.px;
+      const dy = sentinel.ty - sentinel.py;
+      const distance = Math.hypot(dx, dy);
+      if (distance > 0.01) {
+        const step = Math.min(1, sentinel.speed * dt);
+        sentinel.px += (dx / distance) * step;
+        sentinel.py += (dy / distance) * step;
+        if (Math.hypot(sentinel.tx - sentinel.px, sentinel.ty - sentinel.py) < 0.08) {
+          sentinel.px = sentinel.tx;
+          sentinel.py = sentinel.ty;
+          sentinel.col = sentinel.tx;
+          sentinel.row = sentinel.ty;
+        }
+      }
+
+      const hitPlayer = Math.hypot(sentinel.px - runData.player.x, sentinel.py - runData.player.y) < 0.34;
+      if (hitPlayer) {
+        runData.player.col = 0;
+        runData.player.row = 0;
+        runData.score = Math.max(0, runData.score - 70);
+        runData.remainingMs = Math.max(0, runData.remainingMs - 2500);
+        updateHud(runData.level, runData.relics.filter((item) => !item.taken).length, runData);
+        showToast("SENTINEL HIT", "☠️");
+      }
+    }
+
+    ctx.fillStyle = "#060d13";
     ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
-    for (let i = 0; i < 3; i++) {
-      const y = 95 + i * 115;
-      ctx.strokeStyle = i === route[routeIndex] ? "#f9ff9e" : "#2f5872";
-      ctx.lineWidth = 2;
+    ctx.fillStyle = "rgba(79, 126, 153, 0.12)";
+    for (let r = 0; r < MAZE_ROWS; r++) {
+      for (let c = 0; c < MAZE_COLS; c++) {
+        ctx.fillRect(OFFSET_X + c * CELL_SIZE + 1, OFFSET_Y + r * CELL_SIZE + 1, CELL_SIZE - 2, CELL_SIZE - 2);
+      }
+    }
+
+    ctx.strokeStyle = "#8ce8ff";
+    ctx.lineWidth = 2;
+    for (let r = 0; r < MAZE_ROWS; r++) {
+      for (let c = 0; c < MAZE_COLS; c++) {
+        const x = OFFSET_X + c * CELL_SIZE;
+        const y = OFFSET_Y + r * CELL_SIZE;
+        const cell = runData.cells[cellIndex(c, r)];
+        if (cell.walls[0]) {
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(x + CELL_SIZE, y);
+          ctx.stroke();
+        }
+        if (cell.walls[1]) {
+          ctx.beginPath();
+          ctx.moveTo(x + CELL_SIZE, y);
+          ctx.lineTo(x + CELL_SIZE, y + CELL_SIZE);
+          ctx.stroke();
+        }
+        if (cell.walls[2]) {
+          ctx.beginPath();
+          ctx.moveTo(x, y + CELL_SIZE);
+          ctx.lineTo(x + CELL_SIZE, y + CELL_SIZE);
+          ctx.stroke();
+        }
+        if (cell.walls[3]) {
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(x, y + CELL_SIZE);
+          ctx.stroke();
+        }
+      }
+    }
+
+    const relicsLeft = runData.relics.filter((item) => !item.taken).length;
+    for (const relic of runData.relics) {
+      if (relic.taken) continue;
+      relic.pulse += dt * 4;
+      const scale = 0.72 + Math.sin(relic.pulse) * 0.16;
+      const rx = OFFSET_X + relic.col * CELL_SIZE + CELL_SIZE / 2;
+      const ry = OFFSET_Y + relic.row * CELL_SIZE + CELL_SIZE / 2;
+      ctx.fillStyle = "#6df2d8";
       ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(WIDTH, y);
+      ctx.moveTo(rx, ry - 8 * scale);
+      ctx.lineTo(rx + 8 * scale, ry);
+      ctx.lineTo(rx, ry + 8 * scale);
+      ctx.lineTo(rx - 8 * scale, ry);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    const exitX = OFFSET_X + (MAZE_COLS - 1) * CELL_SIZE;
+    const exitY = OFFSET_Y + (MAZE_ROWS - 1) * CELL_SIZE;
+    ctx.fillStyle = relicsLeft ? "rgba(255, 70, 70, 0.35)" : "rgba(120, 255, 130, 0.45)";
+    ctx.fillRect(exitX + 5, exitY + 5, CELL_SIZE - 10, CELL_SIZE - 10);
+    ctx.fillStyle = "#eaf6ff";
+    ctx.font = "bold 12px 'Roboto Mono', monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(relicsLeft ? "LOCK" : "EXIT", exitX + CELL_SIZE / 2, exitY + CELL_SIZE / 2 + 4);
+
+    for (const sentinel of runData.sentinels) {
+      const x = OFFSET_X + sentinel.px * CELL_SIZE + CELL_SIZE / 2;
+      const y = OFFSET_Y + sentinel.py * CELL_SIZE + CELL_SIZE / 2;
+      ctx.fillStyle = "#ff3d73";
+      ctx.beginPath();
+      ctx.arc(x, y, 7, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(255, 61, 115, 0.35)";
+      ctx.beginPath();
+      ctx.arc(x, y, 12, 0, Math.PI * 2);
       ctx.stroke();
     }
 
-    for (const node of nodes) {
-      node.x -= node.speed * dt;
-      if (node.x < -30) {
-        score = Math.max(0, score - 5);
-        node.x = WIDTH + 20;
-      }
-      ctx.fillStyle = "#8bcfff";
-      ctx.beginPath();
-      ctx.arc(node.x, node.y, 18, 0, Math.PI * 2);
-      ctx.fill();
-    }
+    const px = OFFSET_X + runData.player.x * CELL_SIZE + CELL_SIZE / 2;
+    const py = OFFSET_Y + runData.player.y * CELL_SIZE + CELL_SIZE / 2;
+    ctx.fillStyle = "#ffd15c";
+    ctx.beginPath();
+    ctx.arc(px, py, 8, 0, Math.PI * 2);
+    ctx.fill();
 
     run.raf = window.requestAnimationFrame(frame);
   }
 
-  run = { timer, raf: 0, canvas };
+  run = { timer, raf: 0, canvas, onKeyDown };
   run.raf = window.requestAnimationFrame(frame);
   registerGameStop(stop);
 }

--- a/games/quantumflip.js
+++ b/games/quantumflip.js
@@ -2,7 +2,7 @@ import { registerGameStop, setText, showToast, state, updateHighScore } from "..
 
 const WIDTH = 800;
 const HEIGHT = 420;
-const DURATION_MS = 34000;
+const DURATION_MS = 60000;
 
 let run = null;
 
@@ -11,17 +11,44 @@ function stop() {
   window.clearInterval(run.timer);
   window.cancelAnimationFrame(run.raf);
   if (run.canvas) run.canvas.onpointerdown = null;
+  document.removeEventListener("keydown", run.onKeyDown);
+  document.removeEventListener("keyup", run.onKeyUp);
   run = null;
 }
 
-function spawnParticle() {
+function spawnCore(worldPhase) {
+  const phase = Math.random() < 0.62 ? worldPhase : worldPhase ? 0 : 1;
   return {
-    x: 40 + Math.random() * 720,
-    y: -20,
-    r: 12 + Math.random() * 10,
-    vy: 90 + Math.random() * 65,
-    phase: Math.random() < 0.5 ? 0 : 1,
+    x: 50 + Math.random() * 700,
+    y: 45 + Math.random() * 330,
+    r: 11 + Math.random() * 9,
+    vx: -50 + Math.random() * 100,
+    vy: -50 + Math.random() * 100,
+    phase,
   };
+}
+
+function spawnHunter(worldPhase, wave) {
+  const side = Math.random() < 0.5 ? 0 : 1;
+  return {
+    x: side ? WIDTH + 30 : -30,
+    y: 30 + Math.random() * (HEIGHT - 60),
+    r: 14,
+    phase: worldPhase ? 0 : 1,
+    speed: 80 + wave * 7 + Math.random() * 35,
+  };
+}
+
+function tickHud(game) {
+  setText("quantumflipScore", `SCORE: ${Math.floor(game.score)}`);
+  setText(
+    "quantumflipHud",
+    `PHASE: ${game.worldPhase ? "POSITRON" : "NEUTRAL"} | STREAK x${game.streakMult.toFixed(1)} | SHIFT IN ${(game.flipInMs / 1000).toFixed(1)}s`,
+  );
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
 }
 
 export function initQuantumFlip() {
@@ -33,55 +60,82 @@ export function initQuantumFlip() {
   if (!canvas || !action) return;
   const ctx = canvas.getContext("2d");
 
-  let score = 0;
-  let remainingMs = DURATION_MS;
-  let worldPhase = 0;
-  let flipInMs = 3800;
-  let particles = Array.from({ length: 7 }, spawnParticle);
+  const game = {
+    score: 0,
+    remainingMs: DURATION_MS,
+    worldPhase: 0,
+    flipInMs: 5500,
+    streakMult: 1,
+    keys: { up: false, down: false, left: false, right: false },
+    player: { x: WIDTH * 0.5, y: HEIGHT * 0.5, vx: 0, vy: 0, r: 12, invuln: 0 },
+    cores: [],
+    hunters: [],
+    wave: 1,
+    waveInMs: 4200,
+  };
 
-  setText("quantumflipScore", "SCORE: 0");
+  game.cores = Array.from({ length: 11 }, () => spawnCore(game.worldPhase));
+
   setText("quantumflipTimer", `TIME: ${(DURATION_MS / 1000).toFixed(1)}s`);
-  setText("quantumflipHud", "ONLY COLLAPSE PARTICLES THAT MATCH THE CURRENT PHASE");
+  tickHud(game);
 
   action.disabled = true;
   action.textContent = "ROUND LIVE";
 
+  const onKeyDown = (event) => {
+    if (!run) return;
+    const key = event.key.toLowerCase();
+    if (key === "w" || key === "arrowup") game.keys.up = true;
+    if (key === "s" || key === "arrowdown") game.keys.down = true;
+    if (key === "a" || key === "arrowleft") game.keys.left = true;
+    if (key === "d" || key === "arrowright") game.keys.right = true;
+  };
+  const onKeyUp = (event) => {
+    const key = event.key.toLowerCase();
+    if (key === "w" || key === "arrowup") game.keys.up = false;
+    if (key === "s" || key === "arrowdown") game.keys.down = false;
+    if (key === "a" || key === "arrowleft") game.keys.left = false;
+    if (key === "d" || key === "arrowright") game.keys.right = false;
+  };
+
+  document.addEventListener("keydown", onKeyDown);
+  document.addEventListener("keyup", onKeyUp);
+
   canvas.onpointerdown = (event) => {
     const rect = canvas.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
-    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
-
-    const hitIdx = particles.findIndex((p) => Math.hypot(p.x - x, p.y - y) <= p.r + 5);
-    if (hitIdx === -1) {
-      score = Math.max(0, score - 7);
-    } else {
-      const p = particles[hitIdx];
-      if (p.phase === worldPhase) {
-        score += 14;
-      } else {
-        score = Math.max(0, score - 12);
-      }
-      particles[hitIdx] = spawnParticle();
-    }
-
-    setText("quantumflipScore", `SCORE: ${Math.floor(score)}`);
-    updateHighScore("quantumflip", Math.floor(score));
+    const tx = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const ty = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+    const dx = tx - game.player.x;
+    const dy = ty - game.player.y;
+    const mag = Math.max(1, Math.hypot(dx, dy));
+    game.player.vx += (dx / mag) * 220;
+    game.player.vy += (dy / mag) * 220;
   };
 
   const timer = window.setInterval(() => {
-    remainingMs -= 100;
-    flipInMs -= 100;
-    if (flipInMs <= 0) {
-      worldPhase = worldPhase ? 0 : 1;
-      flipInMs = 3800;
-      showToast("QUANTUM FLIP", "⚛️");
+    game.remainingMs -= 100;
+    game.flipInMs -= 100;
+    game.waveInMs -= 100;
+
+    if (game.flipInMs <= 0) {
+      game.worldPhase = game.worldPhase ? 0 : 1;
+      game.flipInMs = Math.max(2400, 5500 - game.wave * 170);
+      game.streakMult = Math.max(1, game.streakMult - 0.3);
+      showToast(`PHASE SHIFT: ${game.worldPhase ? "POSITRON" : "NEUTRAL"}`, "⚛️");
     }
 
-    setText("quantumflipTimer", `TIME: ${(Math.max(0, remainingMs) / 1000).toFixed(1)}s`);
-    setText("quantumflipHud", `PHASE: ${worldPhase ? "POSITIVE" : "NEGATIVE"}`);
+    if (game.waveInMs <= 0) {
+      game.wave += 1;
+      game.waveInMs = 4200;
+      game.hunters.push(spawnHunter(game.worldPhase, game.wave));
+      if (game.wave % 3 === 0) game.hunters.push(spawnHunter(game.worldPhase, game.wave));
+    }
 
-    if (remainingMs <= 0) {
-      const finalScore = Math.floor(score);
+    setText("quantumflipTimer", `TIME: ${(Math.max(0, game.remainingMs) / 1000).toFixed(1)}s`);
+    tickHud(game);
+
+    if (game.remainingMs <= 0) {
+      const finalScore = Math.floor(game.score + game.wave * 8);
       stop();
       updateHighScore("quantumflip", finalScore);
       showToast(`QUANTUM FLIP: ${finalScore} PTS`, "⚛️");
@@ -97,26 +151,111 @@ export function initQuantumFlip() {
     const dt = Math.min(0.04, (now - last) / 1000);
     last = now;
 
-    ctx.fillStyle = worldPhase ? "#24124d" : "#0b0720";
+    const accel = 360;
+    const drag = 0.92;
+    if (game.keys.up) game.player.vy -= accel * dt;
+    if (game.keys.down) game.player.vy += accel * dt;
+    if (game.keys.left) game.player.vx -= accel * dt;
+    if (game.keys.right) game.player.vx += accel * dt;
+
+    game.player.vx *= drag;
+    game.player.vy *= drag;
+    game.player.x = clamp(game.player.x + game.player.vx * dt, game.player.r, WIDTH - game.player.r);
+    game.player.y = clamp(game.player.y + game.player.vy * dt, game.player.r, HEIGHT - game.player.r);
+    game.player.invuln = Math.max(0, game.player.invuln - dt);
+
+    for (const core of game.cores) {
+      core.x += core.vx * dt;
+      core.y += core.vy * dt;
+      if (core.x < core.r || core.x > WIDTH - core.r) core.vx *= -1;
+      if (core.y < core.r || core.y > HEIGHT - core.r) core.vy *= -1;
+
+      const overlap = Math.hypot(core.x - game.player.x, core.y - game.player.y) < core.r + game.player.r;
+      if (!overlap) continue;
+
+      if (core.phase === game.worldPhase) {
+        game.score += 14 * game.streakMult;
+        game.streakMult = Math.min(4.6, game.streakMult + 0.1);
+      } else {
+        game.score = Math.max(0, game.score - 18);
+        game.streakMult = 1;
+        game.player.invuln = 0.6;
+      }
+
+      core.x = 50 + Math.random() * 700;
+      core.y = 45 + Math.random() * 330;
+      core.phase = Math.random() < 0.62 ? game.worldPhase : game.worldPhase ? 0 : 1;
+      core.vx = -65 + Math.random() * 130;
+      core.vy = -65 + Math.random() * 130;
+      updateHighScore("quantumflip", Math.floor(game.score));
+      tickHud(game);
+    }
+
+    for (const hunter of game.hunters) {
+      const dx = game.player.x - hunter.x;
+      const dy = game.player.y - hunter.y;
+      const mag = Math.max(1, Math.hypot(dx, dy));
+      hunter.x += (dx / mag) * hunter.speed * dt;
+      hunter.y += (dy / mag) * hunter.speed * dt;
+
+      const hit = Math.hypot(hunter.x - game.player.x, hunter.y - game.player.y) < hunter.r + game.player.r;
+      if (hit && game.player.invuln <= 0) {
+        game.score = Math.max(0, game.score - 40);
+        game.streakMult = 1;
+        game.player.invuln = 1.2;
+        game.player.vx *= -0.4;
+        game.player.vy *= -0.4;
+        showToast("HUNTER IMPACT", "💥");
+        tickHud(game);
+      }
+    }
+
+    ctx.fillStyle = game.worldPhase ? "#1f153b" : "#070b1b";
     ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
-    particles.forEach((p, i) => {
-      p.y += p.vy * dt;
-      if (p.y > HEIGHT + 30) particles[i] = spawnParticle();
-      ctx.fillStyle = p.phase ? "#7fffd4" : "#9b8cff";
+    for (let i = 0; i < 44; i++) {
+      const px = (i * 129) % WIDTH;
+      const py = ((i * 67 + now * 0.04) % HEIGHT + HEIGHT) % HEIGHT;
+      ctx.fillStyle = "rgba(160, 190, 255, 0.11)";
+      ctx.fillRect(px, py, 2, 2);
+    }
+
+    for (const core of game.cores) {
+      const same = core.phase === game.worldPhase;
+      ctx.fillStyle = same ? "#89fff0" : "#ff7ab6";
       ctx.beginPath();
-      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.arc(core.x, core.y, core.r, 0, Math.PI * 2);
       ctx.fill();
-      ctx.fillStyle = "#0a0f17";
+      ctx.fillStyle = "#09101e";
       ctx.font = "bold 12px monospace";
       ctx.textAlign = "center";
-      ctx.fillText(p.phase ? "+" : "-", p.x, p.y + 4);
-    });
+      ctx.fillText(core.phase ? "+" : "-", core.x, core.y + 4);
+    }
+
+    for (const hunter of game.hunters) {
+      ctx.fillStyle = hunter.phase ? "#f978c5" : "#a766ff";
+      ctx.beginPath();
+      ctx.arc(hunter.x, hunter.y, hunter.r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(255,255,255,0.16)";
+      ctx.beginPath();
+      ctx.arc(hunter.x, hunter.y, hunter.r + 5, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    ctx.fillStyle = game.player.invuln > 0 ? "#ffd877" : "#f3f6ff";
+    ctx.beginPath();
+    ctx.arc(game.player.x, game.player.y, game.player.r, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = "#00f0ff";
+    ctx.beginPath();
+    ctx.arc(game.player.x, game.player.y, game.player.r + 4, 0, Math.PI * 2);
+    ctx.stroke();
 
     run.raf = window.requestAnimationFrame(frame);
   }
 
-  run = { timer, raf: 0, canvas };
+  run = { timer, raf: 0, canvas, onKeyDown, onKeyUp };
   run.raf = window.requestAnimationFrame(frame);
   registerGameStop(stop);
 }

--- a/index.html
+++ b/index.html
@@ -126,9 +126,9 @@
         <button class="game-card" data-game="glitchgate" data-tags="arcade" onclick="window.launchGame('glitchgate')"><span>🧩</span><strong>GLITCH GATE</strong><small>Patch unstable sectors and chase combo bonus.</small></button>
         <button class="game-card" data-game="orbweaver" data-tags="skill" onclick="window.launchGame('orbweaver')"><span>🟣</span><strong>ORB WEAVER</strong><small>Weave energy orbs to push a high-score run.</small></button>
         <button class="game-card" data-game="laserlock" data-tags="arcade skill" onclick="window.launchGame('laserlock')"><span>🔴</span><strong>LASER LOCK</strong><small>Acquire locks fast to farm precision points.</small></button>
-        <button class="game-card" data-game="metromaze" data-tags="skill" onclick="window.launchGame('metromaze')"><span>🚇</span><strong>METRO MAZE</strong><small>Advance nodes at speed through digital tunnels.</small></button>
+        <button class="game-card" data-game="metromaze" data-tags="skill" onclick="window.launchGame('metromaze')"><span>🚇</span><strong>METRO MAZE</strong><small>Procedural mazes with relics, sentinels, and level exits.</small></button>
         <button class="game-card" data-game="stacksmash" data-tags="arcade" onclick="window.launchGame('stacksmash')"><span>🪨</span><strong>STACK SMASH</strong><small>Break layered stacks for big spike payouts.</small></button>
-        <button class="game-card" data-game="quantumflip" data-tags="skill" onclick="window.launchGame('quantumflip')"><span>⚛️</span><strong>QUANTUM FLIP</strong><small>Flip unstable states and fish for mega bursts.</small></button>
+        <button class="game-card" data-game="quantumflip" data-tags="skill" onclick="window.launchGame('quantumflip')"><span>⚛️</span><strong>QUANTUM FLIP</strong><small>Pilot a phase core: chain matching orbs and survive hunter waves.</small></button>
         <button class="game-card" id="btnFlappy" data-game="flappy" data-tags="arcade skill" onclick="window.launchGame('flappy')" style="display: none"><span>🐤</span><strong>FLAPPY GOON</strong><small>Secret bonus mode: tap to survive.</small></button>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
@@ -1491,7 +1491,7 @@
     <div class="overlay" id="overlayCiphercrack">
       <h1>CIPHER CRACK</h1>
       <div class="high-score-display">HIGH: <span id="hsCiphercrack">0</span></div>
-      <div style="margin-bottom: 10px" id="ciphercrackTimer">TIME: 20.0s</div>
+      <div style="margin-bottom: 10px" id="ciphercrackTimer">TIME: 70.0s</div>
       <div style="margin-bottom: 8px" id="ciphercrackScore">SCORE: 0</div>
       <div style="margin-bottom: 12px" id="ciphercrackHud">DECRYPT WOBBLING TOKENS. SMALLER TOKENS SCORE MORE</div>
       <canvas id="ciphercrackCanvas" width="800" height="420"></canvas>
@@ -1563,11 +1563,11 @@
     <div class="overlay" id="overlayMetromaze">
       <h1>METRO MAZE</h1>
       <div class="high-score-display">HIGH: <span id="hsMetromaze">0</span></div>
-      <div style="margin-bottom: 10px" id="metromazeTimer">TIME: 20.0s</div>
+      <div style="margin-bottom: 10px" id="metromazeTimer">TIME: 70.0s</div>
       <div style="margin-bottom: 8px" id="metromazeScore">SCORE: 0</div>
-      <div style="margin-bottom: 12px" id="metromazeHud">TRACK NODES AS THEY SWERVE THROUGH THE GRID</div>
+      <div style="margin-bottom: 12px" id="metromazeHud">COLLECT EVERY RELIC, DODGE SENTINELS, THEN REACH THE EXIT</div>
       <canvas id="metromazeCanvas" width="800" height="420"></canvas>
-      <div class="mobile-hint active" style="margin-top: 10px">CLICK / TAP TARGETS TO SCORE</div>
+      <div class="mobile-hint active" style="margin-top: 10px">WASD / ARROWS TO MOVE. TAP TO STEP ON MOBILE</div>
       <button class="term-btn" id="metromazeAction" style="margin-top: 14px">START ROUND</button>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>
@@ -1587,11 +1587,11 @@
     <div class="overlay" id="overlayQuantumflip">
       <h1>QUANTUM FLIP</h1>
       <div class="high-score-display">HIGH: <span id="hsQuantumflip">0</span></div>
-      <div style="margin-bottom: 10px" id="quantumflipTimer">TIME: 21.0s</div>
+      <div style="margin-bottom: 10px" id="quantumflipTimer">TIME: 60.0s</div>
       <div style="margin-bottom: 8px" id="quantumflipScore">SCORE: 0</div>
-      <div style="margin-bottom: 12px" id="quantumflipHud">REALITY FLIPS PERIODICALLY — ADAPT TO REVERSED MOTION</div>
+      <div style="margin-bottom: 12px" id="quantumflipHud">MOVE YOUR CORE, GRAB MATCHING PHASE ORBS, EVADE HUNTERS</div>
       <canvas id="quantumflipCanvas" width="800" height="420"></canvas>
-      <div class="mobile-hint active" style="margin-top: 10px">CLICK / TAP TARGETS TO SCORE</div>
+      <div class="mobile-hint active" style="margin-top: 10px">WASD / ARROWS TO MOVE. TAP TO DASH ON MOBILE</div>
       <button class="term-btn" id="quantumflipAction" style="margin-top: 14px">START ROUND</button>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>


### PR DESCRIPTION
### Motivation
- The existing mini-games were shallow click/target experiences and needed richer, controller-friendly gameplay loops to feel like proper games.
- Aim was to make the Maze and Quantum Flip feel more like full arcade/roguelite encounters with procedural variety, hazards, and meaningful objectives.

### Description
- Rebuilt `games/metromaze.js` into a procedural maze generator (DFS/backtracker) with wall-based grid movement, relic spawning/collection, roaming sentinels, level progression, exit unlocking, HUD updates, keyboard controls and tap-to-move mobile support. 
- Reworked `games/quantumflip.js` into a movement-based arena where the player pilots a core (WASD + tap dash), collects matching-phase orbs for score/streaks, endures phase shifts, and fends off escalating hunter waves with updated HUD and longer round timer. 
- Updated `index.html` game directory entries and overlay HUD text/timers to reflect the new mechanics and mobile hints for both upgraded games. 
- All game loops now register proper stop handlers, remove added event listeners on stop, and call `updateHighScore`/`showToast` at key events.

### Testing
- Ran syntax/type checks with `node --check games/metromaze.js`, `node --check games/quantumflip.js`, and `node --check script.js`, which completed successfully. 
- Launched a local static server with `python -m http.server 4173` and exercised both overlays via an automated Playwright smoke script which produced visual screenshots of the running upgraded games. 
- The Playwright validation required a register/login flow to dismiss the initial login overlay and ultimately produced screenshots confirming the new gameplay screens were rendering (artifacts available from the test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699610099840832787431133d928b184)