### PR TITLE
Gracefully handle Firestore permission-denied for stock market sync

### DIFF
--- a/core.js
+++ b/core.js
@@ -961,6 +961,7 @@ const STOCK_BASE_PRICES = {
 };
 
 let stopMarketSync = null;
+let marketSyncAvailable = true;
 
 function buildInitialStockState() {
   return STOCK_SYMBOLS.map((entry) => {
@@ -1052,23 +1053,35 @@ function evolveMarketStocks(stocks) {
 
 async function ensureGlobalMarket() {
   const ref = marketDocRef();
-  const snap = await getDoc(ref);
-  if (snap.exists()) {
-    applyMarketPayload(snap.data());
-    return;
+  try {
+    const snap = await getDoc(ref);
+    if (snap.exists()) {
+      applyMarketPayload(snap.data());
+      return;
+    }
+    const initial = getInitialMarketPayload();
+    await setDoc(ref, initial).catch(() => {});
+    applyMarketPayload(initial);
+  } catch (error) {
+    const denied = getFirebaseErrorCode(error) === "permission-denied";
+    marketSyncAvailable = !denied;
+    applyMarketPayload(getInitialMarketPayload());
   }
-  const initial = getInitialMarketPayload();
-  await setDoc(ref, initial).catch(() => {});
-  applyMarketPayload(initial);
 }
 
 function subscribeToGlobalMarket() {
-  if (stopMarketSync) return;
+  if (stopMarketSync || !marketSyncAvailable) return;
   const ref = marketDocRef();
   stopMarketSync = onSnapshot(ref, (snap) => {
     if (!snap.exists()) return;
     applyMarketPayload(snap.data());
-  }, () => {});
+  }, (error) => {
+    if (getFirebaseErrorCode(error) === "permission-denied") {
+      marketSyncAvailable = false;
+      if (stopMarketSync) stopMarketSync();
+      stopMarketSync = null;
+    }
+  });
 }
 
 async function tickStockMarket() {


### PR DESCRIPTION
### Motivation
- The app was repeatedly hitting Firestore `permission-denied` errors when accessing `gooner_meta/stock_market`, causing noisy RPC failures and broken market behavior.
- The goal is to keep gameplay working when Firestore rules disallow market reads by falling back to a local simulated market and stopping repeated failing sync attempts.

### Description
- Added a `marketSyncAvailable` flag and initialized it to `true` to track whether remote market sync should be attempted in `core.js`.
- Wrapped `ensureGlobalMarket()` reads/writes in a `try/catch` that detects `permission-denied` via `getFirebaseErrorCode(error)` and falls back to `getInitialMarketPayload()` when denied.
- Guarded `subscribeToGlobalMarket()` to no-op when `marketSyncAvailable` is `false`, and updated the `onSnapshot` error handler to tear down the listener and set `marketSyncAvailable = false` on `permission-denied`.
- The changes ensure local stock simulation continues when Firestore access is denied and prevent repeated failing `BatchGetDocuments` calls.

### Testing
- Ran `node --check core.js` to verify syntax and it succeeded.
- Verified the file `core.js` builds cleanly after the change with no runtime syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa83476488326b0bb350782613c00)