### PR TITLE
Tune Astro Hop platforming and add fall-death handling

### DIFF
--- a/games/terminaltrials-engine.js
+++ b/games/terminaltrials-engine.js
@@ -560,7 +560,7 @@ function initTrial(id) {
     if (event.code === "ArrowUp" || event.code === "Space" || event.code === "KeyW") {
       const now = performance.now();
       if (!keys.jump && (player.onGround || now < coyoteUntil || player.jumps < 2)) {
-        player.vy = player.jumps === 0 || player.onGround || now < coyoteUntil ? -430 : -400;
+        player.vy = player.jumps === 0 || player.onGround || now < coyoteUntil ? -460 : -420;
         player.jumps = Math.min(2, player.jumps + 1);
         player.onGround = false;
         coyoteUntil = 0;
@@ -639,7 +639,7 @@ function initTrial(id) {
       }
       const dashActive = now < dash.activeUntil;
       const move = keys.left === keys.right ? 0 : keys.right ? 1 : -1;
-      const runSpeed = dashActive ? 310 : 228;
+      const runSpeed = dashActive ? 285 : 205;
       player.vx = move * runSpeed;
 
       cameraX = Math.max(0, player.x - 220);
@@ -647,13 +647,13 @@ function initTrial(id) {
       platformSpawnAt -= dt * 1000;
       ringSpawnAt -= dt * 1000;
       if (platformSpawnAt <= 0 && furthestPlatformX < cameraX + WIDTH + 860) {
-        platformSpawnAt = rand(470, 760);
-        const w = rand(86, 152);
+        platformSpawnAt = rand(520, 820);
+        const w = rand(104, 178);
         const y = rand(HEIGHT - 196, HEIGHT - 72);
-        const x = furthestPlatformX + rand(140, 260);
+        const x = furthestPlatformX + rand(108, 200);
         platforms.push({ x, y, w, h: 18, kind: "ledge" });
         furthestPlatformX = Math.max(furthestPlatformX, x + w);
-        if (Math.random() < 0.62) {
+        if (Math.random() < 0.4) {
           hazards.push({
             x: x + w * rand(0.2, 0.8),
             y: y - 14,
@@ -673,7 +673,7 @@ function initTrial(id) {
 
       const prevX = player.x;
       const prevY = player.y;
-      player.vy += 980 * dt;
+      player.vy += 920 * dt;
       player.x += player.vx * dt;
       player.y += player.vy * dt;
       player.onGround = false;
@@ -687,10 +687,9 @@ function initTrial(id) {
 
       for (const platform of platforms) {
         const top = platform.y;
-        const crossedTop = prevBottom <= top + 1 && curBottom >= top;
+        const crossedTop = prevBottom <= top + 8 && curBottom >= top;
         const overlapX = curRight > platform.x + 2 && curLeft < platform.x + platform.w - 2;
-        const wasNearX = prevRight > platform.x + 2 && prevLeft < platform.x + platform.w - 2;
-        if (crossedTop && overlapX && wasNearX && player.vy >= 0) {
+        if (crossedTop && overlapX && player.vy >= 0) {
           player.y = top - player.h / 2;
           player.vy = 0;
           player.onGround = true;
@@ -727,7 +726,14 @@ function initTrial(id) {
           player.y + player.h / 2 > hazard.y &&
           player.y - player.h / 2 < hazard.y + hazard.h,
       );
-      if ((collided && !dashActive) || player.y > HEIGHT + 60) {
+      if (player.y > HEIGHT + 60) {
+        remainingMs = 0;
+        updateHud(id, score, combo, remainingMs);
+        endRound(id, cfg, { score, bestCombo });
+        return;
+      }
+
+      if (collided && !dashActive) {
         score -= cfg.missPenalty + 4;
         streak = 0;
         combo = 1;


### PR DESCRIPTION
### Motivation

- Make Astro Hop parkour less punishing by easing movement and platform layout so jumps and landings feel fairer.  
- Fix landing/collision edge cases that caused missed landings on ledges.  
- Implement a proper death condition when the player falls off the map instead of silently respawning.

### Description

- Increased jump impulse and slightly reduced gravity by changing jump velocities to `-460`/`-420` and gravity application from `980` to `920`.  
- Reduced movement speed by lowering normal and dash run speeds from `228`/`310` to `205`/`285`.  
- Made procedurally generated parkour more forgiving by widening ledges (`w` from `rand(86,152)` to `rand(104,178)`), shortening the forward placement delta (`x` from `rand(140,260)` to `rand(108,200)`), and reducing spike hazard spawn chance (`Math.random() < 0.62` → `< 0.4`).  
- Improved platform collision reliability by increasing top-cross tolerance (`prevBottom <= top + 1` → `prevBottom <= top + 8`) and removing the previous-frame X overlap check so valid landings are less likely to be missed.  
- Added fall-death handling so if the player falls past the bottom (`player.y > HEIGHT + 60`) the round ends immediately by setting `remainingMs = 0`, updating HUD, and calling `endRound`.

### Testing

- Ran a syntax/consistency check with `node --check games/terminaltrials-engine.js`, which completed successfully.  
- Verified the modified file compiles in a JS syntax check with no runtime parse errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699726e8ade083278a3a5f9175c1ae40)