### PR TITLE
Unify special ability activation and add guaranteed cast feedback

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -225,6 +225,47 @@
             color: #aaa;
             font-size: 12px;
             text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
+            display: none;
+        }
+
+        #tutorialOverlay {
+            position: absolute;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.85);
+            z-index: 300;
+        }
+
+        .tutorial-card {
+            width: min(92vw, 720px);
+            background: rgba(10, 10, 10, 0.96);
+            border: 3px solid #ffd700;
+            border-radius: 8px;
+            padding: 22px;
+            color: #fff;
+            box-shadow: 0 0 30px rgba(255, 215, 0, 0.35);
+        }
+
+        .tutorial-card h2 {
+            color: #ffd700;
+            margin-bottom: 12px;
+            text-align: center;
+        }
+
+        .tutorial-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px 16px;
+            margin: 12px 0 16px;
+            font-size: 13px;
+        }
+
+        .tutorial-actions {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
         }
 
         .title {
@@ -687,7 +728,7 @@
             <span class="keybind-ability">Ranged Attack</span>
         </div>
         <div class="keybind-item">
-            <span class="keybind-key">[G]</span>
+            <span class="keybind-key">[H]</span>
             <span class="keybind-ability">Grapple Hook</span>
         </div>
         <div class="keybind-item">
@@ -719,10 +760,37 @@
     
     <!-- Controls -->
     <div class="controls">
-        WASD/Arrows: Move & Aim Knife | SPACE: Jump | J: Dagger | K: Dash | L: Knife | G: Grapple | X: Execute<br>
-        Q/E: Special Abilities
+        WASD/Arrows: Move & Aim Knife | SPACE: Jump | J: Dagger | K: Dash | L: Knife | H: Grapple | X: Execute<br>
+        Q/E/R/F/C/V: Special Abilities
     </div>
     
+
+
+    <div id="tutorialOverlay">
+        <div class="tutorial-card">
+            <h2>🗡️ SHADOW ASSASSIN TRAINING</h2>
+            <p style="font-size: 13px; color: #ddd; line-height: 1.45;">
+                First-time players must complete this quick training intro. After this, the tutorial won't block your run.
+            </p>
+            <div class="tutorial-grid">
+                <div><strong>MOVE:</strong> WASD / Arrows</div>
+                <div><strong>JUMP:</strong> Space</div>
+                <div><strong>DAGGER:</strong> J</div>
+                <div><strong>DASH:</strong> K</div>
+                <div><strong>RANGED:</strong> L</div>
+                <div><strong>GRAPPLE:</strong> H</div>
+                <div><strong>EXECUTE:</strong> X</div>
+                <div><strong>SPECIALS:</strong> Q / E / R / F / C / V</div>
+            </div>
+            <p style="font-size: 12px; color: #9ec8ff; text-align: center; margin-bottom: 14px;">
+                Tip: Puzzle rooms need the floating key before the door unlocks.
+            </p>
+            <div class="tutorial-actions">
+                <button class="game-button" id="tutorialStartBtn">START TRAINING</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Main Menu -->
     <div id="mainMenu" class="main-menu">
         <h1>⚔️ SHADOW ASSASSIN ⚔️</h1>
@@ -1665,67 +1733,65 @@
                 }
             }
 
