### PR TITLE
Add tabbed config menu with Theme / Accessibility / Notifications / Games and new toggles

### DIFF
--- a/core.js
+++ b/core.js
@@ -4453,6 +4453,9 @@ export function toggleItem(id) {
 
 // Display a toast notification with optional subtitle.
 export function showToast(title, icon, subtitle = "") {
+  const config = readUiConfig();
+  if (config.toastAlerts === false) return;
+
   const toastBox = document.getElementById("toastBox");
   if (!toastBox) return;
 
@@ -4508,7 +4511,7 @@ document.getElementById("btnLogout").onclick = () => {
   location.reload();
 };
 
-const UI_CONFIG_KEY = "goonerUiConfigV1";
+const UI_CONFIG_KEY = "goonerUiConfigV2";
 
 function readUiConfig() {
   try {
@@ -4520,6 +4523,12 @@ function readUiConfig() {
 
 function writeUiConfig(nextConfig) {
   localStorage.setItem(UI_CONFIG_KEY, JSON.stringify({ ...readUiConfig(), ...nextConfig }));
+}
+
+function updateToggleLabel(toggleId, enabled, onLabel = "ON", offLabel = "OFF") {
+  const toggle = document.getElementById(toggleId);
+  if (!toggle) return;
+  toggle.textContent = enabled ? onLabel : offLabel;
 }
 
 function applyUiScale(value) {
@@ -4541,6 +4550,40 @@ function applyReducedMotion(enabled) {
   document.body.classList.toggle("reduce-motion", enabled);
   const motionToggle = document.getElementById("motionToggle");
   if (motionToggle) motionToggle.textContent = enabled ? "ON" : "OFF";
+}
+
+function applyToastAlerts(enabled) {
+  updateToggleLabel("toastToggle", enabled);
+}
+
+function applyDesktopAlerts(enabled) {
+  updateToggleLabel("desktopNotifyToggle", enabled);
+}
+
+function applyGameTips(enabled) {
+  document.body.classList.toggle("hide-game-tips", !enabled);
+  updateToggleLabel("gameTipsToggle", enabled);
+}
+
+function initConfigTabs() {
+  const tabs = Array.from(document.querySelectorAll("[data-config-tab]"));
+  const panels = Array.from(document.querySelectorAll("[data-config-panel]"));
+  if (!tabs.length || !panels.length) return;
+
+  const setActiveTab = (tabName) => {
+    tabs.forEach((tab) => {
+      tab.classList.toggle("active", tab.dataset.configTab === tabName);
+    });
+    panels.forEach((panel) => {
+      panel.classList.toggle("active", panel.dataset.configPanel === tabName);
+    });
+  };
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => setActiveTab(tab.dataset.configTab || "theme"));
+  });
+
+  setActiveTab("theme");
 }
 // Open the games directory from top navigation and keep menu-mash tracking.
 const menuToggleBtn = document.getElementById("menuToggle");
@@ -4606,7 +4649,9 @@ document.getElementById("themeColor").oninput = (e) => {
 };
 // Volume slider controls global audio volume.
 document.getElementById("volSlider").oninput = (e) => {
-  globalVol = e.target.value / 100;
+  const volume = e.target.value / 100;
+  globalVol = volume;
+  writeUiConfig({ volume });
 };
 // Scanline slider controls overlay opacity.
 document.getElementById("scanSlider").oninput = (e) =>
@@ -4650,18 +4695,56 @@ document.getElementById("motionToggle").onclick = () => {
   writeUiConfig({ reducedMotion: enabled });
 };
 
+document.getElementById("toastToggle").onclick = () => {
+  const config = readUiConfig();
+  const enabled = config.toastAlerts !== false ? false : true;
+  applyToastAlerts(enabled);
+  writeUiConfig({ toastAlerts: enabled });
+};
+
+document.getElementById("desktopNotifyToggle").onclick = async () => {
+  const config = readUiConfig();
+  let enabled = config.desktopAlerts === true;
+  if (!enabled && "Notification" in window) {
+    const permission = await Notification.requestPermission();
+    enabled = permission === "granted";
+  } else {
+    enabled = !enabled;
+  }
+  if (!("Notification" in window)) enabled = false;
+  applyDesktopAlerts(enabled);
+  writeUiConfig({ desktopAlerts: enabled });
+};
+
+document.getElementById("gameTipsToggle").onclick = () => {
+  const config = readUiConfig();
+  const enabled = config.gameTips !== false ? false : true;
+  applyGameTips(enabled);
+  writeUiConfig({ gameTips: enabled });
+};
+
+initConfigTabs();
+
 (function hydrateUiConfig() {
   const config = readUiConfig();
   const uiScale = Number(config.uiScale || 1);
   const uiTextSize = Number(config.uiTextSize || 11);
+  const volume = Number.isFinite(Number(config.volume)) ? Number(config.volume) : 0.5;
   applyUiScale(uiScale);
   applyUiTextSize(uiTextSize);
   applyContrastMode(Boolean(config.highContrast));
   applyReducedMotion(Boolean(config.reducedMotion));
+  applyToastAlerts(config.toastAlerts !== false);
+  applyDesktopAlerts(Boolean(config.desktopAlerts));
+  applyGameTips(config.gameTips !== false);
+  globalVol = volume;
+
   const uiScaleSlider = document.getElementById("uiScaleSlider");
   const uiTextSlider = document.getElementById("uiTextSlider");
+  const volSlider = document.getElementById("volSlider");
   if (uiScaleSlider) uiScaleSlider.value = String(Math.round(uiScale * 100));
   if (uiTextSlider) uiTextSlider.value = String(uiTextSize);
+  if (volSlider) volSlider.value = String(Math.round(volume * 100));
 })();
 
 // Konami code sequence for a hidden Matrix unlock.

--- a/index.html
+++ b/index.html
@@ -986,70 +986,41 @@
     <!-- Configuration overlay for display/audio toggles. -->
     <div class="overlay menu-overlay" id="overlayConfig">
       <div class="config-box">
-        <h2
-          style="
-            text-align: center;
-            border-bottom: 1px solid var(--accent);
-            padding-bottom: 10px;
-            margin-bottom: 20px;
-          "
-        >
-          CONFIG
-        </h2>
-        <div class="config-row">
-          <span>THEME</span
-          ><input type="color" id="themeColor" value="#ffffff" />
+        <h2 class="config-title">CONFIG</h2>
+        <div class="config-tabs" role="tablist" aria-label="Config categories">
+          <button class="menu-btn config-tab active" id="configTabTheme" type="button" data-config-tab="theme">THEME</button>
+          <button class="menu-btn config-tab" id="configTabAccessibility" type="button" data-config-tab="accessibility">ACCESSIBILITY</button>
+          <button class="menu-btn config-tab" id="configTabNotifications" type="button" data-config-tab="notifications">NOTIFICATIONS</button>
+          <button class="menu-btn config-tab" id="configTabGames" type="button" data-config-tab="games">GAMES</button>
         </div>
-        <div class="config-row">
-          <span>MATRIX</span
-          ><button class="menu-btn" id="matrixToggle">OFF</button>
+
+        <div class="config-panel active" id="configPanelTheme" data-config-panel="theme">
+          <div class="config-row"><span>ACCENT COLOR</span><input type="color" id="themeColor" value="#ffffff" /></div>
+          <div class="config-row"><span>SCANLINES</span><input type="range" id="scanSlider" min="0" max="100" value="50" /></div>
+          <div class="config-row"><span>FLICKER</span><button class="menu-btn" id="flickerToggle">ON</button></div>
         </div>
-        <div class="config-row">
-          <span>SCANLINES</span
-          ><input type="range" id="scanSlider" min="0" max="100" value="50" />
+
+        <div class="config-panel" id="configPanelAccessibility" data-config-panel="accessibility">
+          <div class="config-row"><span>UI SCALE</span><input type="range" id="uiScaleSlider" min="85" max="110" step="1" value="100" /></div>
+          <div class="config-row"><span>TEXT SIZE</span><input type="range" id="uiTextSlider" min="9" max="13" step="1" value="11" /></div>
+          <div class="config-row"><span>HIGH CONTRAST</span><button class="menu-btn" id="contrastToggle">OFF</button></div>
+          <div class="config-row"><span>REDUCED MOTION</span><button class="menu-btn" id="motionToggle">OFF</button></div>
         </div>
-        <div class="config-row">
-          <span>FLICKER</span
-          ><button class="menu-btn" id="flickerToggle">ON</button>
+
+        <div class="config-panel" id="configPanelNotifications" data-config-panel="notifications">
+          <div class="config-row"><span>SFX VOLUME</span><input type="range" id="volSlider" min="0" max="100" value="50" /></div>
+          <div class="config-row"><span>TOAST ALERTS</span><button class="menu-btn" id="toastToggle">ON</button></div>
+          <div class="config-row"><span>DESKTOP ALERTS</span><button class="menu-btn" id="desktopNotifyToggle">OFF</button></div>
         </div>
-        <div class="config-row">
-          <span>VOLUME</span
-          ><input type="range" id="volSlider" min="0" max="100" value="50" />
+
+        <div class="config-panel" id="configPanelGames" data-config-panel="games">
+          <div class="config-row"><span>MATRIX</span><button class="menu-btn" id="matrixToggle">OFF</button></div>
+          <div class="config-row"><span>FULLSCREEN</span><button class="menu-btn" id="fsToggle">TOGGLE</button></div>
+          <div class="config-row"><span>GAME TIPS</span><button class="menu-btn" id="gameTipsToggle">ON</button></div>
         </div>
-        <div class="config-row">
-          <span>FULLSCREEN</span
-          ><button class="menu-btn" id="fsToggle">TOGGLE</button>
-        </div>
-        <div class="config-row">
-          <span>UI SCALE</span
-          ><input type="range" id="uiScaleSlider" min="85" max="110" step="1" value="100" />
-        </div>
-        <div class="config-row">
-          <span>TEXT SIZE</span
-          ><input type="range" id="uiTextSlider" min="9" max="13" step="1" value="11" />
-        </div>
-        <div class="config-row">
-          <span>HIGH CONTRAST</span
-          ><button class="menu-btn" id="contrastToggle">OFF</button>
-        </div>
-        <div class="config-row">
-          <span>REDUCED MOTION</span
-          ><button class="menu-btn" id="motionToggle">OFF</button>
-        </div>
-        <button
-          class="term-btn"
-          id="btnLogout"
-          style="border-color: red; color: red; margin-top: 10px"
-        >
-          LOGOUT
-        </button>
-        <button
-          class="term-btn"
-          style="margin-top: 20px"
-          onclick="window.closeConfigOverlay()"
-        >
-          CLOSE
-        </button>
+
+        <button class="term-btn" id="btnLogout" style="border-color: red; color: red; margin-top: 10px">LOGOUT</button>
+        <button class="term-btn" style="margin-top: 20px" onclick="window.closeConfigOverlay()">CLOSE</button>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1293,6 +1293,10 @@ canvas {
   opacity: 0.8;
 }
 
+body.hide-game-tips .gamebox-subtitle {
+  display: none;
+}
+
 .gamebox-content {
   width: 100%;
   min-height: 580px;
@@ -2311,6 +2315,38 @@ canvas {
 #overlayConfig .config-box {
   margin-top: 0;
   margin-left: 0;
+}
+
+.config-title {
+  text-align: center;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 10px;
+  margin-bottom: 12px;
+}
+
+.config-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.config-tab {
+  padding: 6px 8px;
+  font-size: 9px;
+}
+
+.config-tab.active {
+  box-shadow: 0 0 10px var(--accent-dim);
+  background: rgba(0, 255, 0, 0.08);
+}
+
+.config-panel {
+  display: none;
+}
+
+.config-panel.active {
+  display: block;
 }
 .config-row {
   display: flex;


### PR DESCRIPTION
### Motivation
- Reorganize the single long Config panel into logical tabs to make settings easier to find and manage.
- Surface new controls for notifications and game UI preferences so users can silence or opt into alerts and in-game tips.
- Persist additional UI preferences (volume, toast/desktop alerts, game tips) so settings survive reloads.

### Description
- Replaced the flat config markup in `index.html` with a tabbed layout (Theme, Accessibility, Notifications, Games) and moved existing controls into the appropriate `data-config-panel` sections while adding `toastToggle`, `desktopNotifyToggle`, and `gameTipsToggle` controls.
- Added tab/panel styles and behavior in `styles.css`, and a small rule to hide the gamebox subtitle when game tips are disabled (`body.hide-game-tips`).
- Extended `core.js` to use a new UI config key (`goonerUiConfigV2`), persist `volume` and new toggles, add helpers (`updateToggleLabel`, `applyToastAlerts`, `applyDesktopAlerts`, `applyGameTips`, `initConfigTabs`), wire click/input handlers for the new controls, and prevent `showToast` from rendering when toast alerts are disabled.
- Hydration now loads the expanded config set into the UI (volume, toast/desktop alerts, game tips, ui scale/text, contrast, reduced motion) and initializes the tab system.

### Testing
- Ran `node --check core.js` which completed successfully.
- Ran `node --check script.js` which completed successfully.
- Attempted a Playwright screenshot to validate the UI, but the headless browser crashed (SIGSEGV) in this environment so visual confirmation was not captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a292b55b3483229730f04900e52d5d)