### PR TITLE
Allow users to delete their own chat messages and refresh mute icons

### DIFF
--- a/core.js
+++ b/core.js
@@ -4754,7 +4754,7 @@ function renderChatTab() {
         localMuteBtn.type = "button";
         localMuteBtn.className = "chat-mute-btn";
         localMuteBtn.title = isLocallyMuted ? `Unmute ${user} locally` : `Mute ${user} locally`;
-        localMuteBtn.textContent = isLocallyMuted ? "L🔊" : "L🔇";
+        localMuteBtn.textContent = isLocallyMuted ? "🔇" : "🔊";
         localMuteBtn.onclick = () => toggleLocalChatMute(user);
         row.appendChild(localMuteBtn);
 
@@ -4763,13 +4763,14 @@ function renderChatTab() {
           globalMuteBtn.type = "button";
           globalMuteBtn.className = "chat-mute-btn chat-global-mute-btn";
           globalMuteBtn.title = isGloballyMuted ? `Unmute ${user} globally` : `Mute ${user} globally`;
-          globalMuteBtn.textContent = isGloballyMuted ? "G🔊" : "G🔇";
+          globalMuteBtn.textContent = isGloballyMuted ? "🎤🚫" : "🎤";
           globalMuteBtn.onclick = () => toggleAdminChatMute(user);
           row.appendChild(globalMuteBtn);
         }
       }
 
-      if (isGodUser() && m.id) {
+      const isOwnMessage = normalizeUsername(m.user || "") === normalizeUsername(myName);
+      if ((isGodUser() || isOwnMessage) && m.id) {
         const removeBtn = document.createElement("button");
         removeBtn.type = "button";
         removeBtn.className = "chat-remove-btn";
@@ -4825,7 +4826,7 @@ function initGlobalChatMutes() {
 }
 
 async function removeChatMessage(tab, messageId) {
-  if (!isGodUser() || !messageId) return;
+  if (!messageId) return;
   const collectionByTab = {
     dm: "gooner_user_chat",
     global: "gooner_global_chat",
@@ -4833,8 +4834,24 @@ async function removeChatMessage(tab, messageId) {
   };
   const collectionName = collectionByTab[tab];
   if (!collectionName) return;
+  const messageRef = doc(db, collectionName, messageId);
+  const canDelete = await runFirestoreTask(
+    async () => {
+      if (isGodUser()) return true;
+      const snapshot = await getDoc(messageRef);
+      if (!snapshot.exists()) return false;
+      const author = normalizeUsername(snapshot.data()?.user || "");
+      return author && author === normalizeUsername(myName);
+    },
+    "CHAT",
+    "Message remove failed."
+  );
+  if (!canDelete) {
+    showToast("CHAT", "🚫", "You can only remove your own messages.");
+    return;
+  }
   const removed = await runFirestoreTask(
-    () => deleteDoc(doc(db, collectionName, messageId)),
+    () => deleteDoc(messageRef),
     "ADMIN CHAT",
     "Message remove failed."
   );


### PR DESCRIPTION
### Motivation
- Make chat moderation more flexible by allowing players to remove their own messages using the same admin-backed deletion flow. 
- Improve chat UI clarity by replacing the `L`/`G` text prefixes with clearer speaker/microphone symbols and inverting icon state so open icons indicate unmuted.

### Description
- Updated per-message UI in `renderChatTab` so the local mute button uses speaker icons (`🔊`/`🔇`) and the global mute button uses mic icons (`🎤`/`🎤🚫`) and removed the `L`/`G` prefixes. 
- Show the message remove (`✕`) button when the viewer is an admin (`isGodUser()`) or the message author (owner). 
- Extended `removeChatMessage` to perform an ownership check via `getDoc` and allow deletion if the caller is the message author or an admin, otherwise show a toast denial; deletion still uses the same Firestore delete flow. 
- Kept admin global-mute behavior unchanged other than the icon swap and ensured existing admin delete capability remains intact.

### Testing
- Ran `node --check core.js` to validate syntax and the module passed successfully. 
- Served the app locally with `python3 -m http.server 4173 --directory /workspace/webstie` and loaded the page for manual verification. 
- Captured an automated UI screenshot using Playwright to confirm the updated chat UI and icons; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2906e3c5483229128a4017a0869fa)