### PR TITLE
Append apostrophe-s to HTML document title

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1"
     />
     <meta name="app-version" content="dev" />
-    <title>GOONER TERMINAL V32 [PVP FIX]</title>
+    <title>GOONER TERMINAL V32 [PVP FIX]'s</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Roboto+Mono:wght@400;700&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
### Motivation
- Align the app shell metadata with the requested naming by appending `'s` to the document title.

### Description
- Updated the page title in `index.html` from `GOONER TERMINAL V32 [PVP FIX]` to `GOONER TERMINAL V32 [PVP FIX]'s`.

### Testing
- No automated tests were run because this is a text-only metadata change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5635f85e08330af1388eca4231d82)