### PR TITLE
Add per-game shield cooldown enforcement

### DIFF
--- a/core.js
+++ b/core.js
@@ -3668,8 +3668,8 @@ export async function tradeMoney() {
 }
 
 // Consume exactly one shield charge if available.
-export function consumeShield() {
-  const gameKey = String(currentGame || "global").toLowerCase();
+export function consumeShield(gameId = currentGame) {
+  const gameKey = String(gameId || currentGame || "global").toLowerCase();
   const now = Date.now();
   if (shieldCooldowns[gameKey] && shieldCooldowns[gameKey] > now) return true;
   if (!hasActiveItem("item_shield")) return false;

--- a/games/dodge.js
+++ b/games/dodge.js
@@ -303,7 +303,7 @@ function loopDodge(now) {
       player.y < s.y + s.h &&
       player.y + player.h > s.y
     ) {
-      if (consumeShield()) {
+      if (consumeShield("dodge")) {
         shards.splice(i, 1);
         showToast("SHIELD USED", "🛡️");
         continue;

--- a/games/flappy.js
+++ b/games/flappy.js
@@ -84,7 +84,7 @@ function loopFlappy(now) {
   ctx.fillStyle = "#fff";
   ctx.fillRect(fBird.x, fBird.y, 20, 20);
   if (fBird.y > 600 || fBird.y < 0) {
-    if (consumeShield()) {
+    if (consumeShield("flappy")) {
       fBird.y = Math.max(0, Math.min(580, fBird.y));
       fBird.dy = 0;
       showToast("SHIELD USED", "🛡️");
@@ -116,7 +116,7 @@ function loopFlappy(now) {
       fBird.x < p.x + 40 &&
       (fBird.y < p.h || fBird.y + 20 > p.h + p.gap)
     ) {
-      if (consumeShield()) {
+      if (consumeShield("flappy")) {
         fPipes.splice(i, 1);
         showToast("SHIELD USED", "🛡️");
         continue;

--- a/games/geo.js
+++ b/games/geo.js
@@ -174,7 +174,7 @@ function loopGeometry(ctx, now) {
       gPlayer.y < o.y + o.h - 5 &&
       gPlayer.y + gPlayer.h > o.y + 5
     ) {
-      if (consumeShield()) {
+      if (consumeShield("geo")) {
         gObs.splice(i, 1);
         showToast("SHIELD USED", "🛡️");
         continue;

--- a/games/runner.js
+++ b/games/runner.js
@@ -137,7 +137,7 @@ function onTick(dt) {
         obstacleH[i]
       )
     ) {
-      if (consumeShield()) {
+      if (consumeShield("runner")) {
         freeObstacle(i);
         showToast("SHIELD USED", "🛡️");
         continue;

--- a/games/snake.js
+++ b/games/snake.js
@@ -95,7 +95,7 @@ function tick() {
   const self = snake.some((s) => s.x === head.x && s.y === head.y);
 
   if (wall || self) {
-    if (consumeShield()) {
+    if (consumeShield("snake")) {
       snake = [{ x: Math.max(0, Math.min(GRID_W - 1, head.x)), y: Math.max(0, Math.min(GRID_H - 1, head.y)) }];
       showToast("SHIELD USED", "🛡️");
       return;


### PR DESCRIPTION
### Motivation
- Prevent rapid repeated shield consumption and glitches by scoping shield cooldowns to the specific game instance instead of relying on transient global state.

### Description
- Changed `consumeShield()` in `core.js` to accept an optional `gameId` parameter and derive the cooldown key from that id using `String(gameId || currentGame || "global").toLowerCase()`.
- Set the per-game cooldown timestamp in the centralized `shieldCooldowns` map using `SHIELD_COOLDOWN_MS` as before.
- Updated every shield-enabled game to call `consumeShield("<game>")` explicitly for `geo`, `snake`, `runner`, `dodge`, and `flappy` so cooldowns are reliably applied per game.
- No change to the cooldown duration constant `SHIELD_COOLDOWN_MS` (remains `1500` ms).

### Testing
- Ran syntax checks with `node --check` for `core.js`, `games/geo.js`, `games/snake.js`, `games/runner.js`, `games/dodge.js`, and `games/flappy.js`, which all passed.
- Verified repository changes were committed successfully with a descriptive message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28f512acc8322898962ac1a91aa86)