### PR TITLE
Make Shadow Assassin X finisher trigger reliably

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -1340,12 +1340,15 @@
             }
 
             tryExecution() {
-                if (!currentRoom.boss || currentRoom.boss.health <= 0) return;
+                if (!currentRoom.boss || currentRoom.boss.health <= 0 || executionCinematic) return;
 
                 const boss = currentRoom.boss;
+                const executeBonus = this.upgrades.execution || 0;
+                const executeThreshold = BOSS_EXECUTE_THRESHOLD + executeBonus * 0.03;
+                const executeRange = 120 + executeBonus * 8;
                 const dist = Math.hypot(boss.x - this.x, boss.y - this.y);
-                const canExecute = boss.health <= boss.maxHealth * BOSS_EXECUTE_THRESHOLD && dist < 95;
-                if (!canExecute || executionCinematic) return;
+                const canExecute = boss.health <= boss.maxHealth * executeThreshold && dist <= executeRange;
+                if (!canExecute) return;
 
                 executionCinematic = {
                     timer: EXECUTION_CINEMATIC_DURATION,
@@ -2308,7 +2311,7 @@
                                 
                                 setTimeout(() => {
                                     clearInterval(healthDrain);
-                                    if (currentRoom.boss) {
+                                    if (currentRoom.boss && currentRoom.boss.health > 0) {
                                         currentRoom.boss.health = 1;
                                         // Final rewrite flash
                                         for (let i = 0; i < 200; i++) {
@@ -7362,12 +7365,17 @@
                     ctx.fillText('DUEL ROOM - NO MINIONS', canvas.width / 2, 44);
                 }
 
-                if (player && this.health > 0 && this.health <= this.maxHealth * BOSS_EXECUTE_THRESHOLD) {
-                    const inRange = Math.hypot(this.x - player.x, this.y - player.y) < 95;
-                    const promptColor = inRange ? '#ff4444' : '#ffd27a';
-                    ctx.fillStyle = promptColor;
-                    ctx.font = 'bold 12px Courier New';
-                    ctx.fillText(inRange ? 'PRESS X - EXECUTE READY' : 'BOSS EXECUTABLE (GET CLOSER)', this.x, barY - 38);
+                if (player && this.health > 0) {
+                    const executeBonus = player.upgrades.execution || 0;
+                    const executeThreshold = BOSS_EXECUTE_THRESHOLD + executeBonus * 0.03;
+                    if (this.health <= this.maxHealth * executeThreshold) {
+                        const executeRange = 120 + executeBonus * 8;
+                        const inRange = Math.hypot(this.x - player.x, this.y - player.y) <= executeRange;
+                        const promptColor = inRange ? '#ff4444' : '#ffd27a';
+                        ctx.fillStyle = promptColor;
+                        ctx.font = 'bold 12px Courier New';
+                        ctx.fillText(inRange ? 'PRESS X - EXECUTE READY' : 'BOSS EXECUTABLE (GET CLOSER)', this.x, barY - 38);
+                    }
                 }
             }
 
@@ -7416,7 +7424,7 @@
             return nearest;
         }
 
-        const BOSS_EXECUTE_THRESHOLD = 0.14;
+        const BOSS_EXECUTE_THRESHOLD = 0.22;
         const EXECUTION_CINEMATIC_DURATION = 54;
 
         const BOSS_ROTATION = [
@@ -8898,7 +8906,10 @@
             if (executionCinematic.timer <= 0) {
                 const boss = executionCinematic.bossRef;
                 if (boss && currentRoom.boss === boss) {
-                    boss.takeDamage(999999);
+                    // Force a true finisher kill state instead of relying on damage hooks,
+                    // so delayed boss scripts can't leave it alive at 1 HP.
+                    boss.health = 0;
+                    boss.isInvulnerable = false;
                     boss.frozen = false;
                 }
                 if (executionCinematic.ownerRef) {


### PR DESCRIPTION
### Motivation
- Players reported pressing `X` often didn't start the finisher because range/threshold mismatches and re-entry during an active cinematic blocked activation.
- The execution cinematic could also be undermined by delayed callbacks that left bosses alive at 1 HP instead of truly finishing them.

### Description
- Broadened `tryExecution()` to early-return if `executionCinematic` is active and compute dynamic `executeThreshold` and `executeRange` from `this.upgrades.execution` for activation checks. 
- Increased the baseline `BOSS_EXECUTE_THRESHOLD` from `0.14` to `0.22` and tied both range and threshold scaling to the `execution` upgrade so finishers trigger more reliably. 
- Aligned the on-screen boss HUD prompt logic to the same dynamic threshold/range calculations so the UI reflects the actual execution rules. 
- Made the execution cinematic finalizer force a true death by setting `boss.health = 0`, clearing `boss.isInvulnerable`, unfreezing the boss, and restoring the owner’s `invincible` state to prevent resurrection by delayed hooks.

### Testing
- Used `rg` and `sed` to locate and inspect the modified blocks in `games/shadow-assassin-safe-rooms.html`, which matched the intended edits and succeeded. 
- Launched a local server with `python -m http.server 4173 --bind 0.0.0.0` and captured a Playwright screenshot of `http://127.0.0.1:4173/games/shadow-assassin-safe-rooms.html`, which succeeded and produced `artifacts/shadow-assassin-execution-ui.png`.
- Verified the repository diff and committed the change with `git`, which completed successfully and shows the single-file modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f6c1682883319ecd48cc6861844a)