### PR TITLE
Add official-inspired level list to Geo Dash

### DIFF
--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -1,5 +1,5 @@
 export const GAME_DIRECTORY_ENTRIES = Object.freeze([
-  { id: "geo", title: "GEO DASH", description: "Dodge spikes and survive speed ramps.", icon: "🟨", tags: ["arcade", "skill", "platformer", "reflex"], shopItems: ["item_slowmo"] },
+  { id: "geo", title: "GEO DASH", description: "Play official-style levels from Stereo Madness to Dash.", icon: "🟨", tags: ["arcade", "skill", "platformer", "reflex"], shopItems: ["item_slowmo"] },
   { id: "type", title: "TYPE RUNNER", description: "Type fast to outrun incoming threats.", icon: "⌨️", tags: ["arcade", "skill", "typing", "reflex"], shopItems: ["item_autotype"] },
   { id: "pong", title: "PONG", description: "Retro paddle battle with adjustable difficulty.", icon: "🏓", tags: ["arcade", "pvp", "retro", "duel"], shopItems: ["item_aimbot"] },
   { id: "snake", title: "SNAKE", description: "Grow longer while avoiding walls and yourself.", icon: "🐍", tags: ["arcade", "skill"], shopItems: ["item_double"] },

--- a/games/geo.js
+++ b/games/geo.js
@@ -1,4 +1,4 @@
-// Geometry-inspired endless runner with rotating cube and obstacles.
+// Geometry-inspired endless runner with rotating cube and themed level presets.
 import {
   registerGameStop,
   showGameOver,
@@ -10,6 +10,31 @@ import {
   state,
   hasActiveItem,
 } from "../core.js";
+
+const GEO_LEVELS = [
+  { id: "stereo_madness", name: "Stereo Madness", speed: 5.2, gravity: 0.85, jump: 12, pattern: ["block", "spike", "gap", "block"] },
+  { id: "back_on_track", name: "Back on Track", speed: 5.4, gravity: 0.88, jump: 12.2, pattern: ["spike", "gap", "block", "spike"] },
+  { id: "polargeist", name: "Polargeist", speed: 5.6, gravity: 0.9, jump: 12.2, pattern: ["spike", "spike", "gap", "block"] },
+  { id: "dry_out", name: "Dry Out", speed: 5.7, gravity: 0.92, jump: 12.4, pattern: ["block", "gap", "spike", "spike"] },
+  { id: "base_after_base", name: "Base After Base", speed: 5.8, gravity: 0.93, jump: 12.5, pattern: ["block", "spike", "block", "gap"] },
+  { id: "cant_let_go", name: "Can't Let Go", speed: 6, gravity: 0.95, jump: 12.8, pattern: ["spike", "block", "spike", "gap"] },
+  { id: "jumper", name: "Jumper", speed: 6.1, gravity: 0.96, jump: 12.8, pattern: ["gap", "spike", "block", "spike"] },
+  { id: "time_machine", name: "Time Machine", speed: 6.3, gravity: 1, jump: 13, pattern: ["spike", "spike", "block", "gap"] },
+  { id: "cycles", name: "Cycles", speed: 6.4, gravity: 1, jump: 13, pattern: ["block", "spike", "spike", "gap"] },
+  { id: "xstep", name: "xStep", speed: 6.5, gravity: 1.01, jump: 13, pattern: ["spike", "gap", "spike", "block"] },
+  { id: "clutterfunk", name: "Clutterfunk", speed: 6.8, gravity: 1.02, jump: 13.1, pattern: ["spike", "spike", "spike", "gap"] },
+  { id: "toe", name: "Theory of Everything", speed: 6.9, gravity: 1.02, jump: 13.1, pattern: ["block", "spike", "spike", "block"] },
+  { id: "electroman", name: "Electroman Adventures", speed: 7, gravity: 1.03, jump: 13.2, pattern: ["gap", "block", "spike", "spike"] },
+  { id: "clubstep", name: "Clubstep", speed: 7.2, gravity: 1.03, jump: 13.2, pattern: ["spike", "spike", "block", "spike"] },
+  { id: "electrodynamix", name: "Electrodynamix", speed: 7.3, gravity: 1.04, jump: 13.3, pattern: ["spike", "gap", "spike", "spike"] },
+  { id: "hexagon_force", name: "Hexagon Force", speed: 7.4, gravity: 1.04, jump: 13.3, pattern: ["block", "spike", "gap", "spike"] },
+  { id: "blast_processing", name: "Blast Processing", speed: 7.5, gravity: 1.05, jump: 13.4, pattern: ["gap", "spike", "gap", "block"] },
+  { id: "toe2", name: "Theory of Everything 2", speed: 7.6, gravity: 1.05, jump: 13.5, pattern: ["spike", "spike", "gap", "spike"] },
+  { id: "geometrical_dominator", name: "Geometrical Dominator", speed: 7.7, gravity: 1.06, jump: 13.5, pattern: ["block", "block", "spike", "gap"] },
+  { id: "deadlocked", name: "Deadlocked", speed: 7.9, gravity: 1.07, jump: 13.6, pattern: ["spike", "spike", "spike", "block"] },
+  { id: "fingerdash", name: "Fingerdash", speed: 8, gravity: 1.08, jump: 13.6, pattern: ["gap", "spike", "block", "spike"] },
+  { id: "dash", name: "Dash", speed: 8.2, gravity: 1.1, jump: 13.8, pattern: ["spike", "block", "spike", "spike"] },
+];
 
 let gPlayer = {};
 let gObs = [];
@@ -24,6 +49,9 @@ let gOverlayRef = null;
 let gSpawnDistanceRemaining = 0;
 let gLastTime = 0;
 let geoStarted = false;
+let gLevelPatternIndex = 0;
+let gCurrentLevel = GEO_LEVELS[0];
+let gLevelSelectRef = null;
 
 const BASE_FRAME_MS = 1000 / 60;
 const MAX_DT_FRAMES = 2.5;
@@ -36,16 +64,57 @@ export function initGeometry() {
   if (gAnim) cancelAnimationFrame(gAnim);
   gCanvasRef = cv;
   gOverlayRef = document.getElementById("overlayGeo");
+  gLevelSelectRef = document.getElementById("geoLevelSelect");
+  ensureLevelSelector();
+  applySelectedLevel(gLevelSelectRef?.value || GEO_LEVELS[0].id);
   gPlayer = { x: 100, y: 300, w: 30, h: 30, dy: 0, ang: 0, grounded: true };
   gObs = [];
   gScore = 0;
-  gSpeed = 6;
   gSpawnDistanceRemaining = 0;
   gLastTime = 0;
+  gLevelPatternIndex = 0;
   geoStarted = false;
-  setText("geoScore", "SCORE: 0");
+  setText("geoScore", `LEVEL: ${gCurrentLevel.name} • SCORE: 0`);
   bindGeoControls();
   loopGeometry(ctx, performance.now());
+}
+
+function ensureLevelSelector() {
+  if (!gLevelSelectRef || gLevelSelectRef.dataset.ready === "1") return;
+  for (const level of GEO_LEVELS) {
+    const option = document.createElement("option");
+    option.value = level.id;
+    option.textContent = level.name;
+    gLevelSelectRef.appendChild(option);
+  }
+  gLevelSelectRef.value = gCurrentLevel.id;
+  gLevelSelectRef.addEventListener("change", () => {
+    if (state.currentGame !== "geo") return;
+    initGeometry();
+  });
+  gLevelSelectRef.dataset.ready = "1";
+}
+
+function applySelectedLevel(levelId) {
+  gCurrentLevel = GEO_LEVELS.find((level) => level.id === levelId) || GEO_LEVELS[0];
+  gSpeed = gCurrentLevel.speed;
+}
+
+function spawnObstacle() {
+  const spawnType = gCurrentLevel.pattern[gLevelPatternIndex % gCurrentLevel.pattern.length];
+  gLevelPatternIndex += 1;
+  if (spawnType === "gap") {
+    gSpawnDistanceRemaining = 120 + Math.random() * 100;
+    return;
+  }
+  gObs.push({
+    x: 800,
+    y: 320,
+    w: 30,
+    h: 30,
+    type: spawnType,
+  });
+  gSpawnDistanceRemaining = 140 + Math.random() * 90;
 }
 
 // Main loop for the geometry runner: physics, obstacles, rendering.
@@ -62,7 +131,7 @@ function loopGeometry(ctx, now) {
   ctx.fillStyle = "#000";
   ctx.fillRect(0, 0, 800, 400);
   const currentSpeed = gSpeed * (hasActiveItem("item_slowmo") ? 0.8 : 1);
-  gPlayer.dy += 0.9 * simDtFrames;
+  gPlayer.dy += gCurrentLevel.gravity * simDtFrames;
   gPlayer.y += gPlayer.dy * simDtFrames;
   if (gPlayer.y > 320) {
     gPlayer.y = 320;
@@ -85,16 +154,7 @@ function loopGeometry(ctx, now) {
   ctx.fillRect(-gPlayer.w / 2, -gPlayer.h / 2, gPlayer.w, gPlayer.h);
   ctx.restore();
   gSpawnDistanceRemaining -= currentSpeed * simDtFrames;
-  if (gSpawnDistanceRemaining <= 0 && Math.random() < 0.4) {
-    gObs.push({
-      x: 800,
-      y: 320,
-      w: 30,
-      h: 30,
-      type: Math.random() > 0.5 ? "spike" : "block",
-    });
-    gSpawnDistanceRemaining = 180 + Math.random() * 120;
-  }
+  if (gSpawnDistanceRemaining <= 0 && Math.random() < 0.7) spawnObstacle();
   for (let i = gObs.length - 1; i >= 0; i--) {
     const o = gObs[i];
     o.x -= currentSpeed * simDtFrames;
@@ -126,7 +186,7 @@ function loopGeometry(ctx, now) {
       gObs.splice(i, 1);
       gScore++;
       updateHighScore("geo", gScore);
-      setText("geoScore", "SCORE: " + gScore);
+      setText("geoScore", `LEVEL: ${gCurrentLevel.name} • SCORE: ${gScore}`);
     }
   }
   gAnim = requestAnimationFrame((nextNow) => loopGeometry(ctx, nextNow));
@@ -136,7 +196,7 @@ function loopGeometry(ctx, now) {
 function jumpGeo() {
   if (state.currentGame === "geo" && gPlayer.grounded) {
     geoStarted = true;
-    gPlayer.dy = -13;
+    gPlayer.dy = -gCurrentLevel.jump;
     gPlayer.grounded = false;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1069,6 +1069,10 @@
     <div class="overlay" id="overlayGeo">
       <h1>GEO DASH</h1>
       <div class="high-score-display">HIGH: <span id="hsGeo">0</span></div>
+      <div style="display: flex; justify-content: center; gap: 8px; margin-bottom: 10px; flex-wrap: wrap">
+        <label for="geoLevelSelect">LEVEL</label>
+        <select id="geoLevelSelect" class="menu-btn" style="padding: 4px 8px"></select>
+      </div>
       <div style="margin-bottom: 10px" id="geoScore">SCORE: 0</div>
       <canvas id="geoCanvas" width="800" height="400"></canvas>
       <div class="mobile-hint active" style="margin-top: 20px">


### PR DESCRIPTION
### Motivation
- Provide a set of official-style Geometry Dash stages (Stereo Madness → Dash) so players can play themed presets instead of a single generic endless mode. 
- Surface level selection in the UI so players can pick a stage before starting a run.

### Description
- Added a level selector UI to the Geo Dash overlay by updating `index.html` to include a `select` with id `geoLevelSelect` for choosing levels. 
- Reworked `games/geo.js` to include `GEO_LEVELS` presets with tuned `speed`, `gravity`, `jump` and `pattern` arrays, and replaced the single-mode spawn logic with `spawnObstacle()` driven by the chosen preset. 
- Wired level selection into `initGeometry()` and `ensureLevelSelector()` so changing the select reinitializes the game and `gCurrentLevel` settings are applied at runtime, and updated the score line to show the active level name. 
- Updated `gameCatalog.js` description for the `geo` entry to advertise the new official-style level set.

### Testing
- Ran static checks `node --check games/geo.js`, `node --check gameCatalog.js`, and `node --check script.js`, which all completed successfully. 
- Attempted an automated browser render / screenshot via Playwright, but the Chromium process crashed with a SIGSEGV in this environment, so the visual smoke test failed. 
- No other automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e3368151083319b44f0916407f694)