-            useSpecial1() {
-                if (this.special1 && this.special1Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special1];
-                    const cooldown = ability.cooldown || 300;
-                    this.special1Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special1);
+            spawnSpecialCastFeedback(abilityName) {
+                const ringColor = mythicMode ? '#ffd700' : '#66ccff';
+                for (let i = 0; i < 18; i++) {
+                    const angle = (Math.PI * 2 / 18) * i;
+                    particles.push(new Particle(
+                        this.x + Math.cos(angle) * 8,
+                        this.y + Math.sin(angle) * 8,
+                        ringColor,
+                        Math.cos(angle) * (2 + Math.random() * 3),
+                        Math.sin(angle) * (2 + Math.random() * 3),
+                        30
+                    ));
+                }
+
+                // Guarantee each special has a visible baseline impact.
+                const pulseDamage = Math.max(6, this.attackDamage * 0.35);
+                for (const enemy of currentRoom.enemies) {
+                    const dist = Math.hypot(enemy.x - this.x, enemy.y - this.y);
+                    if (dist < 120) {
+                        enemy.takeDamage(pulseDamage);
+                    }
+                }
+                if (currentRoom.boss && currentRoom.boss.health > 0) {
+                    const bossDist = Math.hypot(currentRoom.boss.x - this.x, currentRoom.boss.y - this.y);
+                    if (bossDist < 150) {
+                        currentRoom.boss.takeDamage(pulseDamage * 0.6);
+                    }
                 }
             }
 
-            useSpecial2() {
-                if (this.special2 && this.special2Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special2];
-                    const cooldown = ability.cooldown || 300;
-                    this.special2Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special2);
+            useSpecialSlot(slotKey, cooldownKey) {
+                const abilityName = this[slotKey];
+                if (!abilityName) return false;
+                if (this[cooldownKey] > 0) return false;
+
+                const ability = upgradeDefinitions[abilityName];
+                if (!ability || ability.type !== 'special') {
+                    console.warn('Invalid special ability slot state:', slotKey, abilityName);
+                    this[slotKey] = null;
+                    this[cooldownKey] = 0;
+                    return false;
                 }
+
+                this[cooldownKey] = ability.cooldown || 300;
+                useAbilityRecord();
+                this.executeSpecialAbility(abilityName);
+                this.spawnSpecialCastFeedback(abilityName);
+                return true;
             }
