### PR TITLE
Remove stray top close control from home header

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,11 +68,6 @@
           ADMIN
         </button>
         <button class="menu-btn" id="menuToggle">GAMES</button>
-        <div id="topOverlayControls" class="top-overlay-controls" aria-live="polite">
-          <button id="topCloseBtn" class="menu-btn" type="button" style="display: none">
-            CLOSE
-          </button>
-        </div>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -1079,7 +1079,6 @@ function initAdminTabs() {
 function initTopBarOverlayControls() {
   const overlays = Array.from(document.querySelectorAll(".overlay"));
   const fsBtn = document.getElementById("topFullscreenBtn");
-  const closeBtn = document.getElementById("topCloseBtn");
   if (!overlays.length || !fsBtn) return;
 
   const OVERLAY_TAB_MAP = {
@@ -1176,9 +1175,6 @@ function initTopBarOverlayControls() {
 
     fsBtn.style.display = canFullscreen ? "inline-flex" : "none";
     fsBtn.textContent = document.fullscreenElement ? "EXIT FULLSCREEN" : "FULLSCREEN";
-    if (closeBtn) {
-      closeBtn.style.display = "none";
-    }
   }
 
   const observer = new MutationObserver(updateControls);


### PR DESCRIPTION
### Motivation
- The top header contained an unused `CLOSE` control that rendered as a stray close bar on the home screen and its matching JS handlers were no longer needed.

### Description
- Removed the `topOverlayControls` markup block (the `button` with `id="topCloseBtn"`) from `index.html` and removed the unused `topCloseBtn` handling in `initTopBarOverlayControls` inside `script.js`, preserving existing fullscreen and overlay exit logic.

### Testing
- Ran `node --check script.js` to validate the modified JS and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3d743aa88327a8f88ca963cfd01b)