### PR TITLE
Keep game death screen inside the active game UI

### DIFF
--- a/core.js
+++ b/core.js
@@ -4322,9 +4322,17 @@ export function showGameOver(game, score) {
   saveStats();
   updateUI();
   beep(150, "sawtooth", 0.5);
+  const gameOverModal = document.getElementById("modalGameOver");
+  const activeGameOverlay = document.querySelector(
+    ".overlay.active:not(#modalGameOver)"
+  );
+  if (gameOverModal && activeGameOverlay) {
+    activeGameOverlay.appendChild(gameOverModal);
+    gameOverModal.classList.add("in-game");
+  }
   setText("gameOverText", "SYSTEM_FAILURE: SCORE_" + score);
   showToast(`RUN COMPLETE: +$${rewards.cashReward}`, "💸", `+${rewards.xpReward} SEASON XP`);
-  document.getElementById("modalGameOver").classList.add("active");
+  gameOverModal?.classList.add("active");
   window.addEventListener("keydown", quickRestartListener);
 }
 

--- a/script.js
+++ b/script.js
@@ -448,9 +448,17 @@ initGameCanvasSizing();
 initGameVisibilityGuards();
 initGamesLibraryDiscovery();
 
+function resetGameOverModalHost() {
+  const modal = document.getElementById("modalGameOver");
+  if (!modal) return;
+  document.body.appendChild(modal);
+  modal.classList.remove("in-game");
+}
+
 // Restart the last game from the game-over modal.
 document.getElementById("goRestart").onclick = () => {
   document.getElementById("modalGameOver").classList.remove("active");
+  resetGameOverModalHost();
   clearRestartListener();
   if (state.currentGame === "snake") initSnake();
   if (state.currentGame === "pong") initPong();
@@ -487,4 +495,5 @@ document.getElementById("goExit").onclick = () => {
   stopAllGames();
   closeOverlays();
   document.getElementById("modalGameOver").classList.remove("active");
+  resetGameOverModalHost();
 };

--- a/styles.css
+++ b/styles.css
@@ -1721,6 +1721,17 @@ canvas {
 #modalGameOver {
   background: rgba(5, 5, 5, 0.95);
   z-index: 9500;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+#modalGameOver.in-game {
+  position: absolute;
+  inset: 16px;
+  padding: 20px;
+  border: 2px solid var(--accent);
+  background: rgba(0, 0, 0, 0.82);
 }
 #modalGameOver h1 {
   color: #fff;


### PR DESCRIPTION
### Motivation
- Prevent the shared game-over modal from covering the entire app so the death screen appears as part of the current game's UI and preserves context for restart/exit flows.
- Ensure the modal can be returned to its original host after a restart/exit so subsequent runs behave like before.

### Description
- Modified `showGameOver` in `core.js` to move `#modalGameOver` into the currently active `.overlay` (if any) and add an `in-game` class before showing it, so the modal is rendered inside the active game overlay.
- Added `resetGameOverModalHost()` to `script.js` and call it from the `goRestart` and `goExit` handlers to re-attach the modal back to `document.body` and remove the `in-game` class when leaving or restarting a game.
- Updated `styles.css` to center the modal content by default and add `#modalGameOver.in-game` rules that render the modal as an inset, bordered panel inside the overlay while preserving the global modal appearance.

### Testing
- Ran syntax checks with `node --check core.js && node --check script.js`, which completed successfully.
- Served the app locally with `python -m http.server 4173` and visually exercised the change using a Playwright script that launched a game and triggered `showGameOver`, which produced a screenshot showing the modal inside the game overlay.
- No automated test failures were observed during these validations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa8bd077c8326b0f452ed5586426f)