### PR TITLE
Add per-day headings in full update log history

### DIFF
--- a/core.js
+++ b/core.js
@@ -1634,7 +1634,21 @@ function normalizeUpdateLogRow(row, fallbackNumber = "?") {
   const cleanedTitle = String(rawTitle || "").trim();
   const title = cleanedTitle || `CHANGE ${number}`;
 
-  return { number, title };
+  const mergedAtRaw = rowObj.mergedAt ?? rowObj.merged_at ?? rowObj.date;
+  const mergedAtMs = Date.parse(String(mergedAtRaw || ""));
+  const mergedAt = Number.isFinite(mergedAtMs) ? new Date(mergedAtMs).toISOString() : "";
+
+  return { number, title, mergedAt };
+}
+
+function formatUpdateLogDateHeading(isoDate) {
+  const parsed = Date.parse(String(isoDate || ""));
+  if (!Number.isFinite(parsed)) return "UNKNOWN DATE";
+  return new Date(parsed).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }
 
 function renderFullUpdateLogRows(searchTerm = "") {
@@ -1653,7 +1667,17 @@ function renderFullUpdateLogRows(searchTerm = "") {
     return;
   }
 
-  fullList.innerHTML = rows.map((row) => `<li><span>${escapeHtml(row.number)}</span> ${escapeHtml(row.title)}</li>`).join("");
+  let previousDateHeading = "";
+  fullList.innerHTML = rows
+    .map((row) => {
+      const dateHeading = formatUpdateLogDateHeading(row.mergedAt);
+      const dateRow = dateHeading !== previousDateHeading
+        ? `<li class="update-log-day-title">${escapeHtml(dateHeading)}</li>`
+        : "";
+      previousDateHeading = dateHeading;
+      return `${dateRow}<li><span>${escapeHtml(row.number)}</span> ${escapeHtml(row.title)}</li>`;
+    })
+    .join("");
   fullMeta.innerText = normalizedQuery
     ? `SHOWING ${rows.length} OF ${mergedUpdateLogRows.length} MERGED UPDATES`
     : `SHOWING ${rows.length} MERGED UPDATES`;

--- a/styles.css
+++ b/styles.css
@@ -711,6 +711,14 @@ body::before {
   color: var(--accent);
 }
 
+.update-log-scroll li.update-log-day-title {
+  list-style: none;
+  text-align: center;
+  color: rgba(220, 255, 235, 0.65);
+  letter-spacing: 0.8px;
+  margin: 4px 0;
+}
+
 .panel-overlay-exit {
   display: block !important;
   margin-top: 12px;


### PR DESCRIPTION
### Motivation
- Improve the readability of the full update-log history by grouping merged updates by their merge day so users can visually scan changes per-date.

### Description
- Enhanced `normalizeUpdateLogRow` to extract and normalize a merge timestamp (`mergedAt`) from multiple possible fields (`mergedAt`, `merged_at`, or `date`) and return it with the row metadata in `core.js`.
- Added `formatUpdateLogDateHeading` to format ISO dates into human-friendly headings (e.g. `February 22, 2026`) in `core.js`.
- Updated `renderFullUpdateLogRows` to inject a centered date heading row before the first update of each distinct day when rendering the full history list in `core.js`.
- Added styling for the new heading rows with the `.update-log-day-title` selector in `styles.css` to make day titles lighter, centered, and visually separated from regular entries.

### Testing
- Ran `node --check core.js` to validate JavaScript syntax; the check passed.
- Served the site locally with `python3 -m http.server 4173 --directory /workspace/webstie` and used an automated browser script to open the Update Log overlay and verify the new headings; the automation successfully captured a screenshot showing the new per-day headings.
- The update log overlay loads and the full-history rendering with day separators was exercised via the Playwright script (screenshot captured), with no runtime errors observed during the verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b62e883488322b575341c0c505d80)