### PR TITLE
Remove Instruction Docs from main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,9 +253,6 @@
           >[IRON]</span
         >
       </div>
-      <div style="margin-top: 12px; font-size: 10px">
-        <a class="menu-btn" href="instruction-system-docs.html" target="_blank" rel="noopener">INSTRUCTION DOCS</a>
-      </div>
       <section class="trending-games" aria-label="Trending games">
         <h2>TRENDING GAMES // LAST 24H</h2>
         <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>


### PR DESCRIPTION
### Motivation
- Remove the global "INSTRUCTION DOCS" link from the landing/home UI so it no longer appears in the main menu while keeping in-game documentation reachable from the CPU Emulator.

### Description
- Deleted the `INSTRUCTION DOCS` anchor block from the landing section in `index.html`, and left the CPU emulator `DOCS` link to `cpu-emulator-docs.html` in the emulator controls unchanged.

### Testing
- Ran `rg -n "instruction-system-docs.html|INSTRUCTION DOCS" index.html` to confirm removal and `rg -n "cpu-emulator-docs.html" index.html` to confirm the emulator link remains, and started `python -m http.server` plus a Playwright screenshot to visually validate the home screen; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a941828208326b762bc60035f08ec)