### PR TITLE
Add leaderboard tag filtering support

### DIFF
--- a/core.js
+++ b/core.js
@@ -4081,20 +4081,26 @@ export async function saveGlobalScore(game, score) {
 let leaderboardUnsubs = [];
 
 const LEADERBOARD_COLUMNS = [
-  { id: "players", title: "PLAYERS", type: "players" },
-  { id: "richest", title: "RICHEST", type: "richest" },
-  { id: "geo", title: "GEO DASH", type: "game" },
-  { id: "type", title: "TYPER", type: "game" },
-  { id: "snake", title: "SNAKE", type: "game" },
-  { id: "pong", title: "PONG", type: "game" },
-  { id: "runner", title: "RUNNER", type: "game" },
-  { id: "corebreaker", title: "CORE BREAKER", type: "game" },
-  { id: "neondefender", title: "NEON DEFENDER", type: "game" },
-  { id: "voidminer", title: "VOID MINER", type: "game" },
-  { id: "shadowassassin", title: "SHADOW ASSASSIN", type: "game" },
-  { id: "dodge", title: "DODGE", type: "game" },
-  { id: "flappy", title: "FLAPPY", type: "game" },
+  { id: "players", title: "PLAYERS", type: "players", tags: ["community"] },
+  { id: "richest", title: "RICHEST", type: "richest", tags: ["money", "economy"] },
+  { id: "geo", title: "GEO DASH", type: "game", tags: ["arcade", "skill"] },
+  { id: "type", title: "TYPER", type: "game", tags: ["arcade", "skill"] },
+  { id: "snake", title: "SNAKE", type: "game", tags: ["arcade", "skill"] },
+  { id: "pong", title: "PONG", type: "game", tags: ["arcade", "pvp"] },
+  { id: "runner", title: "RUNNER", type: "game", tags: ["arcade", "skill"] },
+  { id: "corebreaker", title: "CORE BREAKER", type: "game", tags: ["arcade", "skill"] },
+  { id: "neondefender", title: "NEON DEFENDER", type: "game", tags: ["arcade", "skill"] },
+  { id: "voidminer", title: "VOID MINER", type: "game", tags: ["arcade", "skill"] },
+  { id: "shadowassassin", title: "SHADOW ASSASSIN", type: "game", tags: ["arcade", "skill"] },
+  { id: "dodge", title: "DODGE", type: "game", tags: ["arcade", "skill"] },
+  { id: "flappy", title: "FLAPPY", type: "game", tags: ["arcade", "skill"] },
 ];
+
+const leaderboardColumnMatchesFilter = (column, filterValue) => {
+  if (!filterValue) return true;
+  if (column.title.includes(filterValue)) return true;
+  return (column.tags || []).some((tag) => String(tag || "").toUpperCase().includes(filterValue));
+};
 
 const clearLeaderboardSubscriptions = () => {
   leaderboardUnsubs.forEach((unsub) => {
@@ -4249,9 +4255,7 @@ function loadLeaderboard() {
   list.innerHTML = "";
 
   const filterValue = getLeaderboardFilterValue();
-  const visibleColumns = filterValue
-    ? LEADERBOARD_COLUMNS.filter((column) => column.title.includes(filterValue))
-    : LEADERBOARD_COLUMNS;
+  const visibleColumns = LEADERBOARD_COLUMNS.filter((column) => leaderboardColumnMatchesFilter(column, filterValue));
 
   if (!visibleColumns.length) {
     list.innerHTML = `<div class="score-item">NO LEADERBOARD TYPE MATCHES "${escapeHtml(filterValue)}"</div>`;


### PR DESCRIPTION
### Motivation
- Make leaderboard filtering more flexible so users can find columns by semantic tags (for example typing `PVP` should match the `PONG` column).

### Description
- Added a `tags` array to each entry in `LEADERBOARD_COLUMNS` to store semantic tags for columns. 
- Implemented `leaderboardColumnMatchesFilter(column, filterValue)` to match the filter against column titles or tags. 
- Updated `loadLeaderboard()` to use the new matcher so tag-based queries return matching columns. 
- Modified `LEADERBOARD_COLUMNS` entries to include reasonable tag sets (e.g., `PONG` now includes `"pvp"`).

### Testing
- Ran `node --check core.js` to validate syntax and it succeeded. 
- Launched a local HTTP server and manually exercised the leaderboard filter in a browser to verify tag matching works. 
- Automated verification with a Playwright script that opened the scores overlay, entered `pvp` into `#leaderboardFilter`, and captured a screenshot showing the expected tagged column, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaf184af8832685b402a9e116fe6c)