### PR TITLE
Hide top menu while game overlays are active

### DIFF
--- a/script.js
+++ b/script.js
@@ -475,8 +475,11 @@ function initTopBarOverlayControls() {
 
   function updateControls() {
     const activeOverlay = getActiveOverlay();
+    const inGameOverlay = Boolean(activeOverlay && GAME_OVERLAY_IDS.includes(activeOverlay.id));
     const canFullscreen = isFullscreenApplicable(activeOverlay);
     const exitTab = getExitTabButton(activeOverlay);
+
+    document.body.classList.toggle("game-active", inGameOverlay);
 
     topTabs.forEach((button) => {
       button.dataset.exitMode = "0";

--- a/styles.css
+++ b/styles.css
@@ -246,6 +246,10 @@ body::before {
   gap: 8px;
 }
 
+body.game-active .top-bar {
+  display: none;
+}
+
 /* Games dropdown menu anchored to the top bar. */
 .dropdown-content {
   display: none !important;


### PR DESCRIPTION
### Motivation
- Reduce UI clutter and avoid navigation overlap while a game is active by hiding the main top navigation when any game overlay is open.

### Description
- Toggle a `game-active` class on `<body>` from the shared top-bar control updater (`updateControls` in `script.js`) when the active overlay is one of `GAME_OVERLAY_IDS`, and add a CSS rule `body.game-active .top-bar { display: none; }` in `styles.css` to hide the top bar.

### Testing
- Launched a local server with `python3 -m http.server 4173` and ran a Playwright script that loaded the page, executed `window.launchGame('pong')`, and captured `artifacts/game-menu-hidden.png`, which confirms the top bar is hidden while the game overlay is active (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aba68b4848322a81eca3df12bce32)