### PR TITLE
Handle War room creation failures gracefully

### DIFF
--- a/games/war.js
+++ b/games/war.js
@@ -217,8 +217,12 @@ document.getElementById("btnCreateWar").onclick = async () => {
     { uid: state.myUid, name: state.myName, bet: 0, ready: false, card: null, score: 0 },
     null,
   ];
-  await setDoc(getWarRef(code), { seats, deck: createDeck(), phase: "lobby", pot: 0, round: 1 });
-  joinWar(code, 0);
+  try {
+    await setDoc(getWarRef(code), { seats, deck: createDeck(), phase: "lobby", pot: 0, round: 1 });
+    joinWar(code, 0);
+  } catch (error) {
+    if (!handleFirebaseError(error, "WAR CREATE", "Could not create room.")) showToast("FAILED TO CREATE");
+  }
 };
 
 document.getElementById("btnJoinWar").onclick = async () => {


### PR DESCRIPTION
### Motivation
- Players reported they could not create multiplayer War rooms and the create flow failed silently when Firestore errors occurred.

### Description
- Wrapped the War `CREATE ROOM` flow in a `try/catch` block in `games/war.js` so the `setDoc` write is only followed by `joinWar` on success.
- Added Firebase-aware error reporting using `handleFirebaseError` and a fallback `showToast("FAILED TO CREATE")` to surface actionable feedback to the player.
- Change affects the click handler attached to `document.getElementById("btnCreateWar")` and does not alter existing room schema or join/start logic.

### Testing
- Ran `node --check games/war.js` to validate the modified file parses without syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad439c8e08327883bcb8aef3f8718)