### PR TITLE
Fix shop and inventory ON/OFF toggle status updates

### DIFF
--- a/core.js
+++ b/core.js
@@ -4654,6 +4654,7 @@ export function renderInventory() {
 
 function renderShop() {
   const list = document.getElementById("shopList");
+  if (!list) return;
   setText("shopBank", myMoney);
   list.innerHTML = "";
   SHOP_ITEMS.forEach((item) => {
@@ -4731,6 +4732,7 @@ export function toggleItem(id) {
   updateMatrixToggle();
   saveStats();
   renderShop();
+  renderInventory();
   const itemName = SHOP_ITEMS.find((item) => item.id === id)?.name || "ITEM";
   showToast(`${enabled ? "ENABLED" : "DISABLED"}: ${itemName}`, enabled ? "🟢" : "🔴");
 }


### PR DESCRIPTION
### Motivation
- ON/OFF buttons in the Inventory and Shop did not always reflect the current toggle state after a user toggled an item. 
- Ensure UI stays consistent by re-rendering both shop and inventory views when an item is toggled and avoid errors when the shop list container is unavailable.

### Description
- Added a defensive null check at the start of `renderShop()` so it returns early if `document.getElementById("shopList")` is missing. 
- Updated `toggleItem(id)` to call `renderShop()` and `renderInventory()` after updating the item toggle so both panels immediately reflect the new ON/OFF state. 
- Kept existing toggle logic (setting `myItemToggles`, applying visuals, matrix special-case handling, toast notifications) unchanged.

### Testing
- Ran `node --check core.js` to validate syntax and the check succeeded. 
- Attempted an automated UI interaction test via a Playwright script to click shop/inventory toggles, but it failed due to the test environment missing the `playwright` package (test did not run to completion).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe355676c8327a720c2655c6b56a7)