### PR TITLE
Fix trending monthly graph to interactive multi-line chart with per-game legend and day drilldown

### DIFF
--- a/core.js
+++ b/core.js
@@ -1562,50 +1562,196 @@ function renderUpdateLogMessage(message, tag = "SYNC") {
   if (fullList) fullList.innerHTML = row;
 }
 
-function renderMonthlyTrendingGraph(rows) {
+const TRENDING_LINE_COLORS = ["#00ff88", "#00d9ff", "#ff6ad5", "#ffc857", "#8a7dff", "#ff7a59"];
+
+function formatTrendDayLabel(dayMs) {
+  return new Date(dayMs).toLocaleDateString(undefined, { month: "short", day: "numeric" }).toUpperCase();
+}
+
+function renderTrendingDayActivity(dayMs, topGames, dailyMatrix) {
+  const activity = document.getElementById("trendingDayActivity");
+  if (!activity) return;
+  const key = new Date(dayMs).toISOString().slice(0, 10);
+  const gameRows = topGames
+    .map((game) => ({ game, count: Number((dailyMatrix.get(game) || {})[key] || 0) }))
+    .filter((row) => row.count > 0)
+    .sort((a, b) => b.count - a.count);
+  if (!gameRows.length) {
+    activity.innerHTML = `<h3>${escapeHtml(formatTrendDayLabel(dayMs))} // 24H ACTIVITY</h3><div class="trending-empty">NO RECORDED GAME PLAYS FOR THIS DAY.</div>`;
+    return;
+  }
+  const total = gameRows.reduce((sum, row) => sum + row.count, 0);
+  activity.innerHTML = `<h3>${escapeHtml(formatTrendDayLabel(dayMs))} // 24H ACTIVITY</h3><p><strong>${total}</strong> TOTAL PLAYS</p><ul>${gameRows
+    .map((row) => `<li>${escapeHtml(TRENDING_GAME_LABELS[row.game] || row.game.toUpperCase())}: <strong>${row.count}</strong></li>`)
+    .join("")}</ul>`;
+}
+
+function renderMonthlyTrendingGraph(model) {
   const chart = document.getElementById("trendingMonthChart");
   const meta = document.getElementById("trendingMonthlyMeta");
-  if (!chart || !meta) return;
+  const activity = document.getElementById("trendingDayActivity");
+  if (!chart || !meta || !activity) return;
 
-  if (!rows.length) {
+  if (!model || !model.days.length || !model.topGames.length) {
     chart.innerHTML = '<div class="trending-empty">NO TREND DATA YET FOR THE LAST 30 DAYS.</div>';
+    activity.innerHTML = '<div class="trending-empty">CLICK A DAY IN THE GRAPH TO OPEN ITS 24H ACTIVITY.</div>';
     meta.innerText = "MONTHLY TRAFFIC WINDOW: EMPTY";
     return;
   }
 
-  const maxCount = Math.max(...rows.map((row) => row.count), 1);
-  chart.innerHTML = rows
-    .map((row) => {
-      const width = Math.max(2, Math.round((row.count / maxCount) * 100));
-      return `<div class="trend-row"><span>${escapeHtml(row.label)}</span><div class="trend-bar-track"><div class="trend-bar-fill" style="width:${width}%"></div></div><span>${row.count} PLAYS</span></div>`;
+  const width = 760;
+  const height = 320;
+  const left = 44;
+  const right = 12;
+  const top = 14;
+  const bottom = 38;
+  const chartW = width - left - right;
+  const chartH = height - top - bottom;
+  const maxY = Math.max(model.maxCount, 1);
+  const xAt = (idx) => left + (idx / Math.max(model.days.length - 1, 1)) * chartW;
+  const yAt = (value) => top + chartH - (value / maxY) * chartH;
+
+  const legendRows = model.topGames
+    .map((game, idx) => {
+      const label = TRENDING_GAME_LABELS[game] || game.toUpperCase();
+      return `<div class="trend-legend-item" id="trendLegend-${escapeHtml(game)}" data-game="${escapeHtml(game)}"><span class="trend-legend-swatch" style="background:${TRENDING_LINE_COLORS[idx % TRENDING_LINE_COLORS.length]}"></span><span>${escapeHtml(label)}</span></div>`;
     })
     .join("");
-  meta.innerText = `MONTHLY TRAFFIC WINDOW: ${rows.length} DAYS`;
+
+  const yTicks = [0, 0.25, 0.5, 0.75, 1]
+    .map((ratio) => {
+      const value = Math.round(maxY * ratio);
+      const y = yAt(value);
+      return `<g><line x1="${left}" y1="${y}" x2="${width - right}" y2="${y}" stroke="rgba(0,255,136,0.15)" stroke-width="1" /><text x="${left - 8}" y="${y + 3}" text-anchor="end" font-size="8" fill="rgba(220,255,235,0.7)">${value}</text></g>`;
+    })
+    .join("");
+
+  const dayLabels = model.days
+    .filter((_, idx) => idx % 5 === 0 || idx === model.days.length - 1)
+    .map((dayMs, idx, arr) => {
+      const dayIdx = model.days.indexOf(dayMs);
+      const x = xAt(dayIdx);
+      const label = arr.length > 8 && idx % 2 ? "" : `${dayIdx + 1}`;
+      return `<text class="trend-x-day" data-day-idx="${dayIdx}" x="${x}" y="${height - 10}" text-anchor="middle" font-size="8" fill="rgba(220,255,235,0.75)">${label}</text>`;
+    })
+    .join("");
+
+  const paths = model.topGames
+    .map((game, idx) => {
+      const points = model.days
+        .map((dayMs, dayIdx) => {
+          const dayKey = new Date(dayMs).toISOString().slice(0, 10);
+          const value = Number((model.dailyMatrix.get(game) || {})[dayKey] || 0);
+          return `${xAt(dayIdx)},${yAt(value)}`;
+        })
+        .join(" ");
+      const color = TRENDING_LINE_COLORS[idx % TRENDING_LINE_COLORS.length];
+      return `<g data-game-group="${escapeHtml(game)}"><polyline class="trend-line" data-game="${escapeHtml(game)}" points="${points}" stroke="${color}" /><polyline class="trend-line-hit" data-game="${escapeHtml(game)}" points="${points}" /></g>`;
+    })
+    .join("");
+
+  chart.innerHTML = `<div class="trend-line-chart"><div class="trend-chart-legend">${legendRows}</div><div class="trend-chart-stage"><div class="trend-chart-hover-readout" id="trendChartHoverReadout">HOVER A LINE TO INSPECT PLAY COUNT.</div><svg class="trend-chart-svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none"><g>${yTicks}</g><g>${paths}</g><line x1="${left}" y1="${height - bottom}" x2="${width - right}" y2="${height - bottom}" stroke="rgba(0,255,136,0.45)" stroke-width="1"/>${dayLabels}</svg></div></div>`;
+
+  const readout = document.getElementById("trendChartHoverReadout");
+  const lineEls = chart.querySelectorAll(".trend-line");
+  const legendEls = chart.querySelectorAll(".trend-legend-item");
+
+  const clearActive = () => {
+    lineEls.forEach((line) => line.classList.remove("active"));
+    legendEls.forEach((item) => item.classList.remove("active"));
+  };
+
+  const activateGameAtX = (game, clientX, boundsLeft, boundsWidth) => {
+    const ratio = Math.min(1, Math.max(0, (clientX - boundsLeft) / Math.max(boundsWidth, 1)));
+    const dayIdx = Math.round(ratio * Math.max(model.days.length - 1, 0));
+    const dayMs = model.days[dayIdx];
+    const dayKey = new Date(dayMs).toISOString().slice(0, 10);
+    const value = Number((model.dailyMatrix.get(game) || {})[dayKey] || 0);
+    const label = TRENDING_GAME_LABELS[game] || game.toUpperCase();
+    clearActive();
+    chart.querySelector(`.trend-line[data-game="${CSS.escape(game)}"]`)?.classList.add("active");
+    chart.querySelector(`.trend-legend-item[data-game="${CSS.escape(game)}"]`)?.classList.add("active");
+    readout.innerText = `${label} // DAY ${dayIdx + 1} (${formatTrendDayLabel(dayMs)}) // ${value} PLAYS`;
+  };
+
+  chart.querySelectorAll(".trend-line-hit").forEach((hit) => {
+    hit.addEventListener("mousemove", (event) => {
+      const game = String(hit.getAttribute("data-game") || "");
+      const box = hit.closest("svg")?.getBoundingClientRect();
+      if (!game || !box) return;
+      activateGameAtX(game, event.clientX, box.left, box.width);
+    });
+    hit.addEventListener("mouseleave", () => {
+      clearActive();
+      readout.innerText = "HOVER A LINE TO INSPECT PLAY COUNT.";
+    });
+  });
+
+  const openDay = (dayIdx) => {
+    const safeIdx = Math.max(0, Math.min(model.days.length - 1, Number(dayIdx)));
+    renderTrendingDayActivity(model.days[safeIdx], model.topGames, model.dailyMatrix);
+  };
+
+  chart.querySelectorAll(".trend-x-day").forEach((label) => {
+    label.addEventListener("click", () => openDay(Number(label.getAttribute("data-day-idx"))));
+  });
+
+  const stage = chart.querySelector(".trend-chart-stage");
+  stage?.addEventListener("click", (event) => {
+    const box = stage.getBoundingClientRect();
+    const ratio = Math.min(1, Math.max(0, (event.clientX - box.left) / Math.max(box.width, 1)));
+    openDay(Math.round(ratio * Math.max(model.days.length - 1, 0)));
+  });
+
+  meta.innerText = `MONTHLY TRAFFIC WINDOW: LAST 30 DAYS // TOP ${model.topGames.length} GAMES`;
 }
 
 async function refreshTrendingMonthGraph() {
   const chart = document.getElementById("trendingMonthChart");
   const meta = document.getElementById("trendingMonthlyMeta");
-  if (!chart || !meta) return;
+  const activity = document.getElementById("trendingDayActivity");
+  if (!chart || !meta || !activity) return;
 
   try {
-    const since = Date.now() - 30 * 24 * 60 * 60 * 1000;
-    const snap = await getDocs(query(collection(db, "gooner_game_plays"), where("ts", ">=", since), limit(4000)));
-    const counts = new Map();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const windowStart = start.getTime() - 29 * dayMs;
+    const snap = await getDocs(query(collection(db, "gooner_game_plays"), where("ts", ">=", windowStart), limit(12000)));
+
+    const totals = new Map();
+    const dailyMatrix = new Map();
     snap.forEach((entry) => {
       const data = entry.data() || {};
       const ts = Number(data.ts || 0);
-      if (!ts) return;
-      const day = new Date(ts).toISOString().slice(5, 10);
-      counts.set(day, (counts.get(day) || 0) + 1);
+      const game = String(data.game || "").toLowerCase().trim();
+      if (!ts || !game) return;
+      const dayKey = new Date(ts).toISOString().slice(0, 10);
+      totals.set(game, (totals.get(game) || 0) + 1);
+      if (!dailyMatrix.has(game)) dailyMatrix.set(game, {});
+      const gameDays = dailyMatrix.get(game);
+      gameDays[dayKey] = Number(gameDays[dayKey] || 0) + 1;
     });
 
-    const rows = [...counts.entries()]
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([label, count]) => ({ label, count }));
-    renderMonthlyTrendingGraph(rows);
+    const days = Array.from({ length: 30 }, (_, idx) => windowStart + idx * dayMs);
+    const topGames = [...totals.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 6)
+      .map(([game]) => game);
+
+    let maxCount = 0;
+    topGames.forEach((game) => {
+      days.forEach((dayTs) => {
+        const dayKey = new Date(dayTs).toISOString().slice(0, 10);
+        const value = Number((dailyMatrix.get(game) || {})[dayKey] || 0);
+        if (value > maxCount) maxCount = value;
+      });
+    });
+
+    renderMonthlyTrendingGraph({ days, topGames, dailyMatrix, maxCount });
   } catch (_error) {
     chart.innerHTML = '<div class="trending-empty">UNABLE TO LOAD MONTHLY TREND GRAPH.</div>';
+    activity.innerHTML = '<div class="trending-empty">DAY ACTIVITY FEED OFFLINE.</div>';
     meta.innerText = "MONTHLY TREND FEED OFFLINE";
   }
 }

--- a/index.html
+++ b/index.html
@@ -119,6 +119,9 @@
         <div class="trending-month-chart" id="trendingMonthChart">
           <div class="trending-empty">COLLECTING SIGNAL DATA...</div>
         </div>
+        <div class="trending-day-activity" id="trendingDayActivity">
+          <div class="trending-empty">CLICK A DAY IN THE GRAPH TO OPEN ITS 24H ACTIVITY.</div>
+        </div>
         <button class="term-btn panel-overlay-exit" type="button" onclick="window.closeOverlays()">EXIT</button>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -661,30 +661,124 @@ body::before {
   border: 1px solid var(--accent-dim);
   background: rgba(0, 0, 0, 0.45);
   padding: 10px;
-  display: grid;
-  gap: 8px;
-  max-height: min(65vh, 640px);
-  overflow-y: auto;
+  min-height: 360px;
 }
 
-.trend-row {
+.trend-line-chart {
   display: grid;
-  grid-template-columns: 72px 1fr auto;
+  grid-template-columns: 180px 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.trend-chart-legend {
+  border: 1px solid var(--accent-dim);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+  align-content: start;
+}
+
+.trend-legend-item {
+  border: 1px solid rgba(0, 255, 136, 0.16);
+  padding: 4px 6px;
+  font-size: 9px;
+  display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  color: rgba(220, 255, 235, 0.8);
+  transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.trend-legend-item.active {
+  color: #fff;
+  border-color: rgba(0, 255, 136, 0.7);
+  background: rgba(0, 255, 136, 0.12);
+}
+
+.trend-legend-swatch {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 10px;
+}
+
+.trend-chart-stage {
+  border: 1px solid var(--accent-dim);
+  background: rgba(255, 255, 255, 0.02);
+  position: relative;
+}
+
+.trend-chart-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.trend-chart-hover-readout {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 9px;
+  color: rgba(220, 255, 235, 0.95);
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  padding: 4px 6px;
+}
+
+.trend-line {
+  fill: none;
+  stroke-width: 2;
+  opacity: 0.35;
+  transition: opacity 0.12s ease, stroke-width 0.12s ease;
+}
+
+.trend-line.active {
+  opacity: 1;
+  stroke-width: 3.2;
+}
+
+.trend-line-hit {
+  fill: none;
+  stroke-width: 14;
+  stroke: transparent;
+  cursor: crosshair;
+}
+
+.trend-x-day {
+  cursor: pointer;
+}
+
+.trending-day-activity {
+  margin-top: 10px;
+  border: 1px solid var(--accent-dim);
+  background: rgba(0, 0, 0, 0.45);
+  padding: 10px;
   font-size: 9px;
 }
 
-.trend-bar-track {
-  border: 1px solid var(--accent-dim);
-  height: 14px;
-  background: rgba(255, 255, 255, 0.03);
+.trending-day-activity h3 {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 10px;
+  letter-spacing: 1px;
 }
 
-.trend-bar-fill {
-  height: 100%;
-  min-width: 2px;
-  background: linear-gradient(90deg, rgba(0, 255, 136, 0.3), rgba(0, 255, 136, 0.9));
+.trending-day-activity ul {
+  margin: 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 4px;
+}
+
+.trending-day-activity strong {
+  color: var(--accent);
+}
+
+@media (max-width: 760px) {
+  .trend-line-chart {
+    grid-template-columns: 1fr;
+  }
 }
 
 .update-log-scroll {


### PR DESCRIPTION
### Motivation
- Replace the static monthly bar-rows view with an interactive line chart so the monthly trending view shows per-game trends over the last 30 days. 
- Provide clearer per-game identification with a left-side legend and one color per game to make comparisons easier. 
- Allow users to inspect exact play counts by hovering and to drill into a single day's 24-hour activity by clicking the chart.

### Description
- Replaced bar-list rendering with an SVG multi-line chart in `renderMonthlyTrendingGraph` and added `TRENDING_LINE_COLORS`, `formatTrendDayLabel`, and `renderTrendingDayActivity` in `core.js` to render and manage the interactive chart and day drilldown. 
- Changed `refreshTrendingMonthGraph` (in `core.js`) to build a 30-day window, aggregate `dailyMatrix` per-game/per-day, select top games, compute `maxCount`, and pass a structured `model` to the renderer. 
- Added a day-activity panel container `#trendingDayActivity` to `index.html` to show a clicked day's 24H breakdown. 
- Introduced new chart layout, legend, hover readout, and responsive styles in `styles.css` (`.trend-line-chart`, `.trend-chart-legend`, `.trend-line`, `.trend-chart-hover-readout`, `.trending-day-activity`, etc.).

### Testing
- Ran `node --check core.js` to validate the modified JS syntax and it succeeded. 
- Served the site locally with `python3 -m http.server 4173 --directory /workspace/webstie` and exercised the overlay via an automated Playwright script that opened the trending overlay and captured a screenshot; the Playwright run completed and produced a screenshot artifact at `artifacts/trending-monthly-graph.png`. 
- Verified the overlay opens and the chart renders without runtime errors during the automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a286cc74ec83229ff9b0aa14b246ce)