### PR TITLE
Fix overlay content positioning under fixed top bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@
   --leg: #ffd700;
   --font-main: "Press Start 2P", monospace;
   --font-type: "Roboto Mono", monospace;
+  --topbar-clearance: 50px;
 }
 
 /* RAINBOW MODE */
@@ -532,7 +533,7 @@ body::before {
 /* Overlay container for modals and game screens. */
 .overlay {
   position: fixed;
-  inset: 0;
+  inset: var(--topbar-clearance) 0 0 0;
   background: #000;
   display: none;
   flex-direction: column;
@@ -1663,6 +1664,10 @@ canvas {
   opacity: 1;
 }
 @media (max-width: 900px) {
+  :root {
+    --topbar-clearance: 96px;
+  }
+
   .hangman-room {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
### Motivation
- Overlays (menus and game screens) were appearing underneath the fixed top navigation, obscuring titles and controls while the top bar remained fixed during scrolling.

### Description
- Added a shared `--topbar-clearance` CSS variable in `:root`, updated `.overlay` to use `inset: var(--topbar-clearance) 0 0 0`, and added a mobile override (`--topbar-clearance: 96px`) inside `@media (max-width: 900px)` so overlays begin below the top bar.

### Testing
- Verified the CSS diff with `git diff -- styles.css` and `git status --short`, committed the change, and attempted an automated Playwright screenshot test which failed to load the page in this environment (`ERR_EMPTY_RESPONSE`/`ERR_FILE_NOT_FOUND`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa7c4694083269334f71bed064206)