### PR TITLE
Constrain death/game-over screen to game area overlay

### DIFF
--- a/core.js
+++ b/core.js
@@ -4324,7 +4324,14 @@ export function showGameOver(game, score) {
   beep(150, "sawtooth", 0.5);
   setText("gameOverText", "SYSTEM_FAILURE: SCORE_" + score);
   showToast(`RUN COMPLETE: +$${rewards.cashReward}`, "💸", `+${rewards.xpReward} SEASON XP`);
-  document.getElementById("modalGameOver").classList.add("active");
+  const modal = document.getElementById("modalGameOver");
+  const activeGameOverlay = document.querySelector(".overlay.game-overlay.active");
+  const modalHost = activeGameOverlay?.querySelector(".game-content-shell") || activeGameOverlay;
+  if (modalHost) {
+    modalHost.classList.add("game-over-host");
+    modalHost.appendChild(modal);
+  }
+  modal.classList.add("active");
   window.addEventListener("keydown", quickRestartListener);
 }
 

--- a/script.js
+++ b/script.js
@@ -448,9 +448,14 @@ initGameCanvasSizing();
 initGameVisibilityGuards();
 initGamesLibraryDiscovery();
 
+function hideGameOverModal() {
+  document.getElementById("modalGameOver").classList.remove("active");
+  document.querySelectorAll(".game-over-host").forEach((el) => el.classList.remove("game-over-host"));
+}
+
 // Restart the last game from the game-over modal.
 document.getElementById("goRestart").onclick = () => {
-  document.getElementById("modalGameOver").classList.remove("active");
+  hideGameOverModal();
   clearRestartListener();
   if (state.currentGame === "snake") initSnake();
   if (state.currentGame === "pong") initPong();
@@ -486,5 +491,5 @@ document.getElementById("goRestart").onclick = () => {
 document.getElementById("goExit").onclick = () => {
   stopAllGames();
   closeOverlays();
-  document.getElementById("modalGameOver").classList.remove("active");
+  hideGameOverModal();
 };

--- a/styles.css
+++ b/styles.css
@@ -1727,6 +1727,19 @@ canvas {
   background: rgba(5, 5, 5, 0.95);
   z-index: 9500;
 }
+
+.game-over-host {
+  position: relative;
+}
+
+.game-over-host > #modalGameOver {
+  position: absolute;
+  inset: 0;
+  padding: 20px;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
 #modalGameOver h1 {
   color: #fff;
   text-shadow: 2px 2px red;


### PR DESCRIPTION
### Motivation
- The shared game-over/death modal currently covers the entire viewport; this change scopes it to the active game panel so the death screen only overlays the small game area.

### Description
- Updated `showGameOver` in `core.js` to mount the shared `#modalGameOver` inside the active game overlay's `.game-content-shell` (or overlay root) and add a temporary `game-over-host` class to the host container.
- Added scoped CSS in `styles.css` for `.game-over-host` and `.game-over-host > #modalGameOver` so the modal is absolutely positioned and confined to the game content area.
- Added `hideGameOverModal()` to `script.js` and used it for cleanup on restart (`#goRestart`) and exit (`#goExit`) to remove the temporary host class and hide the modal.

### Testing
- Ran `node --check core.js` and `node --check script.js`, both checks succeeded. 
- Launched a temporary server with `python -m http.server 4173` and used a Playwright script to render the UI and capture a screenshot verifying the modal is constrained to the game area, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaa58e67c8326b311ca40f465181a)