### PR TITLE
Replace gamebox favorite star with multi-mode filter button

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,7 +980,7 @@
         <div class="leaderboard-heading-row gamebox-heading-row">
           <h2 id="gameboxHeadingTitle">GAMES</h2>
           <div class="leaderboard-heading-actions">
-            <button class="menu-btn leaderboard-search-toggle" id="gameboxFavoritesToggle" type="button" title="TOGGLE FAVORITES ONLY">★</button>
+            <button class="menu-btn leaderboard-search-toggle" id="gameboxFilterToggle" type="button" title="CHANGE GAME FILTER">FILTER: A-Z</button>
             <button class="menu-btn leaderboard-search-toggle" id="gameboxSearchToggle" type="button">SEARCH</button>
             <button class="menu-btn leaderboard-search-toggle" id="gameboxSwitchBtn" type="button">LEADERBOARD</button>
             <button id="topFullscreenBtn" class="menu-btn" type="button" style="display: none">FULLSCREEN</button>

--- a/script.js
+++ b/script.js
@@ -453,16 +453,17 @@ function initGameScroller() {
   if (!orderedGames.length) return;
 
   const strip = document.getElementById("gameboxGameStrip");
-  const favoritesToggle = document.getElementById("gameboxFavoritesToggle");
+  const filterToggle = document.getElementById("gameboxFilterToggle");
   const searchToggle = document.getElementById("gameboxSearchToggle");
   const searchInput = document.getElementById("gameboxSearchInput");
   const switchBtn = document.getElementById("gameboxSwitchBtn");
-  if (!strip || !favoritesToggle || !searchToggle || !searchInput || !switchBtn) return;
+  if (!strip || !filterToggle || !searchToggle || !searchInput || !switchBtn) return;
 
   let gameSearchQuery = "";
   let selectedGameId = "";
   let centerOnGameId = "";
-  let favoritesFirst = true;
+  const FILTER_MODES = ["az", "za", "trending", "favorites"];
+  let currentFilterIndex = 0;
   let suppressClickUntil = 0;
 
   const getFavorites = () => {
@@ -488,23 +489,47 @@ function initGameScroller() {
   const getVisibleGames = () => {
     const query = String(gameSearchQuery || "").trim().toUpperCase();
     const favorites = new Set(getFavorites());
+    const recents = readStoredGameList(GAME_LIBRARY_RECENTS_KEY);
+    const recentRank = new Map(recents.map((gameId, idx) => [gameId, idx]));
+    const mode = FILTER_MODES[currentFilterIndex] || "az";
     const filtered = orderedGames.filter((game) => {
       if (!query) return true;
       return game.searchText.includes(query);
     });
-    if (!favoritesFirst) return filtered;
-    return filtered.slice().sort((a, b) => {
-      const aFav = favorites.has(a.id) ? 1 : 0;
-      const bFav = favorites.has(b.id) ? 1 : 0;
-      if (aFav !== bFav) return bFav - aFav;
-      return a.title.localeCompare(b.title);
-    });
+
+    if (mode === "favorites") {
+      return filtered
+        .filter((game) => favorites.has(game.id))
+        .sort((a, b) => a.title.localeCompare(b.title));
+    }
+
+    if (mode === "za") {
+      return filtered.slice().sort((a, b) => b.title.localeCompare(a.title));
+    }
+
+    if (mode === "trending") {
+      return filtered.slice().sort((a, b) => {
+        const aRank = recentRank.has(a.id) ? recentRank.get(a.id) : Number.POSITIVE_INFINITY;
+        const bRank = recentRank.has(b.id) ? recentRank.get(b.id) : Number.POSITIVE_INFINITY;
+        if (aRank !== bRank) return aRank - bRank;
+        return a.title.localeCompare(b.title);
+      });
+    }
+
+    return filtered.slice().sort((a, b) => a.title.localeCompare(b.title));
   };
 
   const renderStrip = () => {
     strip.innerHTML = "";
-    favoritesToggle.classList.toggle("active", favoritesFirst);
-    favoritesToggle.textContent = favoritesFirst ? "★" : "☆";
+    const mode = FILTER_MODES[currentFilterIndex] || "az";
+    filterToggle.classList.toggle("active", mode === "favorites" || mode === "trending");
+    const filterLabels = {
+      az: "FILTER: A-Z",
+      za: "FILTER: Z-A",
+      trending: "FILTER: TRENDING",
+      favorites: "FILTER: FAVORITES",
+    };
+    filterToggle.textContent = filterLabels[mode] || "FILTER: A-Z";
     const favoriteSet = new Set(getFavorites());
     const visibleGames = getVisibleGames();
     if (!visibleGames.length) {
@@ -622,8 +647,8 @@ function initGameScroller() {
     didDrag = false;
   });
 
-  favoritesToggle.addEventListener("click", () => {
-    favoritesFirst = !favoritesFirst;
+  filterToggle.addEventListener("click", () => {
+    currentFilterIndex = (currentFilterIndex + 1) % FILTER_MODES.length;
     renderStrip();
   });
 
@@ -655,7 +680,7 @@ function initGameScroller() {
     const inLeaderboard = normalized === "leaderboard";
     if (headingTitle) headingTitle.textContent = inLeaderboard ? "LEADERBOARD" : "GAMES";
     switchBtn.textContent = inLeaderboard ? "GAMES" : "LEADERBOARD";
-    favoritesToggle.style.display = inLeaderboard ? "none" : "inline-flex";
+    filterToggle.style.display = inLeaderboard ? "none" : "inline-flex";
     strip.style.display = inLeaderboard ? "none" : "flex";
     if (gameFrame) gameFrame.style.display = inLeaderboard ? "none" : "flex";
     if (leaderboardPanel) leaderboardPanel.style.display = inLeaderboard ? "grid" : "none";

--- a/styles.css
+++ b/styles.css
@@ -1174,6 +1174,7 @@ canvas {
   border: 2px solid var(--accent);
   background: rgba(0, 0, 0, 0.86);
   box-shadow: 0 0 20px var(--accent-dim);
+  min-height: unset;
   padding: 10px 14px 12px;
   display: flex;
   flex-direction: column;
@@ -1183,7 +1184,6 @@ canvas {
 
 .gamebox-shell {
   width: min(96vw, 1300px);
-  min-height: calc(100vh - var(--topbar-clearance) - 20px);
 }
 
 .gamebox-heading-row {
@@ -1409,15 +1409,14 @@ canvas {
   min-width: 84px;
 }
 
-#gameboxFavoritesToggle {
+#gameboxFilterToggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 36px;
-  width: 36px;
+  min-width: 98px;
   height: 36px;
-  padding: 0;
-  font-size: 16px;
+  padding: 0 8px;
+  font-size: 11px;
   line-height: 1;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1184,6 +1184,7 @@ canvas {
 
 .gamebox-shell {
   width: min(96vw, 1300px);
+  --gamebox-panel-min-height: clamp(420px, calc(100vh - var(--topbar-clearance) - 210px), 760px);
 }
 
 .gamebox-heading-row {
@@ -1214,7 +1215,7 @@ canvas {
   grid-template-rows: auto minmax(0, 1fr);
   gap: 10px;
   margin-bottom: 6px;
-  min-height: 760px;
+  min-height: var(--gamebox-panel-min-height);
 }
 
 .gamebox-leaderboard-panel .score-list {
@@ -1228,7 +1229,7 @@ canvas {
 
 .gamebox-frame {
   width: 100%;
-  min-height: 760px;
+  min-height: var(--gamebox-panel-min-height);
   flex: 1;
   position: relative;
   padding-top: 0;
@@ -1384,9 +1385,9 @@ canvas {
   background: rgba(0, 0, 0, 0.7);
   color: var(--accent);
   text-align: left;
-  min-width: 180px;
-  max-width: 220px;
-  padding: 10px;
+  min-width: clamp(150px, 16vw, 180px);
+  max-width: clamp(180px, 20vw, 220px);
+  padding: clamp(8px, 1vw, 10px);
   display: flex;
   flex-direction: column;
   gap: 6px;


### PR DESCRIPTION
### Motivation
- Provide a more flexible game filter UI in the games menu by replacing the single-star favorites toggle with a multi-mode filter that supports `A-Z`, `Z-A`, `Trending`, and `Favorites` modes. 
- Remove the fixed minimum height on the game overlay shells so game overlays can size more naturally.

### Description
- Replaced the header star button with a filter button in `index.html` (`id="gameboxFilterToggle"`) that displays the current mode label. 
- Implemented `FILTER_MODES` and `currentFilterIndex` in `script.js`, updated `getVisibleGames()` to support `az`, `za`, `trending` (by recent launches), and `favorites`, and updated `renderStrip()` to show the correct label and active styling. 
- Swapped the click handler to cycle filter modes (`filterToggle.addEventListener('click', ...)`) and adjusted leaderboard view handling to hide the filter in leaderboard mode. 
- Removed the `min-height` constraint from `.gamebox-shell` and set `.game-content-shell { min-height: unset; }`, and adjusted the filter button sizing in `styles.css` for readable labels.

### Testing
- Ran `node --check script.js` and `node --check core.js`, both succeeded. 
- Served the site with `python -m http.server 4173 --directory /workspace/webstie` and used Playwright to capture UI screenshots for visual verification, which produced artifacts. 
- The changes were committed locally and the simple static checks and visual verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2adbdaab08322baeb949640053bf5)