### PR TITLE
Add one-day April Fools visual mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
     </div>
 
     <div class="dropdown-content" id="menuDropdown"></div>
+    <div id="aprilFoolsBanner" class="april-fools-banner" hidden>
+      APRIL FOOLS MODE ACTIVE // CHAOS PATCH ENABLED FOR 24 HOURS
+    </div>
 
     <div class="overlay menu-overlay" id="overlayTrending">
       <div class="score-box panel-overlay-box">

--- a/script.js
+++ b/script.js
@@ -51,6 +51,7 @@ import {
   updateHighScore,
   getShopItemById,
   openGameLeaderboard,
+  showToast,
 } from "./core.js";
 import { initGeometry } from "./games/geo.js";
 import { initFlappy } from "./games/flappy.js";
@@ -1194,6 +1195,20 @@ function initOverlayBackdropExit() {
   });
 }
 
+function initAprilFoolsMode() {
+  const now = new Date();
+  const isAprilFoolsDay = now.getMonth() === 3 && now.getDate() === 1;
+  if (!isAprilFoolsDay) return;
+
+  document.body.classList.add("rainbow-mode");
+  const banner = document.getElementById("aprilFoolsBanner");
+  if (banner) banner.hidden = false;
+
+  setTimeout(() => {
+    showToast("APRIL FOOLS MODE", "🤡", "This visual event auto-disables on April 2.");
+  }, 600);
+}
+
 initSharedGamebox();
 disableInGameExitButtons();
 initPerGameFullscreenButtons();
@@ -1204,6 +1219,7 @@ initGameCanvasSizing();
 initGameVisibilityGuards();
 initGameScroller();
 initMainSiteSearch();
+initAprilFoolsMode();
 
 function hideGameOverModal() {
   const modal = document.getElementById("modalGameOver");

--- a/styles.css
+++ b/styles.css
@@ -208,6 +208,29 @@ body::before {
   align-items: center;
   gap: 12px;
 }
+
+.april-fools-banner {
+  position: fixed;
+  top: 52px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1900;
+  padding: 6px 12px;
+  border: 1px dashed #ff5cad;
+  background: rgba(0, 0, 0, 0.9);
+  color: #ff88c8;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-shadow: 0 0 6px rgba(255, 92, 173, 0.8);
+  animation: aprilFoolsBlink 1s steps(2, end) infinite;
+}
+
+@keyframes aprilFoolsBlink {
+  50% {
+    opacity: 0.65;
+  }
+}
 .menu-btn {
   background: transparent;
   color: var(--accent);


### PR DESCRIPTION
### Motivation
- Add a neutral, time-gated April Fools visual event that only activates for a single day (April 1) to provide a lightweight in-site celebration.

### Description
- Added an always-hidden banner element in `index.html`, new `.april-fools-banner` styles in `styles.css`, and a date-gated initializer `initAprilFoolsMode` in `script.js` (imports `showToast`), which enables `rainbow-mode`, reveals the banner, and shows a toast only on April 1.

### Testing
- Ran `node --check script.js` to validate JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd440ebc588327bc0eaede6195930b)