### PR TITLE
Fix hidden multiplayer lobby start buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3411,9 +3411,7 @@ body.reduce-motion *::after {
 
 /* Remove bottom utility bar elements inside game overlays. */
 .overlay .mobile-hint.active,
-.overlay .term-btn[id$="Action"],
-.overlay .term-btn[id$="StartBtn"],
-.overlay .term-btn[id$="startBtn"] {
+.overlay .term-btn[id$="Action"] {
   display: none !important;
   visibility: hidden !important;
   height: 0 !important;


### PR DESCRIPTION
### Motivation
- Multiplayer lobby host controls ("START GAME" / "START RACE" / similar) were unintentionally hidden by an over-broad CSS rule that targeted `.term-btn` selectors ending in `StartBtn`/`startBtn` inside overlays.
- The intent is to hide legacy utility buttons only, not functional lobby start buttons, so the CSS needed narrowing to restore lobby functionality.

### Description
- Updated `styles.css` to remove ` .overlay .term-btn[id$="StartBtn"]` and ` .overlay .term-btn[id$="startBtn"]` from the combined selector so only ` .overlay .term-btn[id$="Action"]` is hidden.
- This change stops hiding legitimate overlay start buttons while preserving the hiding of legacy utility action buttons.
- The modification is limited to the selector block around the comment `/* Remove bottom utility bar elements inside game overlays. */` (lines ~3412-3422).

### Testing
- Confirmed the CSS change with `rg` to ensure `StartBtn`/`startBtn` selectors were removed from the hide rule and only `Action` remains, which succeeded.
- Served the site locally with `python3 -m http.server 4173` and rendered `index.html` in a headless browser to visually verify a lobby "START" button is visible, which succeeded and produced a screenshot.
- Verified the repo diff shows only the intended selector narrowing in `styles.css`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc8ed2e5c832baa53516a8b53c114)