### PR TITLE
Add HEX FALL and modernize game selector with persistent search

### DIFF
--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -28,6 +28,7 @@ export const GAME_DIRECTORY_ENTRIES = Object.freeze([
   { id: "metromaze", title: "METRO MAZE", description: "Procedural mazes with relics, sentinels, and level exits.", icon: "🚇", tags: ["skill", "maze", "puzzle", "strategy"] },
   { id: "stacksmash", title: "STACK SMASH", description: "Break layered stacks for big spike payouts.", icon: "🪨", tags: ["arcade", "timing", "reflex"] },
   { id: "quantumflip", title: "QUANTUM FLIP", description: "Pilot a phase core: chain matching orbs and survive hunter waves.", icon: "⚛️", tags: ["skill", "strategy", "survival"] },
+  { id: "hexfall", title: "HEX FALL", description: "Rapid target popping: clear falling nodes before they crash.", icon: "🔷", tags: ["arcade", "reflex", "timing"] },
   { id: "flappy", title: "FLAPPY GOON", description: "Secret bonus mode: tap to survive.", icon: "🐤", tags: ["arcade", "skill"], hidden: true, shopItems: ["item_flappy", "item_shield"] },
 ]);
 

--- a/games/hexfall.js
+++ b/games/hexfall.js
@@ -1,0 +1,129 @@
+import { registerGameStop, setText, showToast, state, updateHighScore } from "../core.js";
+
+const WIDTH = 800;
+const HEIGHT = 420;
+const ROUND_MS = 25000;
+
+let run = null;
+
+function stop() {
+  if (!run) return;
+  window.clearInterval(run.timer);
+  window.cancelAnimationFrame(run.raf);
+  if (run.canvas) run.canvas.onpointerdown = null;
+  run = null;
+}
+
+function makeTile() {
+  const radius = 20 + Math.random() * 20;
+  return {
+    x: 60 + Math.random() * (WIDTH - 120),
+    y: -40 - Math.random() * 120,
+    radius,
+    speed: 70 + Math.random() * 120,
+    color: `hsl(${180 + Math.random() * 140}, 85%, 58%)`,
+  };
+}
+
+export function initHexfall() {
+  stop();
+  state.currentGame = "hexfall";
+
+  const canvas = document.getElementById("hexfallCanvas");
+  const action = document.getElementById("hexfallAction");
+  if (!canvas || !action) return;
+  const ctx = canvas.getContext("2d");
+
+  let score = 0;
+  let remaining = ROUND_MS;
+  let started = false;
+  let lastTs = performance.now();
+  const tiles = Array.from({ length: 8 }, makeTile);
+
+  setText("hexfallScore", "SCORE: 0");
+  setText("hexfallTimer", `TIME: ${(ROUND_MS / 1000).toFixed(1)}s`);
+  setText("hexfallHud", "TAP FALLING NODES BEFORE THEY HIT THE FLOOR");
+
+  action.disabled = true;
+  action.textContent = "ROUND LIVE";
+
+  canvas.onpointerdown = (event) => {
+    started = true;
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+    const y = ((event.clientY - rect.top) / rect.height) * HEIGHT;
+
+    const hit = tiles.find((tile) => {
+      const dx = x - tile.x;
+      const dy = y - tile.y;
+      return dx * dx + dy * dy <= tile.radius * tile.radius;
+    });
+
+    if (!hit) {
+      score = Math.max(0, score - 8);
+    } else {
+      score += Math.round(12 + hit.radius);
+      Object.assign(hit, makeTile());
+      hit.y = -30;
+    }
+
+    setText("hexfallScore", `SCORE: ${Math.floor(score)}`);
+    updateHighScore("hexfall", Math.floor(score));
+  };
+
+  const timer = window.setInterval(() => {
+    if (!started) return;
+    remaining -= 100;
+    setText("hexfallTimer", `TIME: ${(Math.max(0, remaining) / 1000).toFixed(1)}s`);
+    if (remaining <= 0) {
+      const finalScore = Math.floor(score);
+      stop();
+      updateHighScore("hexfall", finalScore);
+      showToast(`HEX FALL: ${finalScore} PTS`, "🔷");
+      action.disabled = false;
+      action.textContent = "PLAY AGAIN";
+      action.onclick = initHexfall;
+    }
+  }, 100);
+
+  function frame(ts) {
+    if (!run) return;
+    const dt = started ? Math.min(0.04, (ts - lastTs) / 1000) : 0;
+    lastTs = ts;
+
+    ctx.fillStyle = "#051018";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    const floorY = HEIGHT - 30;
+    ctx.fillStyle = "#153047";
+    ctx.fillRect(0, floorY, WIDTH, HEIGHT - floorY);
+
+    tiles.forEach((tile) => {
+      tile.y += tile.speed * dt;
+      if (tile.y + tile.radius >= floorY) {
+        score = Math.max(0, score - 20);
+        Object.assign(tile, makeTile());
+      }
+
+      ctx.fillStyle = tile.color;
+      ctx.beginPath();
+      ctx.arc(tile.x, tile.y, tile.radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = "rgba(255,255,255,0.35)";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+
+    ctx.fillStyle = "rgba(120, 220, 255, 0.9)";
+    ctx.font = "bold 14px monospace";
+    ctx.textAlign = "left";
+    ctx.fillText("HEX FALL", 14, 24);
+
+    run.raf = window.requestAnimationFrame(frame);
+  }
+
+  run = { canvas, timer, raf: 0 };
+  run.raf = window.requestAnimationFrame(frame);
+  registerGameStop(stop);
+}

--- a/index.html
+++ b/index.html
@@ -991,7 +991,7 @@
           <h2 id="gameboxHeadingTitle">GAMES</h2>
           <div class="leaderboard-heading-actions gamebox-header-actions">
             <button class="menu-btn leaderboard-search-toggle" id="gameboxFilterToggle" type="button" title="CHANGE GAME FILTER">FILTER: A-Z</button>
-            <button class="menu-btn leaderboard-search-toggle" id="gameboxSearchToggle" type="button">SEARCH</button>
+            <button class="menu-btn leaderboard-search-toggle" id="gameboxSearchToggle" type="button">CLEAR SEARCH</button>
             <button class="menu-btn leaderboard-search-toggle" id="gameboxSwitchBtn" type="button">LEADERBOARD</button>
             <button id="topFullscreenBtn" class="menu-btn" type="button" style="display: none">FULLSCREEN</button>
           </div>
@@ -1000,9 +1000,8 @@
           class="term-input leaderboard-search-input gamebox-search-input"
           id="gameboxSearchInput"
           type="search"
-          placeholder="SEARCH GAMES..."
+          placeholder="SEARCH GAMES BY NAME, TAG, OR DESCRIPTION"
           autocomplete="off"
-          style="display: none"
         />
         <div class="leaderboard-game-strip gamebox-game-strip" id="gameboxGameStrip" aria-label="Game selector strip"></div>
         <div id="gameboxLeaderboardPanel" class="gamebox-leaderboard-panel" style="display: none">
@@ -1801,6 +1800,18 @@
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>
 
+
+    <div class="overlay" id="overlayHexfall">
+      <h1>HEX FALL</h1>
+      <div class="high-score-display">HIGH: <span id="hsHexfall">0</span></div>
+      <div style="margin-bottom: 10px" id="hexfallTimer">TIME: 25.0s</div>
+      <div style="margin-bottom: 8px" id="hexfallScore">SCORE: 0</div>
+      <div style="margin-bottom: 12px" id="hexfallHud">TAP FALLING NODES BEFORE THEY HIT THE FLOOR</div>
+      <canvas id="hexfallCanvas" width="800" height="420"></canvas>
+      <div class="mobile-hint active" style="margin-top: 10px">CLICK / TAP FALLING NODES TO SCORE</div>
+      <button class="term-btn" id="hexfallAction" style="margin-top: 14px">START ROUND</button>
+      <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
+    </div>
     <div class="overlay" id="overlayQuantumflip">
       <h1>QUANTUM FLIP</h1>
       <div class="high-score-display">HIGH: <span id="hsQuantumflip">0</span></div>

--- a/script.js
+++ b/script.js
@@ -80,6 +80,7 @@ import { initLaserLock } from "./games/laserlock.js";
 import { initMetroMaze } from "./games/metromaze.js";
 import { initStackSmash } from "./games/stacksmash.js";
 import { initQuantumFlip } from "./games/quantumflip.js";
+import { initHexfall } from "./games/hexfall.js";
 import { initUltimateTTT } from "./games/ultimatettt.js";
 import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
 
@@ -299,6 +300,7 @@ window.launchGame = (game, source = "direct") => {
   if (game === "metromaze") initMetroMaze();
   if (game === "stacksmash") initStackSmash();
   if (game === "quantumflip") initQuantumFlip();
+  if (game === "hexfall") initHexfall();
   if (game === "ultimatettt") initUltimateTTT();
   if (typeof window.__updateGameSwitcherState === "function") window.__updateGameSwitcherState(game);
   resizeAllGameCanvases();
@@ -339,6 +341,7 @@ const GAME_TEMPLATE_OVERLAY_IDS = [
   "overlayMetromaze",
   "overlayStacksmash",
   "overlayQuantumflip",
+  "overlayHexfall",
   "overlayUltimatettt",
 ];
 
@@ -686,14 +689,10 @@ function initGameScroller() {
   });
 
   searchToggle.addEventListener("click", () => {
-    const opening = searchInput.style.display === "none";
-    searchInput.style.display = opening ? "block" : "none";
-    if (opening) searchInput.focus();
-    else {
-      searchInput.value = "";
-      gameSearchQuery = "";
-      renderStrip();
-    }
+    searchInput.value = "";
+    gameSearchQuery = "";
+    renderStrip();
+    searchInput.focus();
   });
 
   searchInput.addEventListener("input", () => {
@@ -714,7 +713,7 @@ function initGameScroller() {
     if (headingTitle) headingTitle.textContent = inLeaderboard ? "LEADERBOARD" : "GAMES";
     switchBtn.textContent = inLeaderboard ? "GAMES" : "LEADERBOARD";
     filterToggle.style.display = inLeaderboard ? "none" : "inline-flex";
-    strip.style.display = inLeaderboard ? "none" : "flex";
+    strip.style.display = inLeaderboard ? "none" : "grid";
     if (gameFrame) gameFrame.style.display = inLeaderboard ? "none" : "flex";
     if (leaderboardPanel) leaderboardPanel.style.display = inLeaderboard ? "grid" : "none";
     const sharedOverlay = document.getElementById(SHARED_GAME_OVERLAY_ID);
@@ -1264,6 +1263,7 @@ document.getElementById("goRestart").onclick = () => {
   if (state.currentGame === "metromaze") initMetroMaze();
   if (state.currentGame === "stacksmash") initStackSmash();
   if (state.currentGame === "quantumflip") initQuantumFlip();
+  if (state.currentGame === "hexfall") initHexfall();
   if (state.currentGame === "roulette") {
     initRoulette();
     document.getElementById("overlayRoulette").classList.add("active");

--- a/styles.css
+++ b/styles.css
@@ -1369,11 +1369,12 @@ canvas {
 
 
 .leaderboard-game-strip {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
   gap: 10px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding-bottom: 8px;
+  overflow-y: auto;
+  max-height: 270px;
+  padding: 4px 2px 10px;
   margin-bottom: 12px;
 }
 
@@ -1383,6 +1384,8 @@ canvas {
   align-items: center;
   gap: 10px;
   margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba(0, 255, 195, 0.2);
 }
 
 .leaderboard-heading-actions {
@@ -1399,22 +1402,23 @@ canvas {
 
 .leaderboard-search-input {
   margin-bottom: 10px;
+  min-height: 38px;
 }
 
 .leaderboard-game-card {
   border: 1px solid var(--accent);
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(0, 0, 0, 0.72);
   color: var(--accent);
   text-align: left;
-  min-width: clamp(168px, 18vw, 210px);
-  max-width: clamp(190px, 22vw, 240px);
-  padding: clamp(8px, 1vw, 10px);
+  width: 100%;
+  padding: 10px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   min-height: 0;
   cursor: pointer;
-  scroll-snap-align: center;
+  border-radius: 6px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 .leaderboard-game-card.is-favorite {
@@ -1429,7 +1433,7 @@ canvas {
 }
 
 .gamebox-heading-row .leaderboard-search-toggle {
-  min-width: 84px;
+  min-width: 100px;
 }
 
 #gameboxFilterToggle {
@@ -1471,6 +1475,7 @@ canvas {
 .leaderboard-game-card:hover {
   background: var(--accent-dim);
   box-shadow: 0 0 10px var(--accent-dim);
+  transform: translateY(-1px);
 }
 
 .leaderboard-layout {


### PR DESCRIPTION
### Motivation

- Add a new reflex mini-game to expand the playable catalog and wire it into existing launcher lifecycle hooks.  
- Improve the Gamebox selector UX so search is always available, cleaner, and easier to reset while keeping the game picker compact.

### Description

- Added a new game implementation at `games/hexfall.js` with full round lifecycle (timer, scoring, hit detection, penalties, restart flow, high-score updates) and a `initHexfall` export.  
- Registered the new entry in `gameCatalog.js` (`{ id: "hexfall", title: "HEX FALL" ... }`) so it appears in the directory and leaderboard metadata.  
- Wired the game into the launcher in `script.js` by importing `initHexfall`, adding it to the `launchGame` routing and template/restore lists, and adding a restart handler entry so `goRestart` restarts `hexfall`.  
- Added the overlay UI for HEX FALL to `index.html` (score/timer/hud/canvas/action button) and changed the Gamebox search control label to `CLEAR SEARCH` and the search input placeholder to `SEARCH GAMES BY NAME, TAG, OR DESCRIPTION`.  
- Changed Gamebox behavior in `script.js` so the search control clears + focuses the persistent input (instead of toggling visibility) and adjusted the mounted strip display to use a grid.  
- Updated `styles.css` to convert the game strip to a responsive card-grid, refine card sizing/hover polish, and increase layout consistency for the game selector.

### Testing

- Ran static checks: `node --check script.js`, `node --check gameCatalog.js`, and `node --check games/hexfall.js` (all succeeded).  
- Launched a local server with `python3 -m http.server 4173` and ran a headless browser script to open the Gamebox, perform a search for `hex`, and capture a screenshot of the updated selector UI (succeeded).  
- Verified the new game module loads in the browser trace and the Gamebox UI reflects the layout and search changes (screenshot artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5101d6438833187f1b71f0913f4ae)