-            
-            useSpecial3() {
-                if (this.special3 && this.special3Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special3];
-                    const cooldown = ability.cooldown || 300;
-                    this.special3Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special3);
-                }
-            }
-            
-            useSpecial4() {
-                if (this.special4 && this.special4Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special4];
-                    const cooldown = ability.cooldown || 300;
-                    this.special4Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special4);
-                }
-            }
-            
-            useSpecial5() {
-                if (this.special5 && this.special5Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special5];
-                    const cooldown = ability.cooldown || 300;
-                    this.special5Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special5);
-                }
-            }
-            
-            useSpecial6() {
-                if (this.special6 && this.special6Cooldown <= 0) {
-                    const ability = upgradeDefinitions[this.special6];
-                    const cooldown = ability.cooldown || 300;
-                    this.special6Cooldown = cooldown;
-                    useAbilityRecord();
-                    this.executeSpecialAbility(this.special6);
-                }
-            }
-            
+
+            useSpecial1() { return this.useSpecialSlot('special1', 'special1Cooldown'); }
+            useSpecial2() { return this.useSpecialSlot('special2', 'special2Cooldown'); }
+            useSpecial3() { return this.useSpecialSlot('special3', 'special3Cooldown'); }
+            useSpecial4() { return this.useSpecialSlot('special4', 'special4Cooldown'); }
+            useSpecial5() { return this.useSpecialSlot('special5', 'special5Cooldown'); }
+            useSpecial6() { return this.useSpecialSlot('special6', 'special6Cooldown'); }
+
             executeSpecialAbility(abilityName) {
+
                 switch(abilityName) {
                     case 'shadowClone':
                         shadowClones.push(new ShadowClone(this.x, this.y));
@@ -7445,17 +7511,24 @@
             return getBossTypeForBossRoom(nextBossRoom);
         }
 
+        function isPuzzleRoomNumber(roomNum) {
+            return roomNum >= 4 && (roomNum % 10 === 3 || roomNum % 10 === 8) && roomNum % 5 !== 0 && roomNum % 7 !== 0;
+        }
+
         // Room class (keeping original castle look)
         class Room {
-            constructor(seed, isBossRoom = false, isSafeRoom = false) {
+            constructor(seed, isBossRoom = false, isSafeRoom = false, isPuzzleRoom = false) {
                 this.seed = seed;
                 this.roomNumber = Math.max(1, Math.round(seed / 12345));
                 this.isBossRoom = isBossRoom;
                 this.isSafeRoom = isSafeRoom;
+                this.isPuzzleRoom = isPuzzleRoom;
                 this.enemies = [];
                 this.boss = null;
                 this.platforms = [];
                 this.cleared = false;
+                this.keyCollected = false;
+                this.puzzleKey = null;
                 this.upcomingBossType = getUpcomingBossType(this.roomNumber);
                 
                 // Seeded random
@@ -7464,34 +7537,53 @@
                     return seed / 233280;
                 }
                 
-                // Generate platforms
-                const platformCount = 3 + Math.floor(rand() * 4);
-                for (let i = 0; i < platformCount; i++) {
+                if (this.isPuzzleRoom) {
+                    this.platforms = [
+                        { x: 50, y: canvas.height - 150, width: 200, height: 15 },
+                        { x: 330, y: canvas.height - 245, width: 140, height: 15 },
+                        { x: 560, y: canvas.height - 330, width: 120, height: 15 },
+                        { x: 760, y: canvas.height - 430, width: 110, height: 15 },
+                        { x: 930, y: canvas.height - 305, width: 130, height: 15 },
+                        { x: 700, y: canvas.height - 210, width: 120, height: 15 },
+                        { x: canvas.width - 250, y: canvas.height - 150, width: 200, height: 15 }
+                    ];
+
+                    this.puzzleKey = {
+                        x: 812,
+                        y: canvas.height - 462,
+                        radius: 14,
+                        bobOffset: rand() * Math.PI * 2
+                    };
+                } else {
+                    // Generate platforms
+                    const platformCount = 3 + Math.floor(rand() * 4);
+                    for (let i = 0; i < platformCount; i++) {
+                        this.platforms.push({
+                            x: 100 + rand() * (canvas.width - 300),
+                            y: 200 + rand() * 300,
+                            width: 100 + rand() * 150,
+                            height: 15
+                        });
+                    }
+                    
+                    // Safe spawn/exit platforms
                     this.platforms.push({
-                        x: 100 + rand() * (canvas.width - 300),
-                        y: 200 + rand() * 300,
-                        width: 100 + rand() * 150,
+                        x: 50,
+                        y: canvas.height - 150,
+                        width: 200,
+                        height: 15
+                    });
+                    
+                    this.platforms.push({
+                        x: canvas.width - 250,
+                        y: canvas.height - 150,
+                        width: 200,
                         height: 15
                     });
                 }
                 
-                // Safe spawn/exit platforms
-                this.platforms.push({
-                    x: 50,
-                    y: canvas.height - 150,
-                    width: 200,
-                    height: 15
-                });
-                
-                this.platforms.push({
-                    x: canvas.width - 250,
-                    y: canvas.height - 150,
-                    width: 200,
-                    height: 15
-                });
-                
                 // Safe rooms have no enemies
-                if (this.isSafeRoom) {
+                if (this.isSafeRoom || this.isPuzzleRoom) {
                     // Empty room - safe zone!
                 } else if (this.isBossRoom) {
                     const bossType = getBossTypeForBossRoom(this.roomNumber);
@@ -7548,6 +7640,23 @@
                                 type
                             ));
                         }
+                    }
+                }
+            }
+
+            updateRoomState() {
+                if (!this.isPuzzleRoom || this.keyCollected || !this.puzzleKey) return;
+                const bobY = this.puzzleKey.y + Math.sin(Date.now() / 280 + this.puzzleKey.bobOffset) * 6;
+                const dist = Math.hypot(player.x - this.puzzleKey.x, player.y - bobY);
+                if (dist < 34) {
+                    this.keyCollected = true;
+                    for (let i = 0; i < 16; i++) {
+                        particles.push(new Particle(
+                            this.puzzleKey.x + (Math.random() - 0.5) * 24,
+                            bobY + (Math.random() - 0.5) * 24,
+                            '#9be07d',
+                            3 + Math.random() * 2
+                        ));
                     }
                 }
             }
