### PR TITLE
Add RANDOM GAME button to home screen above Trending Games

### DIFF
--- a/core.js
+++ b/core.js
@@ -1526,6 +1526,25 @@ function initTrendingGamesPanel() {
   setInterval(refreshTrendingGames, 60000);
 }
 
+function initHomeRandomGameButton() {
+  const randomBtn = document.getElementById("randomGameBtn");
+  if (!randomBtn || randomBtn.dataset.ready === "1") return;
+  randomBtn.dataset.ready = "1";
+
+  randomBtn.addEventListener("click", () => {
+    const gameButtons = Array.from(document.querySelectorAll("#overlayGames .game-card[data-game]"));
+    const games = gameButtons
+      .filter((button) => getComputedStyle(button).display !== "none")
+      .map((button) => String(button.dataset.game || "").trim())
+      .filter(Boolean);
+    if (!games.length) return;
+    const randomGame = games[Math.floor(Math.random() * games.length)];
+    if (typeof window.launchGame === "function") {
+      window.launchGame(randomGame);
+    }
+  });
+}
+
 export function trackGamePlay(game) {
   const normalized = String(game || "").toLowerCase().trim();
   if (!normalized) return;
@@ -1885,6 +1904,7 @@ loadCrewData();
 loadSeasonData();
 renderLiveOps();
 initTrendingGamesPanel();
+initHomeRandomGameButton();
 setupBankTransferUX();
 setupLoanUX();
 setupStockMarketUX();

--- a/index.html
+++ b/index.html
@@ -256,6 +256,9 @@
           >[IRON]</span
         >
       </div>
+      <button class="term-btn home-random-btn" id="randomGameBtn" type="button">
+        🎲 RANDOM GAME
+      </button>
       <section class="trending-games" aria-label="Trending games">
         <h2>TRENDING GAMES // LAST 24H</h2>
         <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,11 @@ body::before {
   text-align: center;
 }
 
+.home-random-btn {
+  margin-top: 18px;
+  min-width: 220px;
+}
+
 .trending-games {
   margin-top: 24px;
   width: min(90vw, 680px);


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to jump into a random playable game from the home screen, placed above the Trending Games panel for visibility.

### Description
- Added a `🎲 RANDOM GAME` button to `index.html` above the Trending Games section as `#randomGameBtn`.
- Added `.home-random-btn` styling in `styles.css` to match spacing and sizing of existing home controls.
- Implemented `initHomeRandomGameButton()` in `core.js` to collect visible game entries from the Games Directory, pick one at random, and call `window.launchGame(...)` on click.
- Wired `initHomeRandomGameButton()` into the startup sequence next to `initTrendingGamesPanel()` so the button is initialized on load.

### Testing
- Ran syntax checks with `node --check core.js` and `node --check script.js`, which passed.
- Served the site with `python -m http.server 8000` and captured an automated screenshot via Playwright to validate the button appears on the home screen, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9ddf74048326931b7367b6ae8544)