### PR TITLE
Monthly trend graph: legacy game key compatibility and legend hover glow

### DIFF
--- a/core.js
+++ b/core.js
@@ -1532,7 +1532,8 @@ async function refreshTrendingGames() {
     const counts = new Map();
     snap.forEach((entry) => {
       const data = entry.data() || {};
-      const key = String(data.game || "").toLowerCase().trim();
+      const legacyGameKey = data.key || data.gameKey || data.game_key;
+      const key = String(data.game || legacyGameKey || "").toLowerCase().trim();
       if (!key) return;
       counts.set(key, (counts.get(key) || 0) + 1);
     });
@@ -1660,7 +1661,13 @@ function renderMonthlyTrendingGraph(model) {
   const readout = document.getElementById("trendChartHoverReadout");
   const legend = document.getElementById("trendChartLegend");
   const lineEls = chart.querySelectorAll(".trend-line");
+  const pointEls = chart.querySelectorAll(".trend-point");
   const svg = document.getElementById("trendChartSvg");
+  const defaultReadout = "HOVER A LINE TO INSPECT PLAY COUNT.";
+  const cssEscape = (value) => {
+    if (typeof CSS !== "undefined" && typeof CSS.escape === "function") return CSS.escape(value);
+    return String(value).replace(/["\\]/g, "\\$&");
+  };
 
   const bindLegendLaunch = () => {
     legend?.querySelectorAll(".trend-legend-item").forEach((legendItem) => {
@@ -1676,6 +1683,7 @@ function renderMonthlyTrendingGraph(model) {
     if (!legend) return;
     legend.innerHTML = renderLegend(monthRows, "MONTH VIEW // MOST TO LEAST PLAYED");
     bindLegendLaunch();
+    bindLegendHover();
   };
 
   const setDayLegend = (dayIdx) => {
@@ -1689,10 +1697,12 @@ function renderMonthlyTrendingGraph(model) {
       .sort((a, b) => b.count - a.count);
     legend.innerHTML = renderLegend(rows, `${formatTrendDayLabel(dayMs)} // 24H PLAY ORDER`);
     bindLegendLaunch();
+    bindLegendHover();
   };
 
   const clearActive = () => {
     lineEls.forEach((line) => line.classList.remove("active"));
+    pointEls.forEach((point) => point.classList.remove("active"));
     legend?.querySelectorAll(".trend-legend-item").forEach((item) => item.classList.remove("active"));
   };
 
@@ -1703,11 +1713,28 @@ function renderMonthlyTrendingGraph(model) {
     const dayKey = new Date(dayMs).toISOString().slice(0, 10);
     const value = Number((model.dailyMatrix.get(game) || {})[dayKey] || 0);
     const label = TRENDING_GAME_LABELS[game] || game.toUpperCase();
+    const escapedGame = cssEscape(game);
     clearActive();
-    chart.querySelector(`.trend-line[data-game="${CSS.escape(game)}"]`)?.classList.add("active");
-    legend?.querySelector(`.trend-legend-item[data-game="${CSS.escape(game)}"]`)?.classList.add("active");
+    chart.querySelector(`.trend-line[data-game="${escapedGame}"]`)?.classList.add("active");
+    chart.querySelectorAll(`.trend-point[data-game="${escapedGame}"]`).forEach((point) => point.classList.add("active"));
+    legend?.querySelector(`.trend-legend-item[data-game="${escapedGame}"]`)?.classList.add("active");
     readout.innerText = `${label} // DAY ${dayIdx + 1} (${formatTrendDayLabel(dayMs)}) // ${value} PLAYS`;
   };
+
+  function bindLegendHover() {
+    legend?.querySelectorAll(".trend-legend-item").forEach((legendItem) => {
+      legendItem.addEventListener("mouseenter", () => {
+        const game = String(legendItem.getAttribute("data-game") || "");
+        const box = svg?.getBoundingClientRect();
+        if (!game || !box) return;
+        activateGameAtX(game, box.left, box.left, box.width);
+      });
+      legendItem.addEventListener("mouseleave", () => {
+        clearActive();
+        readout.innerText = defaultReadout;
+      });
+    });
+  }
 
   chart.querySelectorAll(".trend-line-hit").forEach((hit) => {
     hit.addEventListener("mousemove", (event) => {
@@ -1718,7 +1745,7 @@ function renderMonthlyTrendingGraph(model) {
     });
     hit.addEventListener("mouseleave", () => {
       clearActive();
-      readout.innerText = "HOVER A LINE TO INSPECT PLAY COUNT.";
+      readout.innerText = defaultReadout;
     });
   });
 
@@ -1735,7 +1762,7 @@ function renderMonthlyTrendingGraph(model) {
     if (target.closest(".trend-line-hit") || target.closest(".trend-point-hit") || target.closest(".trend-line") || target.closest(".trend-point")) return;
     setMonthLegend();
     clearActive();
-    readout.innerText = "HOVER A LINE TO INSPECT PLAY COUNT.";
+    readout.innerText = defaultReadout;
   });
 
   setMonthLegend();
@@ -1798,7 +1825,8 @@ async function refreshTrendingMonthGraph() {
     snap.forEach((entry) => {
       const data = entry.data() || {};
       const ts = normalizeTs(data.ts);
-      const game = String(data.game || "").toLowerCase().trim();
+      const legacyGameKey = data.key || data.gameKey || data.game_key;
+      const game = String(data.game || legacyGameKey || "").toLowerCase().trim();
       if (!game || ts < windowStart) return;
       const dayKey = toDayKey(ts);
       if (!dayKey) return;

--- a/styles.css
+++ b/styles.css
@@ -798,6 +798,7 @@ body::before {
   color: #fff;
   border-color: rgba(0, 255, 136, 0.7);
   background: rgba(0, 255, 136, 0.12);
+  box-shadow: 0 0 10px rgba(0, 255, 136, 0.45);
 }
 
 .trend-legend-swatch {
@@ -843,6 +844,7 @@ body::before {
 .trend-line.active {
   opacity: 1;
   stroke-width: 3.2;
+  filter: drop-shadow(0 0 4px currentColor);
 }
 
 .trend-line-hit {
@@ -854,6 +856,11 @@ body::before {
 
 .trend-point {
   opacity: 0.65;
+  transition: opacity 0.12s ease, r 0.12s ease;
+}
+
+.trend-point.active {
+  opacity: 1;
 }
 
 .trend-point-hit {


### PR DESCRIPTION
### Motivation
- Ensure trending counts remain correct for legacy play documents that used `key`, `gameKey`, or `game_key` instead of `game`. 
- Improve UX by making legend items highlight their series (line + points) and update the hover readout when the user hovers over legend rows.

### Description
- Added backward-compatible key parsing in both `refreshTrendingGames` and `refreshTrendingMonthGraph` to read `data.game` or fall back to `data.key`, `data.gameKey`, or `data.game_key` before normalizing. (core.js)
- Wired legend hover interactions in `renderMonthlyTrendingGraph` so hovering a `.trend-legend-item` activates the matching line and its points, highlights the legend row, and updates the hover readout; hovering out clears the active state. (core.js)
- Added a safe `CSS.escape` fallback when building attribute selectors to avoid errors in environments without `CSS.escape`. (core.js)
- Extended active/hover visuals by adding glow/drop-shadow and stronger active-point visibility via CSS changes to `.trend-legend-item.active`, `.trend-line.active`, and `.trend-point.active`. (styles.css)

### Testing
- Ran `node --check core.js` to validate syntax, which succeeded. 
- Served the site locally with `python3 -m http.server` and validated the monthly graph UI changes using a Playwright script that renders sample data and triggers a legend hover; the script captured a screenshot showing the legend hover effect. 
- Visual verification succeeded: legend hover activates the corresponding line and points and updates the readout as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ae708e888322a1831896e5a10128)