### PR TITLE
Simplify games directory dropdown labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,18 +88,18 @@
           maxlength="30"
         />
         <select id="gamesFilter" class="term-input games-select">
-          <option value="all">FILTER: ALL</option>
-          <option value="arcade">FILTER: ARCADE</option>
-          <option value="pvp">FILTER: PVP</option>
-          <option value="casino">FILTER: CASINO</option>
-          <option value="skill">FILTER: SKILL</option>
-          <option value="favorites">FILTER: FAVORITES</option>
+          <option value="all">ALL</option>
+          <option value="arcade">ARCADE</option>
+          <option value="pvp">PVP</option>
+          <option value="casino">CASINO</option>
+          <option value="skill">SKILL</option>
+          <option value="favorites">FAVORITES</option>
         </select>
         <select id="gamesSort" class="term-input games-select">
-          <option value="az">SORT: A-Z</option>
-          <option value="za">SORT: Z-A</option>
-          <option value="recent">SORT: RECENT</option>
-          <option value="favorite">SORT: FAVORITED FIRST</option>
+          <option value="az">A-Z</option>
+          <option value="za">Z-A</option>
+          <option value="recent">RECENT</option>
+          <option value="favorite">FAVORITED FIRST</option>
         </select>
         <button id="gamesClearFilters" class="term-btn games-clear" type="button">
           RESET


### PR DESCRIPTION
### Motivation
- Clean up the games directory UI by removing the redundant "FILTER:" and "SORT:" prefixes from dropdown option labels to make them shorter and easier to scan. 
- Preserve existing dropdown behavior and values so filtering and sorting continue to work unchanged.

### Description
- Modified `index.html` to replace option labels in the `#gamesFilter` control from `FILTER: ...` to just the category names (e.g., `ALL`, `ARCADE`, `PVP`).
- Modified `index.html` to replace option labels in the `#gamesSort` control from `SORT: ...` to just the sort labels (e.g., `A-Z`, `RECENT`).
- Left all `value` attributes and JavaScript logic unchanged so functionality is preserved.

### Testing
- Verified no remaining `FILTER:` or `SORT:` prefixes were found using `rg`, which returned no matches.
- Served the site locally with `python3 -m http.server` and ran a Playwright script to load `/index.html` and capture a screenshot, which completed successfully.
- Observed successful HTTP 200 responses for page assets during the automated run, indicating the page rendered with the updated labels.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab69dc73083228179c27c1c5e6548)