### PR TITLE
Add shield to game shops and add per-game shield cooldown

### DIFF
--- a/core.js
+++ b/core.js
@@ -141,6 +141,8 @@ let myItemToggles = {};
 let transactionLog = [];
 let globalVol = 0.5;
 let currentGame = null;
+const SHIELD_COOLDOWN_MS = 1500;
+const shieldCooldowns = Object.create(null);
 let keysPressed = {};
 let lossStreak = 0;
 let jobData = { cooldowns: {}, completed: { cashier: 0, frontdesk: 0, delivery: 0, stocker: 0, janitor: 0, barista: 0 } };
@@ -3621,10 +3623,14 @@ export async function tradeMoney() {
 
 // Consume exactly one shield charge if available.
 export function consumeShield() {
+  const gameKey = String(currentGame || "global").toLowerCase();
+  const now = Date.now();
+  if (shieldCooldowns[gameKey] && shieldCooldowns[gameKey] > now) return true;
   if (!hasActiveItem("item_shield")) return false;
   const shieldIndex = myInventory.indexOf("item_shield");
   if (shieldIndex === -1) return false;
   myInventory.splice(shieldIndex, 1);
+  shieldCooldowns[gameKey] = now + SHIELD_COOLDOWN_MS;
   saveStats();
   return true;
 }

--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -1,15 +1,15 @@
 export const GAME_DIRECTORY_ENTRIES = Object.freeze([
-  { id: "geo", title: "GEO DASH", description: "Play official-style levels from Stereo Madness to Dash.", icon: "🟨", tags: ["arcade", "skill", "platformer", "reflex"], shopItems: ["item_slowmo"] },
+  { id: "geo", title: "GEO DASH", description: "Play official-style levels from Stereo Madness to Dash.", icon: "🟨", tags: ["arcade", "skill", "platformer", "reflex"], shopItems: ["item_slowmo", "item_shield"] },
   { id: "type", title: "TYPE RUNNER", description: "Type fast to outrun incoming threats.", icon: "⌨️", tags: ["arcade", "skill", "typing", "reflex"], shopItems: ["item_autotype"] },
   { id: "pong", title: "PONG", description: "Retro paddle battle with adjustable difficulty.", icon: "🏓", tags: ["arcade", "pvp", "retro", "duel"], shopItems: ["item_aimbot"] },
-  { id: "snake", title: "SNAKE", description: "Grow longer while avoiding walls and yourself.", icon: "🐍", tags: ["arcade", "skill"], shopItems: ["item_double"] },
-  { id: "runner", title: "RUNNER V2", description: "Endless sprint with jump timing focus.", icon: "🏃", tags: ["arcade", "skill"], shopItems: ["item_slowmo"] },
+  { id: "snake", title: "SNAKE", description: "Grow longer while avoiding walls and yourself.", icon: "🐍", tags: ["arcade", "skill"], shopItems: ["item_double", "item_shield"] },
+  { id: "runner", title: "RUNNER V2", description: "Endless sprint with jump timing focus.", icon: "🏃", tags: ["arcade", "skill"], shopItems: ["item_slowmo", "item_shield"] },
   { id: "corebreaker", title: "CORE BREAKER", description: "Break glowing blocks and protect your core.", icon: "🧱", tags: ["arcade", "skill"] },
   { id: "neondefender", title: "NEON DEFENDER", description: "Aim, auto-fire, and hold the line.", icon: "🎯", tags: ["arcade", "skill"] },
   { id: "voidminer", title: "VOID MINER", description: "Thrust through deep space for score.", icon: "🚀", tags: ["arcade", "skill"] },
   { id: "coredriller", title: "CORE DRILLER", description: "Dive through strata, mine ore, and keep your rig alive.", icon: "⛏️", tags: ["arcade", "skill", "strategy"] },
   { id: "shadowassassin", title: "SHADOW ASSASSIN", description: "Castle infiltration with boss encounters.", icon: "🗡️", tags: ["arcade", "skill"] },
-  { id: "dodge", title: "DODGE GRID", description: "Stay alive in a high-speed hazard field.", icon: "⚡", tags: ["arcade", "skill"], shopItems: ["item_dodge_stabilizer"] },
+  { id: "dodge", title: "DODGE GRID", description: "Stay alive in a high-speed hazard field.", icon: "⚡", tags: ["arcade", "skill"], shopItems: ["item_dodge_stabilizer", "item_shield"] },
   { id: "roulette", title: "ROULETTE", description: "Bet, spin, and chase streaks.", icon: "🎡", tags: ["casino", "luck", "table"] },
   { id: "blackjack", title: "BLACKJACK", description: "Card table duels with live opponents.", icon: "🂡", tags: ["casino", "pvp", "cards", "table"], shopItems: ["item_xray", "item_cardcount"] },
   { id: "ttt", title: "TIC TAC TOE", description: "Classic 3x3 tactical showdown.", icon: "❎", tags: ["pvp", "skill"] },
@@ -28,7 +28,7 @@ export const GAME_DIRECTORY_ENTRIES = Object.freeze([
   { id: "metromaze", title: "METRO MAZE", description: "Procedural mazes with relics, sentinels, and level exits.", icon: "🚇", tags: ["skill", "maze", "puzzle", "strategy"] },
   { id: "stacksmash", title: "STACK SMASH", description: "Break layered stacks for big spike payouts.", icon: "🪨", tags: ["arcade", "timing", "reflex"] },
   { id: "quantumflip", title: "QUANTUM FLIP", description: "Pilot a phase core: chain matching orbs and survive hunter waves.", icon: "⚛️", tags: ["skill", "strategy", "survival"] },
-  { id: "flappy", title: "FLAPPY GOON", description: "Secret bonus mode: tap to survive.", icon: "🐤", tags: ["arcade", "skill"], hidden: true, shopItems: ["item_flappy"] },
+  { id: "flappy", title: "FLAPPY GOON", description: "Secret bonus mode: tap to survive.", icon: "🐤", tags: ["arcade", "skill"], hidden: true, shopItems: ["item_flappy", "item_shield"] },
 ]);
 
 export const LEADERBOARD_GAME_COLUMNS = Object.freeze(


### PR DESCRIPTION
### Motivation
- Prevent shields from being rapidly drained by back-to-back collision events and make shields purchasable from the in-game shop for games that use them.
- Provide a simple per-game cooldown to give shields a short protection window so players don't lose multiple charges from a single hazard sequence.

### Description
- Added `item_shield` to the `shopItems` lists for `geo`, `snake`, `runner`, `dodge`, and `flappy` in `gameCatalog.js` so shields appear in those game shop panels.
- Introduced a shared cooldown system in `core.js` with `const SHIELD_COOLDOWN_MS = 1500` and a `shieldCooldowns` map keyed by the current game.
- Updated `consumeShield()` in `core.js` to check the per-game cooldown and return protection while the cooldown is active, only consuming one `item_shield` when the cooldown is expired, and set the cooldown after consumption.
- The cooldown key is `String(currentGame || "global").toLowerCase()` so it falls back to a global slot when no game is active.

### Testing
- Ran syntax checks: `node --check core.js` and `node --check gameCatalog.js`, both succeeded.
- Attempted to run a headless UI smoke test via a local `python -m http.server` and Playwright to capture the shop UI, but Chromium crashed with a SIGSEGV and Firefox navigation returned `NS_ERROR_NET_RESET`, so no screenshot was captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28d70c2c08322acb1a8e95af8371d)