### PR TITLE
Fix Shadow Assassin FPS-dependent simulation speed

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -8510,7 +8510,6 @@
             frameAccumulator = Math.min(frameAccumulator + frameDelta, FIXED_STEP_MS * MAX_SIM_STEPS);
 
             let steps = Math.floor(frameAccumulator / FIXED_STEP_MS);
-            if (steps < 1) steps = 1;
             steps = Math.min(steps, MAX_SIM_STEPS);
             frameAccumulator = Math.max(0, frameAccumulator - (steps * FIXED_STEP_MS));
 


### PR DESCRIPTION
### Motivation
- The game loop always forced at least one fixed-step update per render, which caused gameplay to run faster on high-refresh-rate machines and made simulation timing FPS-dependent.

### Description
- Removed the forced minimum update (`if (steps < 1) steps = 1`) from `games/shadow-assassin-safe-rooms.html` so the accumulator only advances simulation when a full `FIXED_STEP_MS` has accumulated, preserving fixed-step pacing.

### Testing
- Ran `nl -ba games/shadow-assassin-safe-rooms.html | sed -n '8506,8518p'` to confirm the change was applied (succeeded).
- Committed the modified file and verified the diff with `git -C /workspace/webstie show --stat --oneline HEAD` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997aac602988331a0ea27274983dc9b)