### PR TITLE
Normalize update-log rows to avoid `#? UNTITLED CHANGE` placeholders

### DIFF
--- a/core.js
+++ b/core.js
@@ -1599,6 +1599,19 @@ async function fetchMergedPullRequests(owner, repo, maxPages = 6) {
 
 let mergedUpdateLogRows = [];
 
+function normalizeUpdateLogRow(row, fallbackNumber = "?") {
+  const rowObj = row && typeof row === "object" ? row : {};
+  const rawNumber = rowObj.number ?? rowObj.pull_number ?? rowObj.id ?? fallbackNumber;
+  const normalizedDigits = String(rawNumber).match(/\d+/)?.[0];
+  const number = `#${normalizedDigits || String(fallbackNumber).replace(/^#/, "") || "?"}`;
+
+  const rawTitle = rowObj.title ?? rowObj.name ?? rowObj.message ?? rowObj.body;
+  const cleanedTitle = String(rawTitle || "").trim();
+  const title = cleanedTitle || `CHANGE ${number}`;
+
+  return { number, title };
+}
+
 function renderFullUpdateLogRows(searchTerm = "") {
   const fullList = document.getElementById("updateLogFullList");
   const fullMeta = document.getElementById("updateLogFullMeta");
@@ -1651,10 +1664,7 @@ async function refreshUpdateLogFromMergedPrs() {
     const cached = JSON.parse(localStorage.getItem(cacheKey) || "null");
     if (cached && Date.now() - Number(cached.ts || 0) < cacheTtlMs && Array.isArray(cached.rows) && Array.isArray(cached.allRows)) {
       list.innerHTML = cached.rows.join("");
-      mergedUpdateLogRows = cached.allRows.map((row) => ({
-        number: String(row.number || "#?"),
-        title: String(row.title || "UNTITLED CHANGE"),
-      }));
+      mergedUpdateLogRows = cached.allRows.map((row, index) => normalizeUpdateLogRow(row, index + 1));
       renderFullUpdateLogRows(input?.value || "");
       return;
     }
@@ -1670,11 +1680,13 @@ async function refreshUpdateLogFromMergedPrs() {
       return;
     }
 
-    const allRows = merged.map((pr) => {
-      const title = String(pr.title || "UNTITLED CHANGE");
-      const match = title.match(/commit\s*#?\s*(\d+)/i);
-      const rowNumber = `#${match ? match[1] : String(pr.number || "?")}`;
-      return { number: rowNumber, title };
+    const allRows = merged.map((pr, index) => {
+      const normalized = normalizeUpdateLogRow(pr, index + 1);
+      const match = normalized.title.match(/commit\s*#?\s*(\d+)/i);
+      return {
+        ...normalized,
+        number: match ? `#${match[1]}` : normalized.number,
+      };
     });
 
     mergedUpdateLogRows = allRows;


### PR DESCRIPTION
### Motivation
- The full update-log history was showing placeholder rows like `#? UNTITLED CHANGE` when PR metadata or cached rows were missing or malformed.
- Provide stable fallbacks for row numbers and titles so the update log is readable even when source objects lack expected fields.

### Description
- Added `normalizeUpdateLogRow(row, fallbackNumber)` to derive a stable `number` (like `#123`) and a non-empty `title` (defaults to `CHANGE #n`) from various possible row shapes.
- Use `normalizeUpdateLogRow` when loading cached rows from `localStorage` so stale or partial cache entries are sanitized before rendering.
- Use `normalizeUpdateLogRow` when mapping merged PRs and then re-run existing commit-number extraction against the normalized title to preserve previous numbering behavior.

### Testing
- Ran `node --check core.js` which completed without syntax errors.
- Launched a local static server with `python3 -m http.server 4173` and loaded the site, and captured a full-page screenshot via an automated Playwright script to verify the update-log UI rendered correctly.
- Verified the update-log rendering flow with the new normalization logic while exercising cached and live PR paths (no errors observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acdb34d208322a2381db8193182ea)