### PR TITLE
Add admin-only moderation toggle to chat header

### DIFF
--- a/core.js
+++ b/core.js
@@ -2896,7 +2896,7 @@ async function resolveAdminTargetUsers() {
 }
 
 async function applyAdminActionToTargets({ actionName, emptyToast, mutateRemote, mutateLocal, successToast, failToast }) {
-  if (!isGodUser()) return;
+  if (!canUseChatModeration()) return;
   try {
     const targets = await resolveAdminTargetUsers();
     if (!targets.length) {
@@ -4939,6 +4939,11 @@ let stopChatMuteListener = null;
 let activeDmUser = "";
 let globallyMutedUsers = new Set();
 let isChatInitialized = false;
+let isChatModerationModeEnabled = true;
+
+function canUseChatModeration() {
+  return isGodUser() && isChatModerationModeEnabled;
+}
 
 function getChatTabConfig(tab) {
   const crewTag = normalizeCrewTag(crewData?.tag || "");
@@ -5027,6 +5032,12 @@ function renderChatTab() {
   document.querySelectorAll(".chat-tab").forEach((btn) => {
     btn.classList.toggle("active", btn.dataset.chatTab === currentTab);
   });
+  const moderationBtn = document.getElementById("chatModerationToggleBtn");
+  if (moderationBtn) {
+    const adminView = isGodUser();
+    moderationBtn.style.display = adminView ? "" : "none";
+    moderationBtn.classList.toggle("off", !isChatModerationModeEnabled);
+  }
   if (input) input.placeholder = tabConfig.placeholder;
   if (meta) meta.textContent = tabConfig.meta;
   if (stopChatListener) {
@@ -5066,7 +5077,7 @@ function renderChatTab() {
 
       const canTargetUser = user && user !== "ANON" && user !== normalizeUsername(myName);
       if (canTargetUser) {
-        const isAdminView = isGodUser();
+        const canModerateChat = canUseChatModeration();
 
         const localMuteBtn = document.createElement("button");
         localMuteBtn.type = "button";
@@ -5076,7 +5087,7 @@ function renderChatTab() {
         localMuteBtn.onclick = () => toggleLocalChatMute(user);
         row.appendChild(localMuteBtn);
 
-        if (isAdminView) {
+        if (canModerateChat) {
           const globalMuteBtn = document.createElement("button");
           globalMuteBtn.type = "button";
           globalMuteBtn.className = "chat-mute-btn chat-global-mute-btn";
@@ -5088,7 +5099,7 @@ function renderChatTab() {
       }
 
       const isOwnMessage = normalizeUsername(m.user || "") === normalizeUsername(myName);
-      if ((isGodUser() || isOwnMessage) && m.id) {
+      if ((canUseChatModeration() || isOwnMessage) && m.id) {
         const removeBtn = document.createElement("button");
         removeBtn.type = "button";
         removeBtn.className = "chat-remove-btn";
@@ -5120,7 +5131,7 @@ function toggleLocalChatMute(username) {
 }
 
 async function toggleAdminChatMute(username) {
-  if (!isGodUser()) return;
+  if (!canUseChatModeration()) return;
   const user = normalizeUsername(username);
   if (!user) return;
   const targetRef = doc(db, "gooner_chat_mutes", user);
@@ -5155,7 +5166,7 @@ async function removeChatMessage(tab, messageId) {
   const messageRef = doc(db, collectionName, messageId);
   const canDelete = await runFirestoreTask(
     async () => {
-      if (isGodUser()) return true;
+      if (canUseChatModeration()) return true;
       const snapshot = await getDoc(messageRef);
       if (!snapshot.exists()) return false;
       const author = normalizeUsername(snapshot.data()?.user || "");
@@ -5180,6 +5191,18 @@ async function removeChatMessage(tab, messageId) {
 function initChat() {
   const chatRoot = document.getElementById("globalChat");
   const minimizeBtn = document.getElementById("chatMinimizeBtn");
+  const moderationBtn = document.getElementById("chatModerationToggleBtn");
+
+  const syncChatModerationUi = () => {
+    if (!moderationBtn) return;
+    const adminView = isGodUser();
+    moderationBtn.style.display = adminView ? "" : "none";
+    if (!adminView) return;
+    moderationBtn.classList.toggle("off", !isChatModerationModeEnabled);
+    moderationBtn.setAttribute("aria-pressed", isChatModerationModeEnabled ? "true" : "false");
+    moderationBtn.setAttribute("aria-label", isChatModerationModeEnabled ? "Disable moderation mode" : "Enable moderation mode");
+    moderationBtn.title = isChatModerationModeEnabled ? "Moderation mode on" : "Moderation mode off";
+  };
 
   const syncChatMinimizeUi = () => {
     const isMinimized = chatRoot?.classList.contains("minimized");
@@ -5196,7 +5219,16 @@ function initChat() {
       renderChatTab();
     });
   }
+  if (moderationBtn) {
+    moderationBtn.addEventListener("click", () => {
+      if (!isGodUser()) return;
+      isChatModerationModeEnabled = !isChatModerationModeEnabled;
+      syncChatModerationUi();
+      renderChatTab();
+    });
+  }
   syncChatMinimizeUi();
+  syncChatModerationUi();
 
   document.querySelectorAll(".chat-tab").forEach((btn) => {
     btn.addEventListener("click", () => {

--- a/index.html
+++ b/index.html
@@ -352,7 +352,17 @@
     <div id="globalChat" class="home-chat minimized">
       <div class="chat-header">
         <span>CHAT TERMINAL</span>
-        <button id="chatMinimizeBtn" class="chat-minimize-btn" type="button" aria-expanded="false" aria-controls="chatTabs chatMeta chatHistory chatInput">+</button>
+        <div class="chat-header-actions">
+          <button
+            id="chatModerationToggleBtn"
+            class="chat-minimize-btn chat-moderation-btn"
+            type="button"
+            aria-pressed="true"
+            aria-label="Disable moderation mode"
+            title="Moderation mode on"
+          >🔨</button>
+          <button id="chatMinimizeBtn" class="chat-minimize-btn" type="button" aria-expanded="false" aria-controls="chatTabs chatMeta chatHistory chatInput">+</button>
+        </div>
       </div>
       <div class="chat-tabs" id="chatTabs" role="tablist" aria-label="Chat channels">
         <button class="chat-tab" data-chat-tab="dm" type="button">MESSAGE USERS</button>

--- a/styles.css
+++ b/styles.css
@@ -323,6 +323,11 @@ body::before {
   align-items: center;
   justify-content: space-between;
 }
+.chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 .chat-minimize-btn {
   border: 1px solid var(--accent-dim);
   background: transparent;
@@ -338,6 +343,13 @@ body::before {
 .chat-minimize-btn:hover {
   border-color: var(--accent);
   color: #fff;
+}
+.chat-moderation-btn {
+  font-size: 11px;
+}
+.chat-moderation-btn.off {
+  opacity: 0.5;
+  filter: grayscale(0.8);
 }
 #globalChat.minimized {
   width: 220px;


### PR DESCRIPTION
### Motivation
- Provide a compact admin-only control to enable/disable moderation features in the chat without removing admin access entirely.  
- Allow admins to temporarily turn off moderation-only actions (global mutes / admin message removal) while keeping local user controls available.

### Description
- Added a small hammer-icon moderation toggle button to the chat header to the left of the minimize/maximize control in `index.html` (button id `chatModerationToggleBtn`).
- Added header layout and visual styles in `styles.css` including `.chat-header-actions`, `.chat-moderation-btn`, and an `.off` visual state for the toggle.
- Added moderation state and gating logic in `core.js`: introduced `isChatModerationModeEnabled`, `canUseChatModeration()` and UI sync logic; the toggle is shown only to admin/god users and updates ARIA attributes and title.
- Wired moderation gating so moderation-only actions are disabled when the toggle is off: global mute/unmute buttons and admin-level removal of other users' messages are hidden/blocked unless `canUseChatModeration()` is true.

### Testing
- Performed syntax checks with `node --check core.js` and `node --check script.js`, both succeeded.  
- Served the app with `python -m http.server` and captured a visual verification screenshot via Playwright showing the new hammer toggle in the chat header, which succeeded.  
- Verified the UI updates by loading the page and exercising the toggle to confirm moderation controls hide/show as expected (visual/automated screenshot verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a371dbc5708322ba3996764e04921b)