### PR TITLE
Move notifications/achievement toasts under top bar on the right

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2214,9 +2214,12 @@ canvas {
 
 #toastBox {
   position: fixed;
-  bottom: 30px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: calc(var(--topbar-clearance) + 14px);
+  right: 18px;
+  bottom: auto;
+  left: auto;
+  transform: none;
+  max-width: 340px;
   z-index: 9999;
   display: flex;
   flex-direction: column;
@@ -2225,12 +2228,13 @@ canvas {
 }
 .toast {
   background: rgba(0, 0, 0, 0.95);
-  border: 2px solid var(--accent);
+  border: 1px solid var(--accent);
   color: var(--accent);
-  padding: 15px 25px;
-  min-width: 300px;
+  min-width: 220px;
+  max-width: 340px;
+  padding: 10px 14px;
   text-align: center;
-  box-shadow: 0 0 20px var(--accent-glow);
+  box-shadow: 0 0 10px var(--accent-glow);
   display: flex;
   align-items: center;
   gap: 15px;
@@ -2255,20 +2259,7 @@ canvas {
 }
 
 #toastBox.in-game {
-  top: 18px;
-  right: 18px;
-  bottom: auto;
-  left: auto;
-  transform: none;
-  max-width: 340px;
-}
-
-#toastBox.in-game .toast {
-  min-width: 220px;
-  max-width: 340px;
-  padding: 10px 14px;
-  border-width: 1px;
-  box-shadow: 0 0 10px var(--accent-glow);
+  top: calc(var(--topbar-clearance) + 14px);
 }
 
 #toastBox.in-game .toast-icon {


### PR DESCRIPTION
### Motivation

- Place transient notifications and achievement toasts in the top-right area directly beneath the global top bar for better visibility and consistency.
- Ensure achievement unlocks and other toasts share the same anchored location and visual rhythm.
- Make the toast card styling more compact so stacked notifications fit a right-column layout.

### Description

- Updated `styles.css` to reposition `#toastBox` from the bottom-center to `top: calc(var(--topbar-clearance) + 14px)` with `right: 18px` and constrained width via `max-width: 340px`.
- Unified `.toast` sizing and visuals by setting `min-width`, `max-width`, smaller `padding`, a lighter border, and a reduced glow to match the new placement.
- Simplified the in-game override so `#toastBox.in-game` uses the same anchored top-right position instead of duplicating full layout rules.
- Changes are limited to styling (`styles.css`) and were committed to the repository.

### Testing

- Verified the style diff with `git diff -- styles.css` which showed the `#toastBox` and `.toast` updates and succeeded.
- Launched a local static server with `python -m http.server 4173 --bind 0.0.0.0` and confirmed it served the app.
- Ran a Playwright script that opened `index.html`, invoked `showToast(...)`, and captured `artifacts/top-right-notifications.png`, confirming toasts render in the new top-right location.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad4970cb083229ddcfbdb3de08f84)