### PR TITLE
Add searchable update log and quick site menu/page finder

### DIFF
--- a/core.js
+++ b/core.js
@@ -1693,12 +1693,11 @@ async function refreshUpdateLogFromMergedPrs() {
 }
 
 function initSiteSearch() {
-  const triggerBtn = document.getElementById("tabQuickSearch");
+  const searchInput = document.getElementById("topSiteSearchInput");
   const dropdown = document.getElementById("siteSearchDropdown");
-  const input = document.getElementById("siteSearchInput");
   const results = document.getElementById("siteSearchResults");
-  if (!triggerBtn || !dropdown || !input || !results || triggerBtn.dataset.ready === "1") return;
-  triggerBtn.dataset.ready = "1";
+  if (!searchInput || !dropdown || !results || searchInput.dataset.ready === "1") return;
+  searchInput.dataset.ready = "1";
 
   const buildIndex = () => {
     const seen = new Set();
@@ -1739,16 +1738,25 @@ function initSiteSearch() {
       : '<div class="search-dropdown-empty">NO MATCHING MENU OR PAGE.</div>';
   };
 
-  triggerBtn.addEventListener("click", (event) => {
-    event.stopPropagation();
-    dropdown.classList.toggle("show");
-    if (dropdown.classList.contains("show")) {
-      renderResults(input.value);
-      input.focus();
-    }
+  searchInput.addEventListener("focus", () => {
+    dropdown.classList.add("show");
+    renderResults(searchInput.value);
   });
 
-  input.addEventListener("input", () => renderResults(input.value));
+  searchInput.addEventListener("input", () => {
+    dropdown.classList.add("show");
+    renderResults(searchInput.value);
+  });
+
+  searchInput.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter") return;
+    const first = results.querySelector("[data-overlay-id]");
+    const overlayId = String(first?.dataset.overlayId || "");
+    if (!overlayId) return;
+    openGame(overlayId);
+    dropdown.classList.remove("show");
+  });
+
   results.addEventListener("click", (event) => {
     const button = event.target.closest("[data-overlay-id]");
     const overlayId = String(button?.dataset.overlayId || "");
@@ -1758,7 +1766,7 @@ function initSiteSearch() {
   });
 
   document.addEventListener("click", (event) => {
-    if (!event.target.closest("#siteSearchDropdown") && !event.target.closest("#tabQuickSearch")) {
+    if (!event.target.closest("#siteSearchDropdown") && !event.target.closest("#topSiteSearchInput")) {
       dropdown.classList.remove("show");
     }
   });

--- a/index.html
+++ b/index.html
@@ -31,9 +31,13 @@
       <button id="tabConfig" class="menu-btn" onclick="window.openGame('overlayConfig')">
         CONFIG
       </button>
-      <button id="tabQuickSearch" class="menu-btn" type="button">
-        SEARCH
-      </button>
+      <input
+        id="topSiteSearchInput"
+        class="term-input top-site-search-input"
+        type="text"
+        placeholder="SEARCH MENU/PAGE..."
+        maxlength="50"
+      />
       <div class="sys-info">
         <span id="sysClock">00:00:00</span> | PING:
         <span id="sysPing">24ms</span> | BANK: $<span id="globalBank">0</span>
@@ -79,7 +83,6 @@
 
     <div class="dropdown-content" id="menuDropdown"></div>
     <div class="dropdown-content search-dropdown" id="siteSearchDropdown">
-      <input id="siteSearchInput" class="term-input" type="text" placeholder="FIND MENU OR PAGE..." maxlength="50" />
       <div id="siteSearchResults" class="search-dropdown-results"></div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -250,6 +250,12 @@ body::before {
   gap: 8px;
 }
 
+.top-site-search-input {
+  width: clamp(180px, 20vw, 280px);
+  margin: 0;
+  padding: 9px 10px;
+}
+
 /* Games dropdown menu anchored to the top bar. */
 .dropdown-content {
   display: none !important;
@@ -292,11 +298,6 @@ body::before {
   right: auto;
   left: 20px;
   top: 50px;
-}
-
-.search-dropdown .term-input {
-  width: 100%;
-  margin-bottom: 8px;
 }
 
 .search-dropdown-results {


### PR DESCRIPTION
### Motivation
- Provide a way to search the full update log (merged PR history) and add a quick site finder in the top bar so users can jump to any menu/overlay by title or content.
- Prioritise matches on overlay/menu titles while also matching overlay content to improve discoverability across the UI.

### Description
- Added a top-bar `SEARCH` control and a dropdown finder that indexes overlays and shows ranked results; clicking a result opens the matching overlay (`index.html`, `core.js`, `styles.css`).
- Added an `UPDATE LOG // FULL HISTORY` search toolbar (input + reset) and implemented structured caching of merged PR entries with `renderUpdateLogRows` and `initUpdateLogSearch` to filter by title and body while keeping compact/full views synchronized (`core.js`, `index.html`).
- Implemented `initSiteSearch` which builds a lightweight overlay index, scores/ranks results (title-first weighting, then content), renders clickable result buttons, and closes the dropdown when overlays are closed (`core.js`).
- Added necessary CSS for the quick-search dropdown and update-log toolbar styling (`styles.css`) and wired initialization calls to `initUpdateLogSearch()` and `initSiteSearch()` during app startup.

### Testing
- Ran `node --check core.js` with no syntax errors (success).
- Launched a local server with `python -m http.server 8000` and attempted automated Playwright UI interactions to exercise the new finder and update-log search, but the browser-tooling run timed out in this environment (Playwright attempt failed due to timeout).
- Verified the code changes were applied to `index.html`, `core.js`, and `styles.css` and that the app initialization now calls the new search init functions (static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac637499c83228531e27d2e4473a5)