### PR TITLE
Make notifications closeable with per-toast dismiss button

### DIFF
--- a/core.js
+++ b/core.js
@@ -4460,9 +4460,19 @@ export function showToast(title, icon, subtitle = "") {
 
   const t = document.createElement("div");
   t.className = "toast";
-  t.innerHTML = `<div class="toast-icon">${icon}</div><div class="toast-content"><div class="toast-title">${title}</div><div class="toast-desc">${subtitle}</div></div>`;
+  t.innerHTML = `<button class="toast-close-btn" type="button" aria-label="Close notification">✕</button><div class="toast-icon">${icon}</div><div class="toast-content"><div class="toast-title">${title}</div><div class="toast-desc">${subtitle}</div></div>`;
   toastBox.appendChild(t);
-  setTimeout(() => t.remove(), 4000);
+
+  const removeToast = () => {
+    clearTimeout(autoDismissHandle);
+    t.remove();
+  };
+
+  const autoDismissHandle = setTimeout(removeToast, 4000);
+  const closeBtn = t.querySelector(".toast-close-btn");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", removeToast);
+  }
 }
 
 // Auto-login if credentials exist in local storage.

--- a/styles.css
+++ b/styles.css
@@ -2810,20 +2810,38 @@ body.reduce-motion *::after {
   pointer-events: none;
 }
 .toast {
+  position: relative;
   background: rgba(0, 0, 0, 0.95);
   border: 1px solid var(--accent);
   color: var(--accent);
   min-width: 220px;
   max-width: 340px;
-  padding: 10px 14px;
+  padding: 10px 36px 10px 14px;
   text-align: center;
   box-shadow: 0 0 10px var(--accent-glow);
   display: flex;
   align-items: center;
   gap: 15px;
+  pointer-events: auto;
   animation:
     slideUp 0.5s cubic-bezier(0.18, 0.89, 0.32, 1.28),
     fadeOut 0.5s ease-in 3.5s forwards;
+}
+.toast-close-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px;
+}
+
+.toast-close-btn:hover {
+  color: #fff;
 }
 .toast-icon {
   font-size: 30px;


### PR DESCRIPTION
### Motivation
- Allow users to manually dismiss toast notifications so transient messages can be removed immediately instead of waiting for auto-dismiss.
- Keep existing auto-dismiss behavior while ensuring manual dismiss clears the underlying timer to avoid race conditions.
- Make toast UI interactive without changing container-level pointer behavior so other parts of the UI remain unaffected.

### Description
- Added a close button (`.toast-close-btn`) to each toast produced by `showToast` and wired it to remove the toast and clear the auto-dismiss timer in `core.js`.
- Kept the 4s auto-dismiss but refactored it into a removable `autoDismissHandle` so manual dismissal cancels the timer.
- Updated toast styling in `styles.css` to make toasts `position: relative`, add right padding, enable `pointer-events: auto`, and include styles and hover state for the close button.
- Modified files: `core.js` and `styles.css`.

### Testing
- Ran static checks with `node --check core.js` and `node --check script.js`, both succeeded.
- Served the app locally with `python3 -m http.server 4173 --directory /workspace/webstie` and verified the toast UI loads.
- Performed a Playwright visual verification and captured a screenshot artifact at `artifacts/toast-close-button.png`, confirming the close button is visible and clickable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2927ddda483228736045342365c71)