### PR TITLE
Fix DM and crew chat loading by removing index-heavy queries

### DIFF
--- a/core.js
+++ b/core.js
@@ -4571,7 +4571,8 @@ function getChatTabConfig(tab) {
       label: "MESSAGES",
       placeholder: "@USER MESSAGE...",
       meta: "DIRECT MESSAGES // USE @USERNAME MESSAGE",
-      getQuery: () => query(collection(db, "gooner_user_chat"), where("participants", "array-contains", normalizeUsername(myName)), orderBy("ts", "desc"), limit(25)),
+      // Keep DM queries index-light so chats work without requiring a composite Firestore index.
+      getQuery: () => query(collection(db, "gooner_user_chat"), where("participants", "array-contains", normalizeUsername(myName)), limit(80)),
       send: (txt) => {
         const match = txt.match(/^@([A-Za-z0-9_\-]{2,16})\s+(.+)$/);
         if (!match) return { error: "USE @USERNAME FOLLOWED BY A MESSAGE." };
@@ -4609,7 +4610,8 @@ function getChatTabConfig(tab) {
       meta: crewTag ? `CREW CHANNEL [${crewTag}]` : "CREW CHANNEL // JOIN A CREW TO CHAT",
       getQuery: () => {
         if (!crewTag) return null;
-        return query(collection(db, "gooner_crew_chat"), where("crewTag", "==", crewTag), orderBy("ts", "desc"), limit(25));
+        // Keep crew queries index-light so chats work without requiring a composite Firestore index.
+        return query(collection(db, "gooner_crew_chat"), where("crewTag", "==", crewTag), limit(80));
       },
       send: (txt) => {
         if (!crewTag) return { error: "JOIN A CREW BEFORE USING CREW CHAT." };
@@ -4649,14 +4651,17 @@ function renderChatTab() {
     const muted = getChatSet(CHAT_MUTED_KEY);
     const msgs = [];
     snap.forEach((d) => msgs.push(d.data()));
-    msgs.reverse().forEach((m) => {
+    msgs
+      .sort((a, b) => Number(a?.ts || 0) - Number(b?.ts || 0))
+      .slice(-25)
+      .forEach((m) => {
       const user = normalizeUsername(m.user || "ANON");
       if (blocklist.has(user) || muted.has(user)) return;
       const d = document.createElement("div");
       d.className = "chat-msg";
       d.innerHTML = tabConfig.renderMessage(m);
       list.appendChild(d);
-    });
+      });
     list.scrollTop = list.scrollHeight;
   });
 }


### PR DESCRIPTION
### Motivation
- DM and crew chat queries used `where(...) + orderBy(...)` which requires composite Firestore indexes and can fail to load for users without those indexes.
- Make DM, crew, and UI-side handling resilient so private messages and crew chat work reliably without extra backend index configuration.

### Description
- Changed the DM query to `query(collection(db, "gooner_user_chat"), where("participants", "array-contains", normalizeUsername(myName)), limit(80))` to avoid `orderBy` index dependency.
- Changed the crew query to `query(collection(db, "gooner_crew_chat"), where("crewTag", "==", crewTag), limit(80))` to avoid `orderBy` index dependency.
- Added client-side ordering by timestamp and trimmed results with `.sort((a,b)=>Number(a?.ts||0)-Number(b?.ts||0)).slice(-25)` so displayed messages remain chronological.

### Testing
- Ran `node --check core.js` which completed successfully.
- Attempted automated browser rendering via a local `python3 -m http.server` and Playwright screenshot, but the local HTTP server did not remain available so the browser test could not complete (failure recorded).
- Committed the change and created this PR after validating static syntax checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dcc62e4f8832b8bd397cc1b2e0bc4)