@@ -7754,6 +7863,29 @@
                 
                 ctx.fillStyle = '#4a4a4a';
                 ctx.fillRect(0, canvas.height - 50, canvas.width, 3);
+
+                if (this.isPuzzleRoom && this.puzzleKey && !this.keyCollected) {
+                    const keyY = this.puzzleKey.y + Math.sin(Date.now() / 280 + this.puzzleKey.bobOffset) * 6;
+                    const keyGlow = ctx.createRadialGradient(this.puzzleKey.x, keyY, 0, this.puzzleKey.x, keyY, 38);
+                    keyGlow.addColorStop(0, 'rgba(180, 255, 140, 0.45)');
+                    keyGlow.addColorStop(1, 'rgba(180, 255, 140, 0)');
+                    ctx.fillStyle = keyGlow;
+                    ctx.fillRect(this.puzzleKey.x - 38, keyY - 38, 76, 76);
+
+                    ctx.strokeStyle = '#d4ff9a';
+                    ctx.lineWidth = 4;
+                    ctx.beginPath();
+                    ctx.arc(this.puzzleKey.x, keyY, 10, 0, Math.PI * 2);
+                    ctx.stroke();
+                    ctx.fillStyle = '#d4ff9a';
+                    ctx.fillRect(this.puzzleKey.x - 2, keyY + 9, 4, 16);
+                    ctx.fillRect(this.puzzleKey.x + 2, keyY + 20, 8, 4);
+
+                    ctx.fillStyle = '#c9ff92';
+                    ctx.font = '16px Courier New';
+                    ctx.textAlign = 'center';
+                    ctx.fillText('PARKOUR FOR THE KEY', canvas.width / 2, 70);
+                }
                 
                 // Door
                 if (this.enemies.length === 0 && !this.cleared) {
@@ -7763,6 +7895,7 @@
                 if (this.cleared || this.enemies.length === 0) {
                     const doorX = canvas.width - 60;
                     const doorY = canvas.height - 180;
+                    const doorLocked = this.isPuzzleRoom && !this.keyCollected;
                     
                     ctx.fillStyle = '#4a4a4a';
                     ctx.fillRect(doorX, doorY, 50, 130);
@@ -7775,26 +7908,43 @@
                     ctx.fillRect(doorX + 5, doorY + 20, 40, 110);
                     
                     const doorGradient = ctx.createRadialGradient(doorX + 25, doorY + 75, 0, doorX + 25, doorY + 75, 50);
-                    doorGradient.addColorStop(0, 'rgba(255, 215, 0, 0.4)');
-                    doorGradient.addColorStop(1, 'rgba(255, 215, 0, 0)');
+                    doorGradient.addColorStop(0, doorLocked ? 'rgba(140, 255, 140, 0.28)' : 'rgba(255, 215, 0, 0.4)');
+                    doorGradient.addColorStop(1, doorLocked ? 'rgba(140, 255, 140, 0)' : 'rgba(255, 215, 0, 0)');
                     ctx.fillStyle = doorGradient;
                     ctx.fillRect(doorX - 20, doorY, 90, 130);
                     
                     ctx.globalAlpha = 0.5 + Math.sin(Date.now() / 300) * 0.3;
-                    ctx.fillStyle = '#ffd700';
+                    ctx.fillStyle = doorLocked ? '#9be07d' : '#ffd700';
                     ctx.fillRect(doorX + 5, doorY + 20, 40, 110);
                     ctx.globalAlpha = 1;
+
+                    if (doorLocked) {
+                        ctx.strokeStyle = '#d4ff9a';
+                        ctx.lineWidth = 3;
+                        ctx.beginPath();
+                        ctx.moveTo(doorX + 7, doorY + 45);
+                        ctx.lineTo(doorX + 43, doorY + 85);
+                        ctx.moveTo(doorX + 43, doorY + 45);
+                        ctx.lineTo(doorX + 7, doorY + 85);
+                        ctx.stroke();
+                    }
                     
                     ctx.strokeStyle = '#6a6a6a';
                     ctx.lineWidth = 3;
                     ctx.strokeRect(doorX, doorY, 50, 130);
                     
-                    ctx.fillStyle = '#ffd700';
+                    ctx.fillStyle = doorLocked ? '#c9ff92' : '#ffd700';
                     ctx.font = '20px Courier New';
                     ctx.textAlign = 'center';
                     ctx.globalAlpha = 0.7 + Math.sin(Date.now() / 300) * 0.3;
-                    ctx.fillText('→', doorX + 25, doorY - 10);
+                    ctx.fillText(doorLocked ? '🔒' : '→', doorX + 25, doorY - 10);
                     ctx.globalAlpha = 1;
+
+                    if (doorLocked) {
+                        ctx.fillStyle = '#c9ff92';
+                        ctx.font = '14px Courier New';
+                        ctx.fillText('KEY REQUIRED', canvas.width - 130, doorY - 15);
+                    }
                 }
                 
                 // Safe room indicator text
@@ -8157,28 +8307,14 @@
                     player.damageMultiplier += 0.15;
                     break;
             }
