### PR TITLE
Launch games when selecting game boards from the leaderboard

### DIFF
--- a/core.js
+++ b/core.js
@@ -5680,6 +5680,11 @@ function renderLeaderboardGameStrip() {
       if (selectedBoard.type === "game") {
         const firstMode = selectedBoard.modes?.[0] || "single";
         if (!selectedBoard.modes?.includes(leaderboardSelectedMode)) leaderboardSelectedMode = firstMode;
+        if (typeof window.__setGameboxView === "function") window.__setGameboxView("games");
+        if (typeof window.launchGame === "function") {
+          window.launchGame(selectedBoard.id, "leaderboard-strip");
+          return;
+        }
       }
       loadLeaderboard();
     });


### PR DESCRIPTION
### Motivation
- Restore backward-compatible navigation so tapping a game card in the leaderboard opens the playable game in the Games view instead of only refreshing leaderboard rows.

### Description
- In `core.js` inside `renderLeaderboardGameStrip` when the selected board is a game the code now calls `window.__setGameboxView("games")` and `window.launchGame(selectedBoard.id, "leaderboard-strip")` and returns to avoid the leaderboard-only refresh, while preserving the previous `loadLeaderboard()` fallback.

### Testing
- No package-based test runner was available (`No package.json; no automated test suite available.`) so changes were verified by inspecting `git diff -- core.js` and confirming the intended insertions, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b155111c8322bd1bf3fc431f8a7a)