### PR TITLE
Close overlays when clicking backdrop

### DIFF
--- a/script.js
+++ b/script.js
@@ -1138,9 +1138,21 @@ function initTopBarOverlayControls() {
   updateControls();
 }
 
+function initOverlayBackdropExit() {
+  document.querySelectorAll(".overlay").forEach((overlay) => {
+    overlay.addEventListener("click", (event) => {
+      if (!overlay.classList.contains("active")) return;
+      if (event.target !== overlay) return;
+      if (overlay.id === "overlayLogin") return;
+      closeOverlays();
+    });
+  });
+}
+
 initSharedGamebox();
 disableInGameExitButtons();
 initTopBarOverlayControls();
+initOverlayBackdropExit();
 initGameCanvasSizing();
 initGameVisibilityGuards();
 initGameSwitcher();


### PR DESCRIPTION
### Motivation
- Improve user experience by allowing overlays to be dismissed when the user clicks the dimmed backdrop area outside the panel content.
- Preserve existing behavior for in-panel interactions by only reacting to clicks where the event target is the overlay element itself.
- Prevent accidental dismissal of the login flow by excluding the `overlayLogin` from backdrop-close behavior.

### Description
- Added `initOverlayBackdropExit()` which attaches a `click` listener to every `.overlay` that closes overlays when the click target is the overlay container and the overlay is active.
- The handler ignores clicks inside the overlay content by checking `event.target !== overlay` and skips `overlayLogin` to avoid closing the login panel.
- Wired the new initializer into startup by calling `initOverlayBackdropExit()` alongside other site initialization functions in `script.js`.

### Testing
- Ran `node --check script.js` which completed without errors.
- Started a local server with `python -m http.server 4173` and executed an automated Playwright script that opened the site, logged in, opened the Bank overlay, clicked the backdrop, and confirmed the overlay closed; the Playwright run succeeded and produced a screenshot at `artifacts/overlay-backdrop-close.png`.
- All automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29299a7488322913cf41ba406f2c2)