-            
             // Special ability assignment - NOW SUPPORTS 6 SLOTS!
             if (upgrade.type === 'special') {
-                if (!player.special1) {
-                    player.special1 = upgradeKey;
-                } else if (!player.special2) {
-                    player.special2 = upgradeKey;
-                } else if (!player.special3) {
-                    player.special3 = upgradeKey;
-                } else if (!player.special4) {
-                    player.special4 = upgradeKey;
-                } else if (!player.special5) {
-                    player.special5 = upgradeKey;
-                } else if (!player.special6) {
-                    player.special6 = upgradeKey;
-                } else {
-                    // All 6 slots full - replace oldest (special1)
-                    player.special1 = upgradeKey;
-                }
+                equipSpecialAbility(upgradeKey);
+                normalizeSpecialSlots();
                 updateSpecialAbilitiesUI();
             }
         }
+
         
         function updateSpecialAbilitiesUI() {
             const listElement = document.getElementById('specialAbilitiesList');
@@ -8338,7 +8474,7 @@
         
         function toggleMythicAbility(abilityKey, element) {
             const upgrade = upgradeDefinitions[abilityKey];
-            const specialSlotKeys = ['special1', 'special2', 'special3', 'special4', 'special5', 'special6'];
+            const specialSlotKeys = getSpecialSlotKeys();
             
             if (element.classList.contains('active')) {
                 // Deactivate
@@ -8349,6 +8485,7 @@
                     specialSlotKeys.forEach(slotKey => {
                         if (player[slotKey] === abilityKey) {
                             player[slotKey] = null;
+                            player[getCooldownKeyForSpecialSlot(slotKey)] = 0;
                         }
                     });
                 } else {
@@ -8360,20 +8497,17 @@
                 element.classList.add('active');
                 
                 if (upgrade.type === 'special') {
-                    // Add to first empty special slot, matching applyUpgrade replacement behavior when full
-                    const emptySlotKey = specialSlotKeys.find(slotKey => !player[slotKey]);
-                    if (emptySlotKey) {
-                        player[emptySlotKey] = abilityKey;
-                    } else {
-                        player.special1 = abilityKey; // All slots full - deterministic replacement
-                    }
+                    // Add/refresh special in slots
+                    equipSpecialAbility(abilityKey);
                 } else {
                     // Max out upgrade
                     player.upgrades[abilityKey] = upgrade.maxLevel || 10;
                 }
                 
-                // Apply special effects
-                applyUpgrade(abilityKey);
+                // Apply special effects/stat boosts
+                if (upgrade.type !== 'special') {
+                    applyUpgrade(abilityKey);
+                }
             }
             
             // Update UI
@@ -8773,6 +8907,8 @@
         // SECRET CHEAT CODE SYSTEM
         let cheatCode = '';
         let mythicMode = false;
+        const TUTORIAL_STORAGE_KEY = 'shadowAssassinTutorialComplete';
+        let pendingRunStarter = null;
         
         // Input
         const keys = {};
@@ -8832,7 +8968,7 @@
                 player.dash();
             }
 
-            if (e.key.toLowerCase() === 'g') {
+            if (e.key.toLowerCase() === 'h') {
                 player.fireGrapple();
             }
 
@@ -9108,10 +9244,12 @@
 
             drawExecutionCinematic();
             
+            currentRoom.updateRoomState();
+
             // Check for room transition
-            const roomCleared = currentRoom.isSafeRoom || (currentRoom.boss ? 
-                (currentRoom.boss.health <= 0) : 
-                (currentRoom.enemies.length === 0));
+            const roomCleared = currentRoom.isSafeRoom || (currentRoom.boss ?
+                (currentRoom.boss.health <= 0) :
+                (currentRoom.isPuzzleRoom ? currentRoom.keyCollected : currentRoom.enemies.length === 0));
                 
             if (roomCleared && player.x > canvas.width - 60) {
                 roomNumber++;
@@ -9121,7 +9259,8 @@
                 
                 const isSafeRoom = (roomNumber % 7 === 0);
                 const isBossRoom = (roomNumber % 5 === 0) && !isSafeRoom;
-                currentRoom = new Room(roomNumber * 12345, isBossRoom, isSafeRoom);
+                const isPuzzleRoom = isPuzzleRoomNumber(roomNumber);
+                currentRoom = new Room(roomNumber * 12345, isBossRoom, isSafeRoom, isPuzzleRoom);
                 
                 player.x = 100;
                 player.y = canvas.height - 200;
@@ -9229,14 +9368,69 @@
         }
         
 
-        loadMetaProgress();
-        checkAchievements();
+        function normalizeSpecialSlots() {
+            const slots = ['special1', 'special2', 'special3', 'special4', 'special5', 'special6'];
+            const seen = new Set();
+            for (const slot of slots) {
+                const ability = player[slot];
+                if (!ability) continue;
+                if (seen.has(ability)) {
+                    player[slot] = null;
+                } else {
+                    seen.add(ability);
+                }
+            }
+        }
 
-        // Menu button event listeners
-        document.getElementById('playBtn').addEventListener('click', () => {
+        function getSpecialSlotKeys() {
+            return ['special1', 'special2', 'special3', 'special4', 'special5', 'special6'];
+        }
+
+        function getCooldownKeyForSpecialSlot(slotKey) {
+            return slotKey + 'Cooldown';
+        }
+
+        function equipSpecialAbility(abilityKey) {
+            const slots = getSpecialSlotKeys();
+            const existingSlot = slots.find(slotKey => player[slotKey] === abilityKey);
+            if (existingSlot) {
+                player[getCooldownKeyForSpecialSlot(existingSlot)] = 0;
+                return existingSlot;
+            }
+
+            const emptySlot = slots.find(slotKey => !player[slotKey]);
+            const targetSlot = emptySlot || 'special1';
+            player[targetSlot] = abilityKey;
+            player[getCooldownKeyForSpecialSlot(targetSlot)] = 0;
+            return targetSlot;
+        }
+
+        function refreshCheckpointButtons() {
+            const hasCheckpoint = Boolean(localStorage.getItem('shadowAssassinCheckpoint'));
+            const continueBtn = document.getElementById('continueBtn');
+            continueBtn.style.display = hasCheckpoint ? 'block' : 'none';
+            const loadCheckpointBtn = document.getElementById('loadCheckpointBtn');
+            if (loadCheckpointBtn) {
+                loadCheckpointBtn.disabled = !hasCheckpoint;
+                loadCheckpointBtn.style.opacity = hasCheckpoint ? '1' : '0.5';
+                loadCheckpointBtn.style.cursor = hasCheckpoint ? 'pointer' : 'not-allowed';
+            }
+        }
+
+        function startRunWithTutorial(starter) {
+            const tutorialComplete = localStorage.getItem(TUTORIAL_STORAGE_KEY) === '1';
+            if (tutorialComplete) {
+                starter();
+                return;
+            }
+            pendingRunStarter = starter;
+            document.getElementById('tutorialOverlay').style.display = 'flex';
+        }
+
+        function startNewRun() {
             document.getElementById('mainMenu').style.display = 'none';
             gameStarted = true;
-            mythicMode = false; // Reset mythic mode
+            mythicMode = false;
             player = createRunPlayer();
             currentRoom = new Room(1);
             roomNumber = 1;
@@ -9246,6 +9440,76 @@
             gameOver = false;
             executionCinematic = null;
             resetFrameClock();
+            refreshCheckpointButtons();
+        }
+
+        function loadCheckpointRun(showAlertIfMissing = true) {
+            const saved = localStorage.getItem('shadowAssassinCheckpoint');
+            if (!saved) {
+                if (showAlertIfMissing) {
+                    alert('No checkpoint found! You must reach a safe room (every 7 rooms) to save a checkpoint.');
+                }
+                return false;
+            }
+
+            const checkpoint = JSON.parse(saved);
+            mythicMode = checkpoint.mythicMode || false;
+            player = new Player(100, 300);
+            player.health = checkpoint.health;
+            player.maxHealth = checkpoint.maxHealth;
+            player.upgrades = checkpoint.upgrades;
+            player.special1 = checkpoint.special1;
+            player.special2 = checkpoint.special2;
+            player.special3 = checkpoint.special3 || null;
+            player.special4 = checkpoint.special4 || null;
+            player.special5 = checkpoint.special5 || null;
+            player.special6 = checkpoint.special6 || null;
+            normalizeSpecialSlots();
+            player.hasDoubleJump = checkpoint.hasDoubleJump;
+
+            roomNumber = checkpoint.room;
+            const isSafeRoom = (roomNumber % 7 === 0);
+            const isBossRoom = (roomNumber % 5 === 0) && !isSafeRoom;
+            const isPuzzleRoom = isPuzzleRoomNumber(roomNumber);
+            currentRoom = new Room(roomNumber * 12345, isBossRoom, isSafeRoom, isPuzzleRoom);
+
+            player.x = 100;
+            player.y = canvas.height - 200;
+
+            particles = [];
+            projectiles = [];
+            shadowClones = [];
+            gameStarted = true;
+            gameOver = false;
+            executionCinematic = null;
+            document.getElementById('mainMenu').style.display = 'none';
+            document.getElementById('gameOverScreen').style.display = 'none';
+            resetFrameClock();
+            refreshCheckpointButtons();
+            return true;
+        }
+
+        loadMetaProgress();
+        checkAchievements();
+        refreshCheckpointButtons();
+
+        // Menu button event listeners
+        document.getElementById('playBtn').addEventListener('click', () => {
+            startRunWithTutorial(startNewRun);
+        });
+
+        document.getElementById('continueBtn').addEventListener('click', () => {
+            startRunWithTutorial(() => loadCheckpointRun(true));
+        });
+
+        document.getElementById('tutorialStartBtn').addEventListener('click', () => {
+            localStorage.setItem(TUTORIAL_STORAGE_KEY, '1');
+            document.getElementById('tutorialOverlay').style.display = 'none';
+            if (pendingRunStarter) {
+                const starter = pendingRunStarter;
+                pendingRunStarter = null;
+                starter();
+            }
         });
 
         document.getElementById('settingsBtn').addEventListener('click', () => {
@@ -9326,50 +9590,9 @@
         });
         
         document.getElementById('loadCheckpointBtn').addEventListener('click', () => {
-            // Try to load saved checkpoint
-            const saved = localStorage.getItem('shadowAssassinCheckpoint');
-            if (saved) {
-                const checkpoint = JSON.parse(saved);
-                
-                mythicMode = checkpoint.mythicMode || false;
-                player = new Player(100, 300);
-                player.health = checkpoint.health;
-                player.maxHealth = checkpoint.maxHealth;
-                player.upgrades = checkpoint.upgrades;
-                
-                // Restore special abilities - ALL 6 SLOTS!
-                player.special1 = checkpoint.special1;
-                player.special2 = checkpoint.special2;
-                player.special3 = checkpoint.special3 || null;
-                player.special4 = checkpoint.special4 || null;
-                player.special5 = checkpoint.special5 || null;
-                player.special6 = checkpoint.special6 || null;
-                player.hasDoubleJump = checkpoint.hasDoubleJump;
-                
-                roomNumber = checkpoint.room;
-                
-                // Determine if returning to safe room or continuing
-                const isSafeRoom = (roomNumber % 7 === 0);
-                const isBossRoom = (roomNumber % 5 === 0) && !isSafeRoom;
-                currentRoom = new Room(roomNumber * 12345, isBossRoom, isSafeRoom);
-                
-                player.x = 100;
-                player.y = canvas.height - 200;
-                
-                particles = [];
-                projectiles = [];
-                shadowClones = [];
-                gameStarted = true;
-                gameOver = false;
-                executionCinematic = null;
-                resetFrameClock();
-                document.getElementById('gameOverScreen').style.display = 'none';
-            } else {
-                // No checkpoint exists - button shouldn't even be clickable
-                alert('No checkpoint found! You must reach a safe room (every 7 rooms) to save a checkpoint.');
-            }
+            loadCheckpointRun(true);
         });
-        
+
         // Home button - returns to main menu
         document.getElementById('homeBtn').addEventListener('click', () => {
             document.getElementById('gameOverScreen').style.display = 'none';
@@ -9387,6 +9610,7 @@
             particles = [];
             projectiles = [];
             shadowClones = [];
+            refreshCheckpointButtons();
         });
         
         // Safe room continue button


### PR DESCRIPTION
### Motivation
- Fix player report that some special abilities appeared to do nothing by centralizing activation and guaranteeing visible/functional feedback on cast.  
- Remove duplicated per-slot logic that caused stale slot/cooldown state and mismatched flows between normal upgrades and the mythic panel.  
- Improve UX by clarifying keybinds and making first-run players complete a short tutorial before starting a run.  
- Add puzzle-room support and more robust checkpoint/load behavior to make progression predictable.

### Description
- Replaced per-slot activation methods with a single `useSpecialSlot(slotKey, cooldownKey)` helper and `spawnSpecialCastFeedback(abilityName)` to always show particles and apply a small short-range pulse damage when a special is used.  
- Added slot-management helpers: `getSpecialSlotKeys()`, `getCooldownKeyForSpecialSlot()`, `equipSpecialAbility(abilityKey)` and `normalizeSpecialSlots()` and refactored mythic-panel toggles and upgrade flow to use them so slots and cooldowns stay consistent.  
- Defensive handling: invalid/non-special entries in special slots are auto-cleared and their cooldown reset, and reselecting an already-equipped special resets that slot cooldown.  
- UI/controls and input changes: updated controls text to list `Q/E/R/F/C/V` for six special slots, changed grapple key from `G` to `H`, and wired input to the unified special methods.  
- Added a first-run `tutorialOverlay` with `startRunWithTutorial()` gating and `TUTORIAL_STORAGE_KEY` handling to persist completion, plus `refreshCheckpointButtons()`, `loadCheckpointRun()` and checkpoint UI improvements.  
- Introduced puzzle-room support via `isPuzzleRoomNumber()`, a `Room` constructor `isPuzzleRoom` flag, custom platform/puzzle key placement, `updateRoomState()` to collect puzzle keys, and door-locked visuals/logic tied to puzzle completion.

### Testing
- Ran `rg -n "spawnSpecialCastFeedback|useSpecialSlot\(|Invalid special ability slot state|Q/E/R/F/C/V" games/shadow-assassin-safe-rooms.html` to validate new symbols are present (success).  
- Executed in-file scripts with `node -e

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e8055e30833183d3ce51c5fd67db)