### PR TITLE
Add homepage random game launch button

### DIFF
--- a/core.js
+++ b/core.js
@@ -1589,6 +1589,25 @@ function initTrendingGamesPanel() {
   setInterval(refreshTrendingGames, 60000);
 }
 
+function initRandomGameButton() {
+  const button = document.getElementById("randomGameBtn");
+  if (!button || button.dataset.ready === "1") return;
+  button.dataset.ready = "1";
+
+  button.addEventListener("click", () => {
+    const gameButtons = Array.from(document.querySelectorAll(".games-grid .game-card[data-game]"));
+    if (!gameButtons.length || typeof window.launchGame !== "function") return;
+
+    const visibleGames = gameButtons.filter((gameBtn) => gameBtn.offsetParent !== null);
+    const pool = visibleGames.length ? visibleGames : gameButtons;
+    const pick = pool[Math.floor(Math.random() * pool.length)];
+    const game = String(pick?.dataset.game || "").trim();
+    if (!game) return;
+
+    window.launchGame(game);
+  });
+}
+
 export function trackGamePlay(game) {
   const normalized = String(game || "").toLowerCase().trim();
   if (!normalized) return;
@@ -1948,6 +1967,7 @@ loadCrewData();
 loadSeasonData();
 renderLiveOps();
 initTrendingGamesPanel();
+initRandomGameButton();
 refreshUpdateLogFromMergedPrs();
 setupBankTransferUX();
 setupLoanUX();

--- a/index.html
+++ b/index.html
@@ -257,6 +257,13 @@
           >[IRON]</span
         >
       </div>
+      <section class="random-game-cta" aria-label="Random game">
+        <button class="trending-game-btn random-game-btn" id="randomGameBtn" type="button">
+          <span class="trending-rank">🎲</span>
+          <span>RANDOM GAME</span>
+          <span class="trending-count">LAUNCH</span>
+        </button>
+      </section>
       <section class="trending-games" aria-label="Trending games">
         <h2>TRENDING GAMES // LAST 24H</h2>
         <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,16 @@ body::before {
   text-align: center;
 }
 
+
+.random-game-cta {
+  margin-top: 24px;
+  width: min(90vw, 680px);
+}
+
+.random-game-btn {
+  text-align: left;
+}
+
 .trending-games {
   margin-top: 24px;
   width: min(90vw, 680px);


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to jump into a random game from the homepage to increase discovery and engagement.
- Ensure the new CTA fits the existing terminal aesthetic and placement above the Trending Games panel.

### Description
- Add a `RANDOM GAME` CTA button to `index.html` using the same button layout (`trending-game-btn`) and the id `randomGameBtn` placed above the trending panel.
- Add minimal styles in `styles.css` (`.random-game-cta`, `.random-game-btn`) to match spacing and alignment with the trending UI.
- Implement `initRandomGameButton()` in `core.js` to pick a random `.games-grid .game-card[data-game]`, prefer visible cards when possible, and call `window.launchGame(game)` to launch it.
- Initialize the random button on startup by calling `initRandomGameButton()` during core initialization.

### Testing
- Ran JavaScript syntax checks with `node --check core.js` and `node --check script.js`, both succeeded.
- Served the site with `python -m http.server 4173` and captured a Playwright screenshot to validate visual placement, which produced an artifact successfully.
- Verified the new UI button responds and that `window.launchGame(...)` is invoked by exercising the button in the served site; no runtime errors observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa745c1908326abd889ab58a5454a)