### PR TITLE
Fix Admin button visibility for allowlisted admins

### DIFF
--- a/core.js
+++ b/core.js
@@ -578,7 +578,8 @@ function isGodUser(name = myName) {
 }
 
 function updateAdminMenu() {
-  const adminBtn = document.getElementById("adminMenuBtn");
+  const adminBtn =
+    document.getElementById("tabAdmin") || document.getElementById("adminMenuBtn");
   const adminName = document.getElementById("adminName");
   const hasAccess = isGodUser();
   if (adminBtn) adminBtn.style.display = hasAccess ? "inline-block" : "none";


### PR DESCRIPTION
### Motivation
- The Admin button in the top-bar was not being shown because the UI selector targeted a legacy id (`adminMenuBtn`) while the actual button uses `tabAdmin`, causing allowlisted and claim-based admins to lose access to the Admin menu.

### Description
- Updated `updateAdminMenu` in `core.js` to select `document.getElementById("tabAdmin") || document.getElementById("adminMenuBtn")` so the top-bar `tabAdmin` is used and the legacy `adminMenuBtn` remains a fallback.
- This restores visibility for users on the `ADMIN_ALLOWLIST` and for users with admin/god permission claims by ensuring `updateAdminMenu()` toggles the correct element.

### Testing
- Ran `node --check core.js` to validate the updated file syntax, which succeeded.
- Attempted to verify UI with a headless browser screenshot (Playwright) against a local static server, but the server connection failed in this environment (navigation returned `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab16f93b8832693453b746e6f9cf6)