### PR TITLE
Keep menu overlays layered over the main background/chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
     </div>
 
     <!-- God-tier operator controls. Visible only to allowlisted users. -->
-    <div class="overlay" id="overlayAdmin">
+    <div class="overlay menu-overlay" id="overlayAdmin">
       <div class="score-box" style="border-color: #ffd700">
         <h2 style="text-align: center; color: #ffd700">ADMIN MENU</h2>
         <p style="text-align: center; font-size: 10px">
@@ -334,7 +334,7 @@
     </div>
 
     <!-- Profile overlay with stats + achievements. -->
-    <div class="overlay" id="overlayProfile">
+    <div class="overlay menu-overlay" id="overlayProfile">
       <div class="score-box">
         <h2 style="text-align: center">OPERATOR PROFILE</h2>
         <div class="profile-summary">
@@ -422,7 +422,7 @@
     </div>
 
     <!-- Bank overlay with transaction log. -->
-    <div class="overlay" id="overlayBank">
+    <div class="overlay menu-overlay" id="overlayBank">
       <div class="score-box">
         <h2 style="text-align: center">THE BANK</h2>
         <div
@@ -524,7 +524,7 @@
     </div>
 
     <!-- Shop overlay for perks and cosmetics. -->
-    <div class="overlay" id="overlayShop">
+    <div class="overlay menu-overlay" id="overlayShop">
       <div class="score-box">
         <h2 style="text-align: center">BLACK MARKET</h2>
         <div style="text-align: center; font-size: 10px; margin-bottom: 10px">
@@ -542,7 +542,7 @@
     </div>
 
     <!-- Jobs hub + job mini-game overlays. -->
-    <div class="overlay" id="overlayJobs">
+    <div class="overlay menu-overlay" id="overlayJobs">
       <div class="score-box">
         <h2 style="text-align: center">JOB GAMES</h2>
         <div class="jobs-note">PLAY EACH JOB LIKE A SEPARATE MINI-GAME TO EARN MONEY</div>
@@ -620,7 +620,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayJobCashier">
+    <div class="overlay menu-overlay" id="overlayJobCashier">
       <div class="score-box">
         <h2 style="text-align: center">CASHIER RUSH</h2>
         <div class="jobs-note">CLICK THE CORRECT TOTAL TAG FOR EACH CUSTOMER</div>
@@ -636,7 +636,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayJobFrontdesk">
+    <div class="overlay menu-overlay" id="overlayJobFrontdesk">
       <div class="score-box">
         <h2 style="text-align: center">FRONT DESK MEMORY</h2>
         <div class="jobs-note">CLICK THE MATCHING KEYCARD CODE</div>
@@ -652,7 +652,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayJobDelivery">
+    <div class="overlay menu-overlay" id="overlayJobDelivery">
       <div class="score-box">
         <h2 style="text-align: center">DELIVERY DRIVER RUN</h2>
         <div class="jobs-note">CLICK GREEN CHECKPOINTS, AVOID HAZARDS</div>
@@ -668,7 +668,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayJobStocker">
+    <div class="overlay menu-overlay" id="overlayJobStocker">
       <div class="score-box">
         <h2 style="text-align: center">STOCK SHELF SORT</h2>
         <div class="jobs-note">CLICK THE CRATE THAT MATCHES THE REQUESTED ITEM</div>
@@ -684,7 +684,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayJobJanitor">
+    <div class="overlay menu-overlay" id="overlayJobJanitor">
       <div class="score-box">
         <h2 style="text-align: center">JANITOR SPOT CHECK</h2>
         <div class="jobs-note">CLICK RANDOM SPILLS TO CLEAN 8 MESSES BEFORE TIME RUNS OUT</div>
@@ -701,7 +701,7 @@
     </div>
 
 
-    <div class="overlay" id="overlayJobBarista">
+    <div class="overlay menu-overlay" id="overlayJobBarista">
       <div class="score-box">
         <h2 style="text-align: center">ARCADE BARISTA</h2>
         <div class="jobs-note">CLICK SHOTS IN THE GREEN TEMP RANGE</div>
@@ -723,7 +723,7 @@
     </div>
 
     <!-- Scores overlay for local + global leaderboards. -->
-    <div class="overlay" id="overlayScores">
+    <div class="overlay menu-overlay" id="overlayScores">
       <div class="score-box">
         <h2 style="text-align: center; margin-bottom: 20px">
           GLOBAL LEADERBOARD
@@ -750,7 +750,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlaySeason">
+    <div class="overlay menu-overlay" id="overlaySeason">
       <div class="score-box">
         <h2 style="text-align: center">SEASON PROTOCOL</h2>
         <p id="seasonName" style="text-align: center; font-size: 10px">SEASON // INIT</p>
@@ -775,7 +775,7 @@
       </div>
     </div>
 
-    <div class="overlay" id="overlayCrew">
+    <div class="overlay menu-overlay" id="overlayCrew">
       <div class="score-box">
         <h2 style="text-align: center">CREW TERMINAL</h2>
         <div class="stat-row"><span>YOUR CREW</span><span id="crewName">NONE</span></div>
@@ -804,7 +804,7 @@
     </div>
 
     <!-- Configuration overlay for display/audio toggles. -->
-    <div class="overlay" id="overlayConfig">
+    <div class="overlay menu-overlay" id="overlayConfig">
       <div class="config-box">
         <h2
           style="

--- a/styles.css
+++ b/styles.css
@@ -576,6 +576,24 @@ body::before {
 .overlay.active {
   display: flex !important;
 }
+
+/* Menu-style overlays sit above the home scene so chat/glow stay visible. */
+.menu-overlay {
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(1px);
+}
+
+.menu-overlay .score-box,
+.menu-overlay .menu-box,
+.menu-overlay .job-card,
+.menu-overlay .settings-grid,
+.menu-overlay .games-toolbar,
+.menu-overlay .games-grid,
+.menu-overlay h1,
+.menu-overlay p {
+  position: relative;
+  z-index: 1;
+}
 .menu-box {
   background: rgba(0, 0, 0, 0.9);
   border: 2px solid var(--accent);


### PR DESCRIPTION
### Motivation
- Menus should appear as overlays above the main background and chat so the home glow and chat remain visible when non-game menus open.
- Opening a menu must replace the previous menu in-place while preserving the existing overlay switching behavior.

### Description
- Added a new `menu-overlay` class to non-game overlays in `index.html` (Admin, Profile, Bank, Shop, Jobs and job submenus, Scores, Season, Crew, Config) to mark them as menu-style overlays.
- Updated `styles.css` to add `.menu-overlay` styling with a translucent backdrop and `backdrop-filter` so the home scene (glow/chat) remains visible beneath open menus, and set inner menu elements to `position: relative; z-index: 1`.
- Left overlay activation logic unchanged (`openGame()` still calls `closeOverlays()` before adding `active`), so opening one menu still closes any previously open overlay.
- Files modified: `index.html`, `styles.css`.

### Testing
- Served the app locally with `python -m http.server 4173 --bind 0.0.0.0` and verified the server started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:4173/index.html`, activated `#overlayProfile`, and captured a screenshot to confirm the main background and chat remain visible under the menu; the script completed successfully and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab2383b8483269588d7f8c40fb6e0)