### PR TITLE
Fix filter dropdown contrast in dark theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -595,6 +595,19 @@ body::before {
   margin-bottom: 20px;
   width: 100%;
 }
+
+select.term-input {
+  background: #050505;
+}
+
+select.term-input option {
+  background: #050505;
+  color: var(--accent);
+}
+
+select.term-input:focus {
+  background: #050505;
+}
 .term-btn {
   background: var(--accent);
   color: #000;


### PR DESCRIPTION
### Motivation
- Filter/dropdown options were rendered white-on-white and unreadable when opened, so the select controls need a dark background to match the site theme and restore legibility.

### Description
- Updated `styles.css` to set `select.term-input` and `select.term-input option` backgrounds to `#050505`, set option text color to `var(--accent)`, and preserved the dark background on focus to avoid inversion flashes.

### Testing
- Ran `git diff -- styles.css`, served the site locally with `python3 -m http.server 4173`, and captured a verification screenshot via Playwright; all verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaaad26c88326bc5b4a716418132b)