### PR TITLE
Add per-game fullscreen buttons and refine game-picker UI/layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -359,6 +359,39 @@ function disableInGameExitButtons() {
   });
 }
 
+function initPerGameFullscreenButtons() {
+  GAME_TEMPLATE_OVERLAY_IDS.forEach((overlayId) => {
+    const overlay = document.getElementById(overlayId);
+    if (!overlay) return;
+
+    const existingFullscreenBtn = overlay.querySelector(".fullscreen-btn-fixed, #voidMinerFullscreenBtn");
+    if (existingFullscreenBtn) {
+      existingFullscreenBtn.classList.add("fullscreen-btn-fixed");
+      return;
+    }
+
+    if (!getFullscreenTarget(overlay)) return;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "fullscreen-btn-fixed";
+    button.textContent = "FULLSCREEN";
+    button.addEventListener("click", async () => {
+      try {
+        await toggleGameFullscreen(overlay, button);
+      } catch (error) {
+        console.warn("Game fullscreen toggle failed", error);
+      }
+    });
+    overlay.appendChild(button);
+  });
+
+  document.addEventListener("fullscreenchange", () => {
+    document.querySelectorAll(".fullscreen-btn-fixed").forEach((button) => {
+      button.textContent = document.fullscreenElement ? "EXIT FULLSCREEN" : "FULLSCREEN";
+    });
+  });
+}
+
 const CANVAS_UI_PADDING = 230;
 const GAMEBOX_UI_PADDING = 130;
 const GAME_LIBRARY_FAVORITES_KEY = "goonerFavoriteGames";
@@ -542,7 +575,7 @@ function initGameScroller() {
       btn.type = "button";
       btn.className = `leaderboard-game-card${selectedGameId === game.id ? " active" : ""}${favoriteSet.has(game.id) ? " is-favorite" : ""}`;
       btn.dataset.game = game.id;
-      btn.innerHTML = `<span class="game-strip-icon-row"><span>${game.icon || "🎮"}</span></span><strong>${game.title}</strong><small>${game.description || ""}</small>`;
+      btn.innerHTML = `<span class="game-strip-icon-row"><span>${game.icon || "🎮"}</span></span><strong>${game.title}</strong><small>${game.description || ""}</small><small class="game-picker-hint">CLICK TO PLAY</small>`;
       btn.addEventListener("contextmenu", (event) => {
         event.preventDefault();
         toggleFavorite(game.id);
@@ -1192,6 +1225,7 @@ function initOverlayBackdropExit() {
 
 initSharedGamebox();
 disableInGameExitButtons();
+initPerGameFullscreenButtons();
 initTopBarOverlayControls();
 initOverlayBackdropExit();
 initGameCanvasSizing();

--- a/styles.css
+++ b/styles.css
@@ -1222,9 +1222,11 @@ canvas {
 
 .gamebox-game-strip {
   width: 100%;
-  min-height: 120px;
+  min-height: 116px;
   margin-bottom: 10px;
   overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  padding: 0 2px 8px;
 }
 
 
@@ -1404,7 +1406,7 @@ canvas {
   background: rgba(0, 0, 0, 0.7);
   color: var(--accent);
   text-align: left;
-  min-width: clamp(150px, 16vw, 180px);
+  min-width: clamp(148px, 16vw, 186px);
   max-width: clamp(180px, 20vw, 220px);
   padding: clamp(8px, 1vw, 10px);
   display: flex;
@@ -1412,6 +1414,7 @@ canvas {
   gap: 6px;
   min-height: 0;
   cursor: pointer;
+  scroll-snap-align: center;
 }
 
 .leaderboard-game-card.is-favorite {
@@ -1453,6 +1456,15 @@ canvas {
 .leaderboard-game-card small {
   font-size: 9px;
   color: #ddd;
+}
+
+
+.game-picker-hint {
+  font-size: 8px;
+  letter-spacing: 0.35px;
+  color: #8fffd0;
+  opacity: 0.75;
+  text-transform: uppercase;
 }
 
 .leaderboard-game-card.active,
@@ -1649,6 +1661,23 @@ canvas {
   z-index: 8;
 }
 
+
+#overlayGamebox.has-game-side-shop {
+  padding-left: 20px;
+}
+
+#overlayGamebox.has-game-side-shop .gamebox-frame {
+  padding-right: calc(var(--game-side-shop-width, 260px) + 18px);
+}
+
+#overlayGamebox .game-side-shop {
+  left: auto;
+  right: 14px;
+  top: 186px;
+  height: calc(var(--gamebox-panel-min-height) - 18px);
+  max-height: calc(var(--gamebox-panel-min-height) - 18px);
+}
+
 .game-side-shop h3 {
   margin: 0;
   font-size: 11px;
@@ -1705,6 +1734,14 @@ canvas {
     --game-side-shop-height: 460px;
   }
 
+  #overlayGamebox.has-game-side-shop .gamebox-frame {
+    padding-right: calc(var(--game-side-shop-width, 220px) + 14px);
+  }
+
+  #overlayGamebox .game-side-shop {
+    top: 178px;
+  }
+
   .gamebox-header-actions {
     position: static;
     flex-wrap: wrap;
@@ -1720,6 +1757,10 @@ canvas {
 @media (max-width: 760px) {
   .overlay.has-game-side-shop {
     padding-left: 20px;
+  }
+
+  #overlayGamebox.has-game-side-shop .gamebox-frame {
+    padding-right: 8px;
   }
 
   .game-side-shop {


### PR DESCRIPTION
### Motivation

- Provide per-game fullscreen controls for template game overlays so players can toggle fullscreen directly from each game's overlay.  
- Improve discoverability of playable items in the game strip by adding a subtle "click to play" hint.  
- Tweak leaderboard/gamebox layout and side-shop positioning to improve spacing and responsiveness.

### Description

- Add `initPerGameFullscreenButtons()` which injects a `.fullscreen-btn-fixed` button into each template overlay when a fullscreen target exists and wires it to `toggleGameFullscreen`, and register a `fullscreenchange` listener to update button text.  
- Ensure existing fullscreen controls (including `#voidMinerFullscreenBtn`) are preserved by adding a selector check and applying the `.fullscreen-btn-fixed` class when found.  
- Call `initPerGameFullscreenButtons()` during initialization alongside other overlay setup calls.  
- Update the game strip rendering to append a small hint element (`<small class="game-picker-hint">CLICK TO PLAY</small>`) to each game card.  
- CSS adjustments: slightly adjust `.gamebox-game-strip` min-height and add `scroll-snap-type` and padding, tweak `.leaderboard-game-card` min-width and add `scroll-snap-align`, add `.game-picker-hint` styling, and refine `.game-side-shop` and `#overlayGamebox` layout and responsive paddings for better alignment.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a869744f7c8327b3b281fcf7b597d4)