### PR TITLE
Add inventory/hotbar, crafting, and procedural world gen to Builder

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -27,6 +27,11 @@ export function initBuilder() {
     const uiX = document.getElementById("builderX");
     const uiY = document.getElementById("builderY");
     const uiBlockType = document.getElementById("builderBlockType");
+    const hotbarEl = document.getElementById("builderHotbar");
+    const craftGlassBtn = document.getElementById("builderCraftGlass");
+    const craftBrickBtn = document.getElementById("builderCraftBrick");
+    const craftWoodBtn = document.getElementById("builderCraftWood");
+    const craftStoneBtn = document.getElementById("builderCraftStone");
 
     const TILE_SIZE = 32;
 
@@ -37,6 +42,11 @@ export function initBuilder() {
         4: "#e1c699", // Wood
         5: "#ffffff", // Glass
         6: "#b22222", // Brick
+        7: "#d9c37a", // Sand
+        8: "#f0f8ff", // Snow
+        9: "#2f7f2f", // Leaves
+        10: "#2f2f2f", // Coal
+        11: "#8f7b6e", // Iron
     };
 
     const blockNames = {
@@ -46,10 +56,17 @@ export function initBuilder() {
         4: "WOOD",
         5: "GLASS",
         6: "BRICK",
+        7: "SAND",
+        8: "SNOW",
+        9: "LEAVES",
+        10: "COAL",
+        11: "IRON",
     };
 
-    let selectedBlockType = 3; // Default to stone
+    let selectedHotbarSlot = 0;
     let localPlayerId = null;
+    let worldWidth = 100;
+    let worldHeight = 40;
 
     let camera = { x: 0, y: 0 };
 
@@ -72,6 +89,8 @@ export function initBuilder() {
 
             menu.style.display = "none";
             gameArea.style.display = "block";
+            worldWidth = room.state.worldWidth || worldWidth;
+            worldHeight = room.state.worldHeight || worldHeight;
 
             startGameLoop();
         } catch (e) {
@@ -89,9 +108,9 @@ export function initBuilder() {
             keys.w = true;
         }
 
-        // Block selection (1-6)
-        if (e.key >= "1" && e.key <= "6") {
-            selectedBlockType = parseInt(e.key);
+        // Hotbar selection (1-9)
+        if (e.key >= "1" && e.key <= "9") {
+            selectedHotbarSlot = parseInt(e.key, 10) - 1;
         }
     }
 
@@ -111,13 +130,16 @@ export function initBuilder() {
     }
 
     function sendBuildOrBreak(e) {
+        const localPlayer = room?.state?.players?.get(localPlayerId);
+        if (!localPlayer) return;
         const worldX = mouse.x + camera.x;
         const worldY = mouse.y + camera.y;
+        const selectedBlockType = localPlayer.hotbar?.[selectedHotbarSlot] || 0;
 
         if (e.shiftKey || e.button === 2) {
             // Break
             room.send("break", { x: worldX, y: worldY });
-        } else {
+        } else if (selectedBlockType) {
             // Build
             room.send("build", { x: worldX, y: worldY, type: selectedBlockType });
         }
@@ -196,11 +218,24 @@ export function initBuilder() {
             // Constrain camera (optional, based on world size)
             camera.x = Math.max(0, camera.x);
             camera.y = Math.max(0, camera.y);
+            camera.x = Math.min(camera.x, worldWidth * TILE_SIZE - canvas.width);
+            camera.y = Math.min(camera.y, worldHeight * TILE_SIZE - canvas.height);
 
             // Update UI
             uiX.textContent = Math.floor(localPlayer.x / TILE_SIZE);
             uiY.textContent = Math.floor(localPlayer.y / TILE_SIZE);
-            uiBlockType.textContent = blockNames[selectedBlockType];
+            const selectedType = localPlayer.hotbar?.[selectedHotbarSlot] || 0;
+            uiBlockType.textContent = blockNames[selectedType] || "EMPTY";
+
+            hotbarEl.innerHTML = "";
+            for (let i = 0; i < 9; i++) {
+                const typeId = localPlayer.hotbar?.[i] || 0;
+                const count = Number(localPlayer.inventory?.get(String(typeId)) || 0);
+                const slot = document.createElement("div");
+                slot.className = `builder-slot ${i === selectedHotbarSlot ? "active" : ""}`;
+                slot.textContent = `${i + 1}: ${blockNames[typeId] || "EMPTY"} (${count})`;
+                hotbarEl.appendChild(slot);
+            }
         }
 
         ctx.save();
@@ -252,10 +287,13 @@ export function initBuilder() {
         ctx.strokeRect(gridX, gridY, TILE_SIZE, TILE_SIZE);
 
         // Preview block color slightly transparent
-        ctx.fillStyle = blockColors[selectedBlockType];
-        ctx.globalAlpha = 0.5;
-        ctx.fillRect(gridX, gridY, TILE_SIZE, TILE_SIZE);
-        ctx.globalAlpha = 1.0;
+        const selectedType = localPlayer?.hotbar?.[selectedHotbarSlot] || 0;
+        if (selectedType) {
+            ctx.fillStyle = blockColors[selectedType] || "#ffffff";
+            ctx.globalAlpha = 0.5;
+            ctx.fillRect(gridX, gridY, TILE_SIZE, TILE_SIZE);
+            ctx.globalAlpha = 1.0;
+        }
 
         ctx.restore();
 
@@ -266,6 +304,19 @@ export function initBuilder() {
         if (animationFrameId) cancelAnimationFrame(animationFrameId);
         render();
     }
+
+    const sendCraft = (recipeId) => {
+        if (!room) return;
+        room.send("craft", { recipeId });
+    };
+    const onCraftGlass = () => sendCraft("glass");
+    const onCraftBrick = () => sendCraft("brick");
+    const onCraftWood = () => sendCraft("wood");
+    const onCraftStone = () => sendCraft("stone");
+    craftGlassBtn?.addEventListener("click", onCraftGlass);
+    craftBrickBtn?.addEventListener("click", onCraftBrick);
+    craftWoodBtn?.addEventListener("click", onCraftWood);
+    craftStoneBtn?.addEventListener("click", onCraftStone);
 
     // Cleanup hook
     const stopBuilder = () => {
@@ -280,6 +331,10 @@ export function initBuilder() {
         canvas.removeEventListener("mousedown", handleMouseDown);
         canvas.removeEventListener("mouseup", handleMouseUp);
         canvas.removeEventListener("mouseleave", handleMouseUp);
+        craftGlassBtn?.removeEventListener("click", onCraftGlass);
+        craftBrickBtn?.removeEventListener("click", onCraftBrick);
+        craftWoodBtn?.removeEventListener("click", onCraftWood);
+        craftStoneBtn?.removeEventListener("click", onCraftStone);
         clearBuildHoldTimers();
         menu.style.display = "block";
         gameArea.style.display = "none";

--- a/index.html
+++ b/index.html
@@ -2027,11 +2027,18 @@
       <div id="builderGame" class="builder-wrap" style="display: none">
         <div class="builder-hud">
           <span>X: <span id="builderX">0</span> Y: <span id="builderY">0</span></span>
-          <span style="margin-left: 20px;">BLOCK: <span id="builderBlockType">GRASS</span></span>
+          <span style="margin-left: 20px;">SLOT: <span id="builderBlockType">STONE</span></span>
         </div>
         <canvas id="builderCanvas" width="800" height="450" style="background: #87CEEB;"></canvas>
+        <div class="builder-hotbar" id="builderHotbar"></div>
+        <div class="builder-crafting">
+          <button class="menu-btn" id="builderCraftGlass">CRAFT GLASS (2 SAND)</button>
+          <button class="menu-btn" id="builderCraftBrick">CRAFT BRICK (2 STONE + 1 DIRT)</button>
+          <button class="menu-btn" id="builderCraftWood">CRAFT WOOD (2 LEAVES)</button>
+          <button class="menu-btn" id="builderCraftStone">CRAFT STONE (2 DIRT)</button>
+        </div>
         <div class="mobile-hint active" style="margin-top: 10px">
-          WASD TO MOVE. CLICK TO BUILD. SHIFT-CLICK TO BREAK. NUMBER KEYS TO SELECT BLOCK.
+          WASD TO MOVE. CLICK TO BUILD. SHIFT/RIGHT-CLICK TO MINE. 1-9 TO SELECT HOTBAR.
         </div>
       </div>
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const colyseus = require("colyseus");
 const { WebSocketTransport } = require("@colyseus/ws-transport");
-const { Schema, type, MapSchema } = require("@colyseus/schema");
+const { Schema, type, MapSchema, ArraySchema } = require("@colyseus/schema");
 const http = require("http");
 const express = require("express");
 const cors = require("cors");
@@ -340,6 +340,8 @@ type("number")(BuilderPlayer.prototype, "y");
 type("number")(BuilderPlayer.prototype, "vx");
 type("number")(BuilderPlayer.prototype, "vy");
 type("string")(BuilderPlayer.prototype, "color");
+type({ map: "number" })(BuilderPlayer.prototype, "inventory");
+type(["number"])(BuilderPlayer.prototype, "hotbar");
 
 class Block extends Schema {}
 type("number")(Block.prototype, "x");
@@ -355,12 +357,147 @@ class BuilderState extends Schema {
 }
 type({ map: BuilderPlayer })(BuilderState.prototype, "players");
 type({ map: Block })(BuilderState.prototype, "blocks");
+type("number")(BuilderState.prototype, "worldWidth");
+type("number")(BuilderState.prototype, "worldHeight");
 
 const BUILDER_TICK_RATE = 20;
 const TILE_SIZE = 32;
-const MAP_WIDTH = 100;
-const MAP_HEIGHT = 40;
+const MAP_WIDTH = 320;
+const MAP_HEIGHT = 120;
 const BUILDER_JUMP_BUFFER_TICKS = 6; // ~120ms at 50Hz
+
+const BLOCK = {
+  GRASS: 1,
+  DIRT: 2,
+  STONE: 3,
+  WOOD: 4,
+  GLASS: 5,
+  BRICK: 6,
+  SAND: 7,
+  SNOW: 8,
+  LEAVES: 9,
+  COAL: 10,
+  IRON: 11
+};
+
+const CRAFTING_RECIPES = {
+  glass: { needs: { [BLOCK.SAND]: 2 }, gives: { type: BLOCK.GLASS, amount: 1 } },
+  brick: { needs: { [BLOCK.STONE]: 2, [BLOCK.DIRT]: 1 }, gives: { type: BLOCK.BRICK, amount: 1 } },
+  wood: { needs: { [BLOCK.LEAVES]: 2 }, gives: { type: BLOCK.WOOD, amount: 1 } },
+  stone: { needs: { [BLOCK.DIRT]: 2 }, gives: { type: BLOCK.STONE, amount: 1 } }
+};
+
+function addInventory(player, typeId, amount) {
+  const key = String(typeId);
+  const current = player.inventory.get(key) || 0;
+  player.inventory.set(key, current + amount);
+}
+
+function hasInventory(player, typeId, amount) {
+  return (player.inventory.get(String(typeId)) || 0) >= amount;
+}
+
+function removeInventory(player, typeId, amount) {
+  const key = String(typeId);
+  const current = player.inventory.get(key) || 0;
+  const next = Math.max(0, current - amount);
+  player.inventory.set(key, next);
+}
+
+function maybeAddToHotbar(player, typeId) {
+  for (let i = 0; i < player.hotbar.length; i++) {
+    if (player.hotbar[i] === typeId) return;
+    if (player.hotbar[i] === 0) {
+      player.hotbar[i] = typeId;
+      return;
+    }
+  }
+}
+
+function generateBuilderTerrain(state) {
+  const biomeStrip = [];
+  let cursor = 0;
+  while (cursor < MAP_WIDTH) {
+    const len = 24 + Math.floor(Math.random() * 26);
+    const biomeRoll = Math.random();
+    const biome = biomeRoll < 0.25 ? "plains" : biomeRoll < 0.5 ? "forest" : biomeRoll < 0.72 ? "desert" : biomeRoll < 0.88 ? "mountains" : "snow";
+    const end = Math.min(MAP_WIDTH, cursor + len);
+    for (let x = cursor; x < end; x++) biomeStrip[x] = biome;
+    cursor = end;
+  }
+
+  let height = Math.floor(MAP_HEIGHT * 0.4);
+  for (let x = 0; x < MAP_WIDTH; x++) {
+    const biome = biomeStrip[x];
+    const driftScale = biome === "mountains" ? 2 : 1;
+    height += Math.floor((Math.random() * 3 - 1) * driftScale);
+    const minHeight = biome === "mountains" ? Math.floor(MAP_HEIGHT * 0.24) : Math.floor(MAP_HEIGHT * 0.32);
+    const maxHeight = biome === "mountains" ? Math.floor(MAP_HEIGHT * 0.55) : Math.floor(MAP_HEIGHT * 0.48);
+    height = Math.max(minHeight, Math.min(maxHeight, height));
+
+    for (let y = height; y < MAP_HEIGHT; y++) {
+      const b = new Block();
+      b.x = x;
+      b.y = y;
+      if (y === height) {
+        b.type = biome === "desert" ? BLOCK.SAND : biome === "snow" ? BLOCK.SNOW : BLOCK.GRASS;
+      } else if (y < height + 4) {
+        b.type = biome === "desert" ? BLOCK.SAND : BLOCK.DIRT;
+      } else {
+        b.type = BLOCK.STONE;
+      }
+      state.blocks.set(`${x},${y}`, b);
+    }
+
+    const canTree = (biome === "forest" || biome === "plains" || biome === "snow") && Math.random() < (biome === "forest" ? 0.25 : 0.09);
+    if (canTree && height > 6) {
+      const trunk = 3 + Math.floor(Math.random() * 3);
+      for (let t = 1; t <= trunk; t++) {
+        const wood = new Block();
+        wood.x = x;
+        wood.y = height - t;
+        wood.type = BLOCK.WOOD;
+        state.blocks.set(`${wood.x},${wood.y}`, wood);
+      }
+      for (let lx = x - 2; lx <= x + 2; lx++) {
+        for (let ly = height - trunk - 2; ly <= height - trunk; ly++) {
+          if (lx < 1 || lx >= MAP_WIDTH - 1 || ly < 1) continue;
+          if (Math.abs(lx - x) + Math.abs(ly - (height - trunk - 1)) > 3) continue;
+          const leaves = new Block();
+          leaves.x = lx;
+          leaves.y = ly;
+          leaves.type = biome === "snow" ? BLOCK.SNOW : BLOCK.LEAVES;
+          state.blocks.set(`${leaves.x},${leaves.y}`, leaves);
+        }
+      }
+    }
+  }
+
+  const caveCount = Math.floor(MAP_WIDTH / 10);
+  for (let i = 0; i < caveCount; i++) {
+    const centerX = 8 + Math.floor(Math.random() * (MAP_WIDTH - 16));
+    const centerY = Math.floor(MAP_HEIGHT * 0.45) + Math.floor(Math.random() * Math.floor(MAP_HEIGHT * 0.45));
+    const radiusX = 3 + Math.floor(Math.random() * 8);
+    const radiusY = 2 + Math.floor(Math.random() * 5);
+    for (let x = centerX - radiusX; x <= centerX + radiusX; x++) {
+      for (let y = centerY - radiusY; y <= centerY + radiusY; y++) {
+        if (x < 1 || x >= MAP_WIDTH - 1 || y < 2 || y >= MAP_HEIGHT - 1) continue;
+        const nx = (x - centerX) / radiusX;
+        const ny = (y - centerY) / radiusY;
+        if ((nx * nx + ny * ny) <= 1 && Math.random() > 0.15) {
+          state.blocks.delete(`${x},${y}`);
+        }
+      }
+    }
+  }
+
+  state.blocks.forEach(block => {
+    if (block.type !== BLOCK.STONE) return;
+    const roll = Math.random();
+    if (roll < 0.02) block.type = BLOCK.IRON;
+    else if (roll < 0.06) block.type = BLOCK.COAL;
+  });
+}
 
 class BuilderRoom extends colyseus.Room {
   onCreate(options) {
@@ -369,16 +506,9 @@ class BuilderRoom extends colyseus.Room {
 
     const state = new BuilderState();
 
-    // Generate initial terrain
-    for (let x = 0; x < MAP_WIDTH; x++) {
-      for (let y = MAP_HEIGHT - 5; y < MAP_HEIGHT; y++) {
-        const b = new Block();
-        b.x = x;
-        b.y = y;
-        b.type = y === MAP_HEIGHT - 5 ? 1 : 2; // 1: grass, 2: dirt
-        state.blocks.set(`${x},${y}`, b);
-      }
-    }
+    state.worldWidth = MAP_WIDTH;
+    state.worldHeight = MAP_HEIGHT;
+    generateBuilderTerrain(state);
 
     this.setState(state);
 
@@ -394,13 +524,16 @@ class BuilderRoom extends colyseus.Room {
     });
 
     this.onMessage("build", (client, message) => {
+      const p = this.state.players.get(client.sessionId);
+      if (!p) return;
       const x = Math.floor(message.x / TILE_SIZE);
       const y = Math.floor(message.y / TILE_SIZE);
+      const blockType = Number(message.type) || BLOCK.STONE;
 
       if (x >= 0 && x < MAP_WIDTH && y >= 0 && y < MAP_HEIGHT) {
         const key = `${x},${y}`;
         // Check if block already exists
-        if (!this.state.blocks.get(key)) {
+        if (!this.state.blocks.get(key) && hasInventory(p, blockType, 1)) {
             // Check intersection with players
             let intersect = false;
             this.state.players.forEach(p => {
@@ -417,20 +550,42 @@ class BuilderRoom extends colyseus.Room {
                 const b = new Block();
                 b.x = x;
                 b.y = y;
-                b.type = message.type || 3;
+                b.type = blockType;
                 this.state.blocks.set(key, b);
+                removeInventory(p, blockType, 1);
             }
         }
       }
     });
 
     this.onMessage("break", (client, message) => {
+      const p = this.state.players.get(client.sessionId);
+      if (!p) return;
       const x = Math.floor(message.x / TILE_SIZE);
       const y = Math.floor(message.y / TILE_SIZE);
       const key = `${x},${y}`;
-      if (this.state.blocks.get(key)) {
+      const block = this.state.blocks.get(key);
+      if (block) {
           this.state.blocks.delete(key);
+          addInventory(p, block.type, 1);
+          maybeAddToHotbar(p, block.type);
       }
+    });
+
+    this.onMessage("craft", (client, message) => {
+      const p = this.state.players.get(client.sessionId);
+      if (!p) return;
+      const recipe = CRAFTING_RECIPES[message.recipeId];
+      if (!recipe) return;
+
+      for (const [typeId, amount] of Object.entries(recipe.needs)) {
+        if (!hasInventory(p, Number(typeId), amount)) return;
+      }
+      for (const [typeId, amount] of Object.entries(recipe.needs)) {
+        removeInventory(p, Number(typeId), amount);
+      }
+      addInventory(p, recipe.gives.type, recipe.gives.amount);
+      maybeAddToHotbar(p, recipe.gives.type);
     });
 
     this.setSimulationInterval(() => this.simulateTick(), BUILDER_TICK_RATE);
@@ -445,6 +600,14 @@ class BuilderRoom extends colyseus.Room {
     p.vx = 0;
     p.vy = 0;
     p.color = `hsl(${Math.random() * 360}, 100%, 50%)`;
+    p.inventory = new MapSchema();
+    p.hotbar = new ArraySchema(BLOCK.STONE, BLOCK.DIRT, BLOCK.GRASS, BLOCK.WOOD, BLOCK.SAND, BLOCK.SNOW, BLOCK.BRICK, BLOCK.GLASS, BLOCK.LEAVES);
+    addInventory(p, BLOCK.STONE, 64);
+    addInventory(p, BLOCK.DIRT, 64);
+    addInventory(p, BLOCK.GRASS, 32);
+    addInventory(p, BLOCK.WOOD, 16);
+    addInventory(p, BLOCK.SAND, 24);
+    addInventory(p, BLOCK.LEAVES, 16);
     this.state.players.set(client.sessionId, p);
 
     this.inputs[client.sessionId] = { left: false, right: false, jumpBuffer: 0 };

--- a/styles.css
+++ b/styles.css
@@ -4397,6 +4397,33 @@ body.reduce-motion *::after {
   background: #152115;
 }
 
+.builder-hotbar {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.builder-slot {
+  min-width: 82px;
+  border: 1px solid #39ff14;
+  background: rgba(0, 0, 0, 0.65);
+  color: #d9ffd0;
+  font-size: 9px;
+  padding: 6px 4px;
+  text-align: center;
+}
+.builder-slot.active {
+  box-shadow: 0 0 10px rgba(57, 255, 20, 0.8);
+  border-color: #fff;
+}
+.builder-crafting {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
 
 @media (max-width: 560px) {
   .game-content-shell {


### PR DESCRIPTION
### Motivation
- Provide a server-authoritative inventory and hotbar so mining, placing and crafting are resource-driven rather than purely cosmetic. 
- Allow players to craft useful block types and to auto-populate hotbar slots from mined resources. 
- Replace the tiny flat map with a larger procedurally generated world (biomes, mountains, trees, caves, ore) so building/mining feel meaningful. 

### Description
- Extended the server schema in `server.js` to add `inventory` and a 9-slot `hotbar` on `BuilderPlayer`, exposed `worldWidth`/`worldHeight`, increased `MAP_WIDTH`/`MAP_HEIGHT`, and added `BLOCK` constants and `CRAFTING_RECIPES`. 
- Implemented server helpers `addInventory`, `hasInventory`, `removeInventory`, `maybeAddToHotbar` and a `generateBuilderTerrain` function that creates biomes, trees, caves and ore, then replaced the flat spawn with `generateBuilderTerrain(state)`. 
- Made `build` consume one unit from the player inventory and made `break` add the mined block type back into the player inventory and attempt to populate the hotbar; added a `craft` message handler that validates and executes recipes. 
- Updated the client `games/builder.js` to render a live hotbar, support 1–9 hotbar selection, clamp camera to replicated world dimensions, display crafting buttons and send `craft` messages; updated `index.html` to include hotbar/crafting UI and added styles in `styles.css`. 

### Testing
- Ran `node --check server.js` which completed without errors. 
- Ran `node --check games/builder.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52623ac78832797b8d3e6b4ffa9c5)