### PR TITLE
Unify Blackjack mode selection with shared game menu UI

### DIFF
--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -28,14 +28,16 @@ let soloRounds = 0;
 const suits = ["♠", "♥", "♦", "♣"];
 const values = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"];
 
-// Initialize Blackjack overlay into mode select.
+// Initialize Blackjack overlay into the unified game menu.
 export function initBJ() {
   state.currentGame = "blackjack";
+  bjMode = "solo";
   bjCurrentBet = 0;
-  document.getElementById("bjMode").style.display = "flex";
-  document.getElementById("bjNetMenu").style.display = "none";
+  document.getElementById("bjMenu").style.display = "flex";
   document.getElementById("bjLobby").style.display = "none";
   document.getElementById("bjTable").style.display = "none";
+  document.querySelector(".bj-pot-display").style.display = "none";
+  document.getElementById("bjSide").innerHTML = "";
   updBJ();
 }
 
@@ -48,10 +50,10 @@ function cleanupBJ() {
   bjLastPhase = "";
 }
 
-// Select solo or multiplayer mode from the UI.
+// Select solo or multiplayer mode from the unified Blackjack menu.
 window.bjSelect = (mode) => {
   bjMode = mode;
-  document.getElementById("bjMode").style.display = "none";
+  document.getElementById("bjMenu").style.display = "none";
   if (mode === "solo") {
     document.getElementById("bjTable").style.display = "flex";
     setText("bjHostLabel", "DEALER");
@@ -60,7 +62,6 @@ window.bjSelect = (mode) => {
     startSoloBetting();
   } else {
     document.querySelector(".bj-pot-display").style.display = "block";
-    document.getElementById("bjNetMenu").style.display = "flex";
   }
   beep(400, "square", 0.1);
 };
@@ -204,6 +205,7 @@ function getBJRef(code) {
 
 // Create a new multiplayer Blackjack room as seat 0.
 document.getElementById("btnCreateBJ").onclick = async () => {
+  bjMode = "multi";
   if (!state.myUid) return showToast("OFFLINE", "⚠️", "Connect to Firebase to play online.");
   const code = Math.floor(1000 + Math.random() * 9000).toString();
   const seats = [
@@ -218,6 +220,7 @@ document.getElementById("btnCreateBJ").onclick = async () => {
 
 // Join an existing Blackjack room if a seat is open.
 document.getElementById("btnJoinBJ").onclick = async () => {
+  bjMode = "multi";
   const code = document.getElementById("joinBJCode").value;
   const ref = getBJRef(code);
   await runTransaction(firebase.db, async (t) => {
@@ -250,7 +253,7 @@ document.getElementById("btnJoinBJ").onclick = async () => {
 function joinBJ(code, idx) {
   bjRoomCode = code;
   bjMySeatIdx = idx;
-  document.getElementById("bjNetMenu").style.display = "none";
+  document.getElementById("bjMenu").style.display = "none";
   document.getElementById("bjLobby").style.display = "flex";
   setText("bjRoomId", code);
   if (bjRoomUnsub) bjRoomUnsub();
@@ -393,6 +396,8 @@ function handleBJUpdate(d) {
 document.getElementById("bjStartBtn").onclick = async () => {
   await updateDoc(getBJRef(bjRoomCode), { phase: "betting" });
 };
+
+document.getElementById("btnBJSolo").onclick = () => window.bjSelect("solo");
 
 // Deck click handler for both solo and multiplayer flows.
 document.getElementById("bjDeck").onclick = async () => {

--- a/index.html
+++ b/index.html
@@ -1414,16 +1414,7 @@
     <!-- Solo + multiplayer Blackjack overlay. -->
     <div class="overlay" id="overlayBlackjack">
       <h1>BLACKJACK</h1>
-      <div id="bjMode" class="menu-box">
-        <button class="term-btn" onclick="window.bjSelect('solo')">
-          SOLO (VS DEALER)
-        </button>
-        <br /><br />
-        <button class="term-btn" onclick="window.bjSelect('multi')">
-          PVP (4 PLAYER)
-        </button>
-      </div>
-      <div id="bjNetMenu" class="menu-box" style="display: none">
+      <div id="bjMenu" class="menu-box">
         <button class="term-btn" id="btnCreateBJ">CREATE TABLE</button>
         <p>- OR -</p>
         <input
@@ -1434,6 +1425,7 @@
           maxlength="4"
         />
         <button class="term-btn" id="btnJoinBJ">JOIN TABLE</button>
+        <button class="menu-btn" id="btnBJSolo" style="margin-top: 10px">SINGLEPLAYER VS DEALER</button>
       </div>
       <div id="bjLobby" class="menu-box" style="display: none">
         <h2>ROOM: <span id="bjRoomId">????</span></h2>


### PR DESCRIPTION
### Motivation
- Make Blackjack use the same Create/Join/Singleplayer menu pattern as other games so mode selection is consistent across the UI.
- Remove the old two-step Blackjack mode picker and avoid duplicate network/singleplayer screens.

### Description
- Replaced the old `bjMode` / `bjNetMenu` UI with a unified `bjMenu` element in `index.html` and added a `SINGLEPLAYER VS DEALER` button (`btnBJSolo`).
- Updated `initBJ()` to show `bjMenu` by default, reset table UI state, and set `bjMode = "solo"` on open in `games/blackjack.js`.
- Made multiplayer entry points explicitly set `bjMode = "multi"` when `btnCreateBJ` or `btnJoinBJ` are used, and switched join/create flows to hide `bjMenu` and show the lobby.
- Added `document.getElementById("btnBJSolo").onclick = () => window.bjSelect("solo")` and adjusted deck/menu visibility logic to work with the new unified menu.

### Testing
- Ran `node --check games/blackjack.js` which completed successfully.  
- Ran `node --check script.js` which completed successfully.  
- Attempted to capture a UI screenshot with Playwright, but the browser could not load the local server and the run failed with `net::ERR_EMPTY_RESPONSE` (environment issue, not code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad79055a88322a7f92923628e1845)