### PR TITLE
Add per-room seeded PRNG state and `seededRandom()` method to Room

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -7968,6 +7968,7 @@
                 this.isMimicRoom = isMimicRoom;
                 this.isWaveRoom = isWaveRoom;
                 this.enemies = [];
+                this.randState = (this.seed >>> 0) || 1;
 
                 // Wave mechanics
                 if (this.isWaveRoom) {
@@ -8161,6 +8162,11 @@
                         }
                     }
                 }
+            }
+
+            seededRandom() {
+                this.randState = (this.randState * 1664525 + 1013904223) >>> 0;
+                return this.randState / 4294967296;
             }
 
             updateRoomState() {


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, per-room pseudo-random state so procedural elements can use reproducible randomness tied to the room seed.

### Description
- Initialize a per-room random state as `this.randState = (this.seed >>> 0) || 1` and add a `seededRandom()` method implementing an LCG (`this.randState = (this.randState * 1664525 + 1013904223) >>> 0; return this.randState / 4294967296;`) to produce repeatable values in `[0,1)` while keeping the existing local `rand()` function intact.

### Testing
- Ran the repository's automated checks including linting and the unit test suite and observed they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcea4e95bc8331afc1becad3e4e63c)