### PR TITLE
Position config overlay beneath top-left CONFIG button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1450,6 +1450,11 @@ canvas {
   border: 1px solid var(--accent);
   background: #000;
 }
+
+#overlayConfig {
+  align-items: flex-start;
+  padding: 8px 20px 20px;
+}
 .config-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation

- The CONFIG overlay was centered and not visually anchored to the top-left `CONFIG` button, so the UI required a small layout tweak to open the menu directly beneath that button.

### Description

- Added a targeted `#overlayConfig` rule in `styles.css` to left-align the overlay contents by setting `align-items: flex-start` and reduced top padding with `padding: 8px 20px 20px;` so the panel appears under the top-left `CONFIG` control.
- No other behavior changes; `.config-box` sizing was left intact.

### Testing

- Launched a local static server with `python3 -m http.server 4173` and ran a Playwright script to click `#tabConfig` and capture a screenshot (first Playwright run failed due to a missing `ports_to_forward` parameter, second run succeeded). — second run succeeded and produced `artifacts/config-overlay-position.png`. 
- The Playwright click and screenshot validation completed successfully after the corrected run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab3ff56448326ad614b66e6091e8e)