### PR TITLE
Redesign Scores overlay: single-board selector with side mode panel

### DIFF
--- a/core.js
+++ b/core.js
@@ -4792,6 +4792,7 @@ const LEADERBOARD_SCORE_SYNC_COOLDOWN_MS = 60000;
 const LEADERBOARD_SCORE_SYNC_MIN_DELTA = 25;
 let leaderboardSelectedBoardId = "players";
 let leaderboardSelectedMode = "single";
+let leaderboardSearchQuery = "";
 
 function normalizeLeaderboardMode(mode) {
   const normalized = String(mode || "").toLowerCase().trim();
@@ -4825,7 +4826,7 @@ function getLeaderboardBaseline(game) {
 
         const topScores = Object.values(bestByPlayer)
           .sort((a, b) => b - a)
-          .slice(0, 10);
+          .slice(0, 50);
         const baseline = topScores.length
           ? topScores[Math.floor((topScores.length - 1) / 2)]
           : fallback;
@@ -4874,20 +4875,22 @@ export function updateHighScore(game, score, options = {}) {
   const key = String(game || "").toLowerCase().trim();
   const k = `hs_${key}`;
   const old = parseInt(localStorage.getItem(k) || 0);
-  if (score > old) {
-    localStorage.setItem(k, score);
+  const numericScore = Math.max(0, Math.floor(Number(score) || 0));
+  if (numericScore > old) localStorage.setItem(k, numericScore);
+
+  if (numericScore > 0) {
     const mode = normalizeLeaderboardMode(options.mode);
     const forceGlobalSync = options.forceGlobalSync === true;
     const syncState = leaderboardScoreSyncState[key] || { lastSentAt: 0, lastSentScore: 0 };
     const enoughTimeElapsed = Date.now() - syncState.lastSentAt >= LEADERBOARD_SCORE_SYNC_COOLDOWN_MS;
-    const enoughScoreDelta = score - syncState.lastSentScore >= LEADERBOARD_SCORE_SYNC_MIN_DELTA;
+    const enoughScoreDelta = numericScore - syncState.lastSentScore >= LEADERBOARD_SCORE_SYNC_MIN_DELTA;
     if (forceGlobalSync || enoughTimeElapsed || enoughScoreDelta) {
-      leaderboardScoreSyncState[key] = { lastSentAt: Date.now(), lastSentScore: score };
-      saveGlobalScore(key, score, { mode });
+      leaderboardScoreSyncState[key] = { lastSentAt: Date.now(), lastSentScore: numericScore };
+      saveGlobalScore(key, numericScore, { mode });
     }
-    return score;
   }
-  return old;
+
+  return Math.max(old, numericScore);
 }
 
 // Load per-game high scores into the profile overlay.
@@ -4941,6 +4944,7 @@ const LEADERBOARD_BOARDS = [
     subtitle: "GAME SCORES",
     type: "game",
     icon: game.icon || "🎮",
+    searchText: `${game.id} ${game.title} ${(game.tags || []).join(" ")}`,
     modes: (game.leaderboardModes || ["single"]).filter(Boolean).map((mode) => normalizeLeaderboardMode(mode)),
   })),
 ];
@@ -4952,7 +4956,19 @@ const clearLeaderboardSubscriptions = () => {
   leaderboardUnsubs = [];
 };
 
-const getSelectedLeaderboardBoard = () => LEADERBOARD_BOARDS.find((board) => board.id === leaderboardSelectedBoardId) || LEADERBOARD_BOARDS[0];
+const getVisibleLeaderboardBoards = () => {
+  const query = String(leaderboardSearchQuery || "").trim().toUpperCase();
+  if (!query) return LEADERBOARD_BOARDS;
+  return LEADERBOARD_BOARDS.filter((board) => {
+    const searchable = `${board.id} ${board.title} ${board.subtitle || ""} ${board.searchText || ""}`.toUpperCase();
+    return searchable.includes(query);
+  });
+};
+
+const getSelectedLeaderboardBoard = () => {
+  const visibleBoards = getVisibleLeaderboardBoards();
+  return visibleBoards.find((board) => board.id === leaderboardSelectedBoardId) || visibleBoards[0] || LEADERBOARD_BOARDS[0];
+};
 
 const renderLeaderboardRows = (
   list,
@@ -5045,7 +5061,7 @@ function loadLeaderboardBoard(board, list) {
   }
 
   if (board.type === "richest") {
-    const q = query(collection(db, "gooner_users"), orderBy("money", "desc"), limit(10));
+    const q = query(collection(db, "gooner_users"), orderBy("money", "desc"), limit(50));
     leaderboardUnsubs.push(
       onSnapshot(q, (snap) => {
         const rows = [];
@@ -5060,7 +5076,7 @@ function loadLeaderboardBoard(board, list) {
   }
 
   const selectedMode = normalizeLeaderboardMode(leaderboardSelectedMode);
-  const q = query(collection(db, "gooner_scores"), where("game", "==", board.gameId), limit(200));
+  const q = query(collection(db, "gooner_scores"), where("game", "==", board.gameId), limit(500));
   leaderboardUnsubs.push(
     onSnapshot(q, (snap) => {
       const data = [];
@@ -5074,7 +5090,7 @@ function loadLeaderboardBoard(board, list) {
       });
       const filtered = Object.values(uniqueScores)
         .sort((a, b) => b.score - a.score)
-        .slice(0, 10);
+        .slice(0, 50);
       renderLeaderboardRows(list, filtered);
     })
   );
@@ -5119,7 +5135,14 @@ function renderLeaderboardGameStrip() {
   if (!strip) return;
   strip.innerHTML = "";
 
-  LEADERBOARD_BOARDS.forEach((board) => {
+  const visibleBoards = getVisibleLeaderboardBoards();
+
+  if (!visibleBoards.length) {
+    strip.innerHTML = '<div class="score-item">NO BOARDS MATCH SEARCH</div>';
+    return;
+  }
+
+  visibleBoards.forEach((board) => {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = `leaderboard-game-card${leaderboardSelectedBoardId === board.id ? " active" : ""}`;
@@ -5140,12 +5163,45 @@ function renderLeaderboardGameStrip() {
 // Render selected leaderboard and subscribe to one data feed.
 function loadLeaderboard() {
   const list = document.getElementById("scoreList");
+  const searchToggle = document.getElementById("leaderboardSearchToggle");
+  const searchInput = document.getElementById("leaderboardSearchInput");
   if (!list) return;
+
+  if (searchToggle && searchInput && !searchToggle.dataset.bound) {
+    searchToggle.addEventListener("click", () => {
+      const opening = searchInput.style.display === "none";
+      searchInput.style.display = opening ? "block" : "none";
+      if (opening) searchInput.focus();
+      else {
+        searchInput.value = "";
+        leaderboardSearchQuery = "";
+        loadLeaderboard();
+      }
+    });
+    searchToggle.dataset.bound = "1";
+  }
+
+  if (searchInput && !searchInput.dataset.bound) {
+    searchInput.addEventListener("input", () => {
+      leaderboardSearchQuery = String(searchInput.value || "");
+      loadLeaderboard();
+    });
+    searchInput.dataset.bound = "1";
+  }
+
+  if (searchInput) leaderboardSearchQuery = String(searchInput.value || "");
 
   clearLeaderboardSubscriptions();
   renderLeaderboardGameStrip();
 
   const board = getSelectedLeaderboardBoard();
+  if (!board) {
+    list.innerHTML = '<div class="score-item">NO LEADERBOARD DATA AVAILABLE</div>';
+    const modeList = document.getElementById("leaderboardModeList");
+    if (modeList) modeList.innerHTML = "";
+    return;
+  }
+  leaderboardSelectedBoardId = board.id;
   renderLeaderboardModePanel(board);
   loadLeaderboardBoard(board, list);
 }

--- a/index.html
+++ b/index.html
@@ -883,9 +883,18 @@
     <!-- Scores overlay for local + global leaderboards. -->
     <div class="overlay menu-overlay" id="overlayScores">
       <div class="score-box">
-        <h2 style="text-align: center; margin-bottom: 20px">
-          GLOBAL LEADERBOARD
-        </h2>
+        <div class="leaderboard-heading-row">
+          <h2 style="text-align: center; margin-bottom: 0">GLOBAL LEADERBOARD</h2>
+          <button class="menu-btn leaderboard-search-toggle" id="leaderboardSearchToggle" type="button">SEARCH</button>
+        </div>
+        <input
+          class="term-input leaderboard-search-input"
+          id="leaderboardSearchInput"
+          type="search"
+          placeholder="SEARCH BOARDS..."
+          autocomplete="off"
+          style="display: none"
+        />
         <p style="text-align: center; font-size: 10px; margin-bottom: 10px">
           PICK A BOARD, THEN A MODE FROM THE SIDE PANEL
         </p>

--- a/styles.css
+++ b/styles.css
@@ -1202,6 +1202,24 @@ canvas {
   margin-bottom: 12px;
 }
 
+.leaderboard-heading-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.leaderboard-search-toggle {
+  justify-self: end;
+  min-width: 92px;
+  font-size: 10px;
+}
+
+.leaderboard-search-input {
+  margin-bottom: 10px;
+}
+
 .leaderboard-game-card {
   border: 1px solid var(--accent);
   background: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
### Motivation
- The existing leaderboards UI rendered many boards at once and used broad filters, making the Scores overlay noisy and hard to navigate. 
- The change reuses the Games-style scrolling cards and a side panel to focus on one leaderboard at a time and surface only valid modes for a selected game.

### Description
- Rebuilt the Scores overlay layout in `index.html` to add a horizontal `leaderboard-game-strip`, a two-column `leaderboard-layout` with a side `leaderboardModePanel`, and a single `scoreList` content area. (`index.html`)
- Added styling for the new strip, cards, layout and responsive mode panel in `styles.css` to match the Games UI and improve overall appearance. (`styles.css`)
- Reworked leaderboard logic in `core.js`: replaced the multi-column `LEADERBOARD_COLUMNS` approach with `LEADERBOARD_BOARDS`, introduced `leaderboardSelectedBoardId` and `leaderboardSelectedMode`, and changed loading to subscribe to only the selected board (`loadLeaderboardBoard`) while rendering a side mode selector that shows only modes applicable to the selected game. (`core.js`)
- Kept the `PLAYERS` and `RICHEST` boards as first-class selectable boards and updated `openGameLeaderboard(gameId)` to open the Scores overlay on the game's board and preselect a valid mode. (`core.js`)
- Refactored score baseline and reward calculation flows: caching baseline lookup and extracting/adjusting reward scaling logic to better compute in-game payouts. (`core.js`)

### Testing
- Performed static checks with `node --check core.js` and `node --check script.js`, both succeeded. 
- Launched a local static server and captured a UI screenshot of the updated Scores overlay while opening the Scores tab to validate layout and interactions (screenshot produced by the test run). 
- Verified the app builds and simple runtime checks (server start and overlay open) completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28513af288322a3a63835ad62c399)