### PR TITLE
Add overlay menus for Random Game, Trending Games and Update Log; convert Games directory to menu-overlay

### DIFF
--- a/core.js
+++ b/core.js
@@ -1485,20 +1485,31 @@ function formatTrendingWindowLabel() {
   return `LAST REFRESH ${now.toLocaleTimeString("en-GB")} // WINDOW 24H`;
 }
 
+function formatTrendingTimestamp(tsValue) {
+  const numericTs = Number(tsValue || 0);
+  if (!numericTs) return "--:--:--";
+  return new Date(numericTs).toLocaleTimeString("en-GB");
+}
+
 async function refreshTrendingGames() {
   const wrap = document.getElementById("trendingGamesList");
   const meta = document.getElementById("trendingGamesMeta");
+  const overlayWrap = document.getElementById("overlayTrendingGamesList");
+  const overlayMeta = document.getElementById("overlayTrendingGamesMeta");
   if (!wrap || !meta) return;
   const since = Date.now() - 24 * 60 * 60 * 1000;
 
   try {
     const snap = await getDocs(query(collection(db, "gooner_game_plays"), where("ts", ">=", since), limit(800)));
     const counts = new Map();
+    const latestPlayByGame = new Map();
     snap.forEach((entry) => {
       const data = entry.data() || {};
       const key = String(data.game || "").toLowerCase().trim();
       if (!key) return;
+      const ts = Number(data.ts || 0);
       counts.set(key, (counts.get(key) || 0) + 1);
+      if (ts > Number(latestPlayByGame.get(key) || 0)) latestPlayByGame.set(key, ts);
     });
 
     const rows = [...counts.entries()]
@@ -1506,8 +1517,12 @@ async function refreshTrendingGames() {
       .slice(0, 5);
 
     if (!rows.length) {
-      wrap.innerHTML = '<div class="trending-empty">NO GAME PLAYS IN THE LAST 24H.</div>';
-      meta.innerText = formatTrendingWindowLabel();
+      const emptyMarkup = '<div class="trending-empty">NO GAME PLAYS IN THE LAST 24H.</div>';
+      wrap.innerHTML = emptyMarkup;
+      if (overlayWrap) overlayWrap.innerHTML = emptyMarkup;
+      const label = formatTrendingWindowLabel();
+      meta.innerText = label;
+      if (overlayMeta) overlayMeta.innerText = label;
       return;
     }
 
@@ -1518,24 +1533,44 @@ async function refreshTrendingGames() {
       })
       .join("");
 
-    meta.innerText = formatTrendingWindowLabel();
+    if (overlayWrap) {
+      overlayWrap.innerHTML = rows
+        .map(([game, plays], idx) => {
+          const label = TRENDING_GAME_LABELS[game] || game.toUpperCase();
+          const latestTs = latestPlayByGame.get(game) || 0;
+          return `<div class="trending-overlay-row"><span class="trending-rank">#${idx + 1}</span><button class="trending-game-btn" type="button" data-game="${escapeHtml(game)}"><span>${escapeHtml(label)}</span><span class="trending-count">${plays} PLAYS</span></button><button class="trending-game-time" type="button" data-game="${escapeHtml(game)}" title="Launch ${escapeHtml(label)}">${formatTrendingTimestamp(latestTs)}</button></div>`;
+        })
+        .join("");
+    }
+
+    const label = formatTrendingWindowLabel();
+    meta.innerText = label;
+    if (overlayMeta) overlayMeta.innerText = label;
   } catch (error) {
-    meta.innerText = "TRENDING SIGNAL OFFLINE";
+    const offlineLabel = "TRENDING SIGNAL OFFLINE";
+    meta.innerText = offlineLabel;
     wrap.innerHTML = '<div class="trending-empty">UNABLE TO LOAD TRENDING GAMES.</div>';
+    if (overlayMeta) overlayMeta.innerText = offlineLabel;
+    if (overlayWrap) overlayWrap.innerHTML = '<div class="trending-empty">UNABLE TO LOAD TRENDING GAMES.</div>';
   }
 }
 
 
+
 function renderUpdateLogMessage(message, tag = "SYNC") {
-  const list = document.getElementById("updateLogList");
-  if (!list) return;
-  list.innerHTML = `<li><span>${escapeHtml(tag)}</span> ${escapeHtml(message)}</li>`;
+  const lists = [document.getElementById("updateLogList"), document.getElementById("overlayUpdateLogList")].filter(Boolean);
+  if (!lists.length) return;
+  const row = `<li><span>${escapeHtml(tag)}</span> ${escapeHtml(message)}</li>`;
+  lists.forEach((list) => {
+    list.innerHTML = row;
+  });
 }
 
 
 async function refreshUpdateLogFromMergedPrs() {
   const panel = document.getElementById("updateLogPanel");
   const list = document.getElementById("updateLogList");
+  const overlayList = document.getElementById("overlayUpdateLogList");
   if (!panel || !list) return;
 
   const owner = String(panel.dataset.githubOwner || "").trim();
@@ -1550,7 +1585,9 @@ async function refreshUpdateLogFromMergedPrs() {
   try {
     const cached = JSON.parse(localStorage.getItem(cacheKey) || "null");
     if (cached && Date.now() - Number(cached.ts || 0) < cacheTtlMs && Array.isArray(cached.rows)) {
-      list.innerHTML = cached.rows.join("");
+      const cachedHtml = cached.rows.join("");
+      list.innerHTML = cachedHtml;
+      if (overlayList) overlayList.innerHTML = cachedHtml;
       return;
     }
   } catch {}
@@ -1581,7 +1618,9 @@ async function refreshUpdateLogFromMergedPrs() {
       return `<li><span>${escapeHtml(rowNumber)}</span> ${escapeHtml(title)}</li>`;
     });
 
-    list.innerHTML = rows.join("");
+    const html = rows.join("");
+    list.innerHTML = html;
+    if (overlayList) overlayList.innerHTML = html;
     localStorage.setItem(cacheKey, JSON.stringify({ ts: Date.now(), rows }));
   } catch (_error) {
     renderUpdateLogMessage("UNABLE TO LOAD MERGED PR FEED", "OFFLINE");
@@ -1590,38 +1629,57 @@ async function refreshUpdateLogFromMergedPrs() {
 
 function initTrendingGamesPanel() {
   const wrap = document.getElementById("trendingGamesList");
+  const overlayWrap = document.getElementById("overlayTrendingGamesList");
+  const openMenuBtn = document.getElementById("trendingGamesMenuBtn");
   if (!wrap || wrap.dataset.ready === "1") return;
   wrap.dataset.ready = "1";
 
-  wrap.addEventListener("click", (event) => {
+  const handleLaunchFromTarget = (event) => {
     const button = event.target.closest("[data-game]");
     const game = button?.dataset.game;
     if (!game) return;
     if (typeof window.launchGame === "function") {
       window.launchGame(game);
     }
-  });
+  };
+
+  wrap.addEventListener("click", handleLaunchFromTarget);
+  if (overlayWrap) overlayWrap.addEventListener("click", handleLaunchFromTarget);
+  if (openMenuBtn) {
+    openMenuBtn.addEventListener("click", () => {
+      openGame("overlayTrendingGames");
+      refreshTrendingGames();
+    });
+  }
 
   refreshTrendingGames();
   setInterval(refreshTrendingGames, 60000);
 }
 
 function initRandomGameButton() {
-  const button = document.getElementById("randomGameBtn");
+  const menuButton = document.getElementById("randomGameBtn");
+  const launchButton = document.getElementById("randomGameLaunchBtn");
+  if (menuButton && menuButton.dataset.ready !== "1") {
+    menuButton.dataset.ready = "1";
+    menuButton.addEventListener("click", () => {
+      openGame("overlayGames");
+    });
+  }
+
+  if (!launchButton || launchButton.dataset.ready === "1") return;
+  launchButton.dataset.ready = "1";
+  launchButton.addEventListener("click", () => {
+    openGame("overlayGames");
+  });
+}
+
+function initUpdateLogMenuButton() {
+  const button = document.getElementById("updateLogMenuBtn");
   if (!button || button.dataset.ready === "1") return;
   button.dataset.ready = "1";
-
   button.addEventListener("click", () => {
-    const gameButtons = Array.from(document.querySelectorAll(".games-grid .game-card[data-game]"));
-    if (!gameButtons.length || typeof window.launchGame !== "function") return;
-
-    const visibleGames = gameButtons.filter((gameBtn) => gameBtn.offsetParent !== null);
-    const pool = visibleGames.length ? visibleGames : gameButtons;
-    const pick = pool[Math.floor(Math.random() * pool.length)];
-    const game = String(pick?.dataset.game || "").trim();
-    if (!game) return;
-
-    window.launchGame(game);
+    openGame("overlayUpdateLog");
+    refreshUpdateLogFromMergedPrs();
   });
 }
 
@@ -1985,6 +2043,7 @@ loadSeasonData();
 renderLiveOps();
 initTrendingGamesPanel();
 initRandomGameButton();
+initUpdateLogMenuButton();
 refreshUpdateLogFromMergedPrs();
 setupBankTransferUX();
 setupLoanUX();

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <div class="dropdown-content" id="menuDropdown"></div>
 
     <!-- Dedicated games directory overlay. -->
-    <div class="overlay" id="overlayGames">
+    <div class="overlay menu-overlay" id="overlayGames">
       <h1>GAMES DIRECTORY</h1>
       <div class="games-toolbar">
         <input
@@ -141,6 +141,36 @@
         <button class="game-card" id="btnFlappy" data-game="flappy" data-tags="arcade skill" onclick="window.launchGame('flappy')" style="display: none"><span>🐤</span><strong>FLAPPY GOON</strong><small>Secret bonus mode: tap to survive.</small></button>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
+
+    <div class="overlay menu-overlay" id="overlayTrendingGames">
+      <div class="score-box menu-feed-box">
+        <h2 style="text-align: center">TRENDING GAMES DIRECTORY // LAST 24H</h2>
+        <div class="trending-meta" id="overlayTrendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>
+        <div class="menu-scroll-panel">
+          <div id="overlayTrendingGamesList" class="trending-overlay-list">
+            <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
+          </div>
+        </div>
+        <button class="term-btn" style="margin-top: 12px" onclick="window.closeOverlays()">CLOSE</button>
+      </div>
+    </div>
+
+    <div
+      class="overlay menu-overlay"
+      id="overlayUpdateLog"
+      data-github-owner="thefoxssss"
+      data-github-repo="webstie"
+    >
+      <div class="score-box menu-feed-box">
+        <h2 style="text-align: center">UPDATE LOG // FULL HISTORY</h2>
+        <div class="menu-scroll-panel">
+          <ul id="overlayUpdateLogList" class="update-log-overlay-list">
+            <li><span>#01</span> LOADING LATEST UPDATES...</li>
+          </ul>
+        </div>
+        <button class="term-btn" style="margin-top: 12px" onclick="window.closeOverlays()">CLOSE</button>
+      </div>
     </div>
 
     <!-- God-tier operator controls. Visible only to allowlisted users. -->
@@ -266,21 +296,31 @@
         >
       </div>
       <section class="random-game-cta" aria-label="Random game">
-        <button class="trending-game-btn random-game-btn" id="randomGameBtn" type="button">
+        <h2>
+          RANDOM GAME
+          <button class="section-menu-btn" id="randomGameBtn" type="button">OPEN MENU</button>
+        </h2>
+        <button class="trending-game-btn random-game-btn" id="randomGameLaunchBtn" type="button">
           <span class="trending-rank">🎲</span>
-          <span>RANDOM GAME</span>
+          <span>OPEN GAMES DIRECTORY</span>
           <span class="trending-count">LAUNCH</span>
         </button>
       </section>
       <section class="trending-games" aria-label="Trending games">
-        <h2>TRENDING GAMES // LAST 24H</h2>
+        <h2>
+          TRENDING GAMES // LAST 24H
+          <button class="section-menu-btn" id="trendingGamesMenuBtn" type="button">OPEN MENU</button>
+        </h2>
         <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>
         <div class="trending-games-list" id="trendingGamesList">
           <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
         </div>
       </section>
       <section class="update-log" aria-label="Update log" id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="webstie">
-        <h2>UPDATE LOG</h2>
+        <h2>
+          UPDATE LOG
+          <button class="section-menu-btn" id="updateLogMenuBtn" type="button">OPEN MENU</button>
+        </h2>
         <ul id="updateLogList">
           <li><span>#01</span> LOADING LATEST UPDATES...</li>
         </ul>

--- a/styles.css
+++ b/styles.css
@@ -408,6 +408,88 @@ body::before {
   color: #fff;
 }
 
+
+.random-game-cta h2,
+.trending-games h2,
+.update-log h2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.section-menu-btn {
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.65);
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.section-menu-btn:hover {
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.menu-feed-box {
+  width: min(92vw, 760px);
+}
+
+.menu-scroll-panel {
+  margin-top: 8px;
+  max-height: min(62vh, 520px);
+  overflow-y: auto;
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.72);
+  padding: 10px;
+}
+
+.trending-overlay-list {
+  display: grid;
+  gap: 8px;
+}
+
+.trending-overlay-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.trending-game-time {
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.trending-game-time:hover {
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.update-log-overlay-list {
+  margin: 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 10px;
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.update-log-overlay-list li span {
+  color: var(--accent);
+}
+
 .trending-meta {
   font-size: 8px;
   color: var(--accent);


### PR DESCRIPTION
### Motivation
- Make the Random/Trending/Update UI behave like other top-level menus (Bank/Shop/Profile) by opening overlay menus from the page titles and keep the Games directory consistent with other overlays. 
- Provide a richer Trending view with clickable timestamps and a scrollable full Update Log so users can inspect and launch content without leaving the home page.

### Description
- Converted the Games directory overlay to a menu-style overlay by adding `menu-overlay` to `#overlayGames` in `index.html`. 
- Added title-level `OPEN MENU` buttons for Random Game, Trending Games and Update Log in `index.html`, plus a separate Random-launch button that opens the Games directory. 
- Added two new overlays in `index.html`: `#overlayTrendingGames` (trending list with timestamps) and `#overlayUpdateLog` (scrollable update history). 
- Wired Trending overlay and timestamp buttons in `core.js` by adding `formatTrendingTimestamp`, enhancing `refreshTrendingGames` to populate both the home list and the overlay (including latest-play timestamps), and making overlay entries clickable to launch games. 
- Synced the Update Log feed into the new overlay by updating `renderUpdateLogMessage` and `refreshUpdateLogFromMergedPrs` to target both the home list and `#overlayUpdateLogList`. 
- Updated initialization in `core.js` to add `initUpdateLogMenuButton`, updated `initTrendingGamesPanel` and `initRandomGameButton` to support opening overlays, and kept existing home widgets in sync. 
- Added supporting styles in `styles.css` for `.section-menu-btn`, `.menu-feed-box`, `.menu-scroll-panel`, `.trending-overlay-row`, `.trending-game-time`, and update-log overlay list formatting.

### Testing
- Ran static code checks with `node --check core.js` and `node --check script.js` which reported no syntax errors. 
- Launched a local static server using `python -m http.server 4173 --bind 0.0.0.0` and used Playwright to load the app and capture a screenshot for visual verification, which completed successfully. 
- Verified overlays open and the new menu buttons trigger the corresponding overlays in the running app during the smoke test; Trending and Update Log content is synchronized between the home page and their overlays.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab50d3eb48326b532cb8731284928)