### PR TITLE
Rename Builder to Survival and add unbreakable bedrock layer

### DIFF
--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -36,7 +36,7 @@ export const GAME_DIRECTORY_ENTRIES = Object.freeze([
   { id: "metromaze", title: "METRO MAZE", description: "Procedural mazes with relics, sentinels, and level exits.", icon: "🚇", tags: ["skill", "maze", "puzzle", "strategy"] },
   { id: "stacksmash", title: "STACK SMASH", description: "Break layered stacks for big spike payouts.", icon: "🪨", tags: ["arcade", "timing", "reflex"] },
   { id: "quantumflip", title: "QUANTUM FLIP", description: "Pilot a phase core: chain matching orbs and survive hunter waves.", icon: "⚛️", tags: ["skill", "strategy", "survival"] },
-  { id: "builder", title: "BUILDER", description: "Multiplayer sandbox. Place and break blocks together.", icon: "⛏️", tags: ["sandbox", "multiplayer", "pvp"] },
+  { id: "survival", title: "SURVIVAL", description: "Multiplayer sandbox. Place and break blocks together.", icon: "⛏️", tags: ["sandbox", "multiplayer", "pvp"] },
   { id: "flappy", title: "FLAPPY GOON", description: "Secret bonus mode: tap to survive.", icon: "🐤", tags: ["arcade", "skill"], hidden: true, shopItems: ["item_flappy", "item_shield"] },
 ]);
 

--- a/games/Survival/fix_survival.js
+++ b/games/Survival/fix_survival.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-let content = fs.readFileSync('games/builder.js', 'utf8');
+let content = fs.readFileSync('games/Survival/survival.js', 'utf8');
 
 const drawIconCode = `
     function drawItemIcon(ctx, type, x, y, size) {
@@ -112,4 +112,4 @@ content = content.replace(/99 - inventorySlots\[i\]\.count/g, "getMaxStack(merge
 // Also check any other direct 99 references
 content = content.replace(/count < 99/g, "count < getMaxStack(mergedType)");
 
-fs.writeFileSync('games/builder.js', content);
+fs.writeFileSync('games/Survival/survival.js', content);

--- a/games/Survival/survival.js
+++ b/games/Survival/survival.js
@@ -1,8 +1,8 @@
 import { state, isInputFocused } from "../core.js";
 
-export function initBuilder() {
+export function initSurvival() {
     const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
-    const networkSelect = document.getElementById("builderNetwork");
+    const networkSelect = document.getElementById("survivalNetwork");
     const defaultServer = isLocal ? "local" : "prod";
     if (networkSelect && !networkSelect.value) {
         networkSelect.value = "auto";
@@ -26,19 +26,19 @@ export function initBuilder() {
     let animationFrameId;
     let selectedRoomId = null;
 
-    const canvas = document.getElementById("builderCanvas");
+    const canvas = document.getElementById("survivalCanvas");
     const ctx = canvas.getContext("2d");
-    const menu = document.getElementById("builderMenu");
-    const gameArea = document.getElementById("builderGame");
-    const btnJoin = document.getElementById("btnJoinBuilder");
-    const btnRefreshServers = document.getElementById("btnRefreshBuilderServers");
-    const btnCreateServer = document.getElementById("btnCreateBuilderServer");
-    const serverNameInput = document.getElementById("builderServerName");
-    const serverListEl = document.getElementById("builderServerList");
+    const menu = document.getElementById("survivalMenu");
+    const gameArea = document.getElementById("survivalGame");
+    const btnJoin = document.getElementById("btnJoinSurvival");
+    const btnRefreshServers = document.getElementById("btnRefreshSurvivalServers");
+    const btnCreateServer = document.getElementById("btnCreateSurvivalServer");
+    const serverNameInput = document.getElementById("survivalServerName");
+    const serverListEl = document.getElementById("survivalServerList");
 
-    const uiX = document.getElementById("builderX");
-    const uiY = document.getElementById("builderY");
-    const uiBlockType = document.getElementById("builderBlockType");
+    const uiX = document.getElementById("survivalX");
+    const uiY = document.getElementById("survivalY");
+    const uiBlockType = document.getElementById("survivalBlockType");
 
     const TILE_SIZE = 32;
     const CHUNK_SIZE = 16;
@@ -72,6 +72,7 @@ export function initBuilder() {
         26: "#00FFFF", // Diamond Rifle
         27: "#39FF14", // Uranium Laser
         28: "#B87333", // Copper Ammo
+        29: "#111111", // Bedrock
     };
 
     const blockNames = {
@@ -103,6 +104,7 @@ export function initBuilder() {
         26: "DIAMOND RIFLE",
         27: "URANIUM LASER",
         28: "COPPER AMMO",
+        29: "BEDROCK",
     };
     const getMergedInventoryType = (type) => type;
     const getMaxStack = (type) => [11, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27].includes(type) ? 1 : 99;
@@ -496,7 +498,7 @@ export function initBuilder() {
         if (!btnRefreshServers) return;
         btnRefreshServers.textContent = "LOADING...";
         try {
-            const response = await fetch(`${getServerHttpBase()}/builder-servers`);
+            const response = await fetch(`${getServerHttpBase()}/survival-servers`);
             const payload = await response.json();
             renderServerList(payload.servers || []);
         } catch (error) {
@@ -551,7 +553,7 @@ export function initBuilder() {
         try {
             btnJoin.textContent = "CONNECTING...";
             client = new window.Colyseus.Client(getServerUrl());
-            room = await client.joinOrCreate("builder_room", { name: playerName() });
+            room = await client.joinOrCreate("survival_room", { name: playerName() });
             localPlayerId = room.sessionId;
             setupRoomListeners();
             menu.style.display = "none";
@@ -569,7 +571,7 @@ export function initBuilder() {
                 btnCreateServer.textContent = "CREATING...";
                 const serverName = (serverNameInput?.value || "").trim() || "Public World";
                 client = new window.Colyseus.Client(getServerUrl());
-                room = await client.create("builder_room", { name: playerName(), serverName });
+                room = await client.create("survival_room", { name: playerName(), serverName });
                 localPlayerId = room.sessionId;
                 setupRoomListeners();
                 menu.style.display = "none";
@@ -1946,7 +1948,7 @@ export function initBuilder() {
     }
 
     // Cleanup hook
-    const stopBuilder = () => {
+    const stopSurvival = () => {
         if (room) {
             room.leave();
             room = null;
@@ -1968,8 +1970,8 @@ export function initBuilder() {
     };
 
     if (window.gameStops) {
-        window.gameStops.push(stopBuilder);
+        window.gameStops.push(stopSurvival);
     } else {
-        window.gameStops = [stopBuilder];
+        window.gameStops = [stopSurvival];
     }
 }

--- a/games/Survival/survival_tmp.js
+++ b/games/Survival/survival_tmp.js
@@ -1,8 +1,8 @@
 import { state, isInputFocused } from "../core.js";
 
-export function initBuilder() {
+export function initSurvival() {
     const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
-    const networkSelect = document.getElementById("builderNetwork");
+    const networkSelect = document.getElementById("survivalNetwork");
     const defaultServer = isLocal ? "local" : "prod";
     if (networkSelect && !networkSelect.value) {
         networkSelect.value = "auto";
@@ -26,19 +26,19 @@ export function initBuilder() {
     let animationFrameId;
     let selectedRoomId = null;
 
-    const canvas = document.getElementById("builderCanvas");
+    const canvas = document.getElementById("survivalCanvas");
     const ctx = canvas.getContext("2d");
-    const menu = document.getElementById("builderMenu");
-    const gameArea = document.getElementById("builderGame");
-    const btnJoin = document.getElementById("btnJoinBuilder");
-    const btnRefreshServers = document.getElementById("btnRefreshBuilderServers");
-    const btnCreateServer = document.getElementById("btnCreateBuilderServer");
-    const serverNameInput = document.getElementById("builderServerName");
-    const serverListEl = document.getElementById("builderServerList");
+    const menu = document.getElementById("survivalMenu");
+    const gameArea = document.getElementById("survivalGame");
+    const btnJoin = document.getElementById("btnJoinSurvival");
+    const btnRefreshServers = document.getElementById("btnRefreshSurvivalServers");
+    const btnCreateServer = document.getElementById("btnCreateSurvivalServer");
+    const serverNameInput = document.getElementById("survivalServerName");
+    const serverListEl = document.getElementById("survivalServerList");
 
-    const uiX = document.getElementById("builderX");
-    const uiY = document.getElementById("builderY");
-    const uiBlockType = document.getElementById("builderBlockType");
+    const uiX = document.getElementById("survivalX");
+    const uiY = document.getElementById("survivalY");
+    const uiBlockType = document.getElementById("survivalBlockType");
 
     const TILE_SIZE = 32;
     const CHUNK_SIZE = 16;
@@ -402,7 +402,7 @@ export function initBuilder() {
         if (!btnRefreshServers) return;
         btnRefreshServers.textContent = "LOADING...";
         try {
-            const response = await fetch(`${getServerHttpBase()}/builder-servers`);
+            const response = await fetch(`${getServerHttpBase()}/survival-servers`);
             const payload = await response.json();
             renderServerList(payload.servers || []);
         } catch (error) {
@@ -456,7 +456,7 @@ export function initBuilder() {
         try {
             btnJoin.textContent = "CONNECTING...";
             client = new window.Colyseus.Client(getServerUrl());
-            room = await client.joinOrCreate("builder_room", { name: playerName() });
+            room = await client.joinOrCreate("survival_room", { name: playerName() });
             localPlayerId = room.sessionId;
             setupRoomListeners();
             menu.style.display = "none";
@@ -474,7 +474,7 @@ export function initBuilder() {
                 btnCreateServer.textContent = "CREATING...";
                 const serverName = (serverNameInput?.value || "").trim() || "Public World";
                 client = new window.Colyseus.Client(getServerUrl());
-                room = await client.create("builder_room", { name: playerName(), serverName });
+                room = await client.create("survival_room", { name: playerName(), serverName });
                 localPlayerId = room.sessionId;
                 setupRoomListeners();
                 menu.style.display = "none";
@@ -1570,7 +1570,7 @@ export function initBuilder() {
     }
 
     // Cleanup hook
-    const stopBuilder = () => {
+    const stopSurvival = () => {
         if (room) {
             room.leave();
             room = null;
@@ -1592,8 +1592,8 @@ export function initBuilder() {
     };
 
     if (window.gameStops) {
-        window.gameStops.push(stopBuilder);
+        window.gameStops.push(stopSurvival);
     } else {
-        window.gameStops = [stopBuilder];
+        window.gameStops = [stopSurvival];
     }
 }

--- a/games/Survival/update_survival_icons.js
+++ b/games/Survival/update_survival_icons.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-let content = fs.readFileSync('games/builder.js', 'utf8');
+let content = fs.readFileSync('games/Survival/survival.js', 'utf8');
 
 const drawIconCode = `
     function drawItemIcon(ctx, type, x, y, size) {
@@ -85,4 +85,4 @@ const fillRectRegex = /ctx\.fillStyle = blockColors\[item\.type\];\s*const inset
 content = content.replace(fillRectRegex, "const inset = 6;\n                        drawItemIcon(ctx, item.type, slotX + inset, slotY + inset, hotbarLayout.slotSize - (inset * 2));");
 
 // Now we need to fix the specific occurrences.
-fs.writeFileSync('games/builder_tmp.js', content);
+fs.writeFileSync('games/survival_tmp.js', content);

--- a/index.html
+++ b/index.html
@@ -2027,27 +2027,27 @@
     </div>
 
     <!-- Solo + multiplayer War overlay. -->
-    <!-- Builder Room overlay. -->
-    <div class="overlay" id="overlayBuilder">
-      <h1>BUILDER</h1>
-      <div id="builderMenu" class="menu-box">
-        <select id="builderNetwork" class="term-input">
+    <!-- Survival Room overlay. -->
+    <div class="overlay" id="overlaySurvival">
+      <h1>SURVIVAL</h1>
+      <div id="survivalMenu" class="menu-box">
+        <select id="survivalNetwork" class="term-input">
           <option value="auto">AUTO NETWORK (RECOMMENDED)</option>
           <option value="prod">PRODUCTION NETWORK</option>
           <option value="local">LOCALHOST NETWORK</option>
         </select>
-        <button class="menu-btn" id="btnRefreshBuilderServers" style="margin-top: 10px;">REFRESH SERVER LIST</button>
-        <input type="text" id="builderServerName" class="term-input" placeholder="NEW SERVER NAME" maxlength="24" />
-        <button class="term-btn" id="btnCreateBuilderServer">CREATE SERVER</button>
-        <div id="builderServerList" style="text-align: left; margin-top: 12px; max-height: 180px; overflow-y: auto;"></div>
-        <button class="menu-btn" id="btnJoinBuilder">QUICK JOIN ANY SERVER</button>
+        <button class="menu-btn" id="btnRefreshSurvivalServers" style="margin-top: 10px;">REFRESH SERVER LIST</button>
+        <input type="text" id="survivalServerName" class="term-input" placeholder="NEW SERVER NAME" maxlength="24" />
+        <button class="term-btn" id="btnCreateSurvivalServer">CREATE SERVER</button>
+        <div id="survivalServerList" style="text-align: left; margin-top: 12px; max-height: 180px; overflow-y: auto;"></div>
+        <button class="menu-btn" id="btnJoinSurvival">QUICK JOIN ANY SERVER</button>
       </div>
-      <div id="builderGame" class="builder-wrap" style="display: none">
-        <div class="builder-hud">
-          <span>X: <span id="builderX">0</span> Y: <span id="builderY">0</span></span>
-          <span style="margin-left: 20px;">BLOCK: <span id="builderBlockType">GRASS</span></span>
+      <div id="survivalGame" class="survival-wrap" style="display: none">
+        <div class="survival-hud">
+          <span>X: <span id="survivalX">0</span> Y: <span id="survivalY">0</span></span>
+          <span style="margin-left: 20px;">BLOCK: <span id="survivalBlockType">GRASS</span></span>
         </div>
-        <canvas id="builderCanvas" width="800" height="450" style="background: #87CEEB;"></canvas>
+        <canvas id="survivalCanvas" width="800" height="450" style="background: #87CEEB;"></canvas>
         <div class="mobile-hint active" style="margin-top: 10px">
           WASD TO MOVE. CLICK TO BUILD. SHIFT-CLICK TO BREAK. PRESS I FOR IN-GAME INVENTORY.
         </div>

--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ import { initStackSmash } from "./games/stacksmash.js";
 import { initQuantumFlip } from "./games/quantumflip.js";
 import { initUltimateTTT } from "./games/ultimatettt.js";
 import { initSmashArena } from "./games/smasharena.js";
-import { initBuilder } from "./games/builder.js";
+import { initSurvival } from "./games/Survival/survival.js";
 import { initWar } from "./games/war.js";
 import { initVideoPoker } from "./games/videopoker.js";
 import { initCraps } from "./games/craps.js";
@@ -329,7 +329,7 @@ window.launchGame = (game, source = "direct") => {
   if (game === "quantumflip") initQuantumFlip();
   if (game === "ultimatettt") initUltimateTTT();
   if (game === "smasharena") initSmashArena();
-  if (game === "builder") initBuilder();
+  if (game === "survival") initSurvival();
   if (game === "war") initWar();
   if (game === "videopoker") initVideoPoker();
   if (game === "craps") initCraps();
@@ -377,7 +377,7 @@ const GAME_TEMPLATE_OVERLAY_IDS = [
   "overlayQuantumflip",
   "overlayUltimatettt",
   "overlaySmasharena",
-  "overlayBuilder",
+  "overlaySurvival",
   "overlayVideopoker",
   "overlayCraps",
   "overlayBaccarat",
@@ -1354,7 +1354,7 @@ document.getElementById("goRestart").onclick = () => {
   if (state.currentGame === "stacksmash") initStackSmash();
   if (state.currentGame === "quantumflip") initQuantumFlip();
   if (state.currentGame === "smasharena") initSmashArena();
-  if (state.currentGame === "builder") initBuilder();
+  if (state.currentGame === "survival") initSurvival();
   if (state.currentGame === "mines") {
     initMines();
     document.getElementById("overlayMines").classList.add("active");

--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ function layeredNoise(x, y, octaves, persistence, scale) {
 const app = express();
 app.use(cors());
 const port = process.env.PORT || 2567;
-const builderServerDirectory = new Map();
+const survivalServerDirectory = new Map();
 
 const gameServer = new colyseus.Server({
   transport: new WebSocketTransport({
@@ -393,32 +393,32 @@ class GameRoom extends colyseus.Room {
 }
 
 // --------------------------------------------------------
-// BUILDER ROOM DEFINITION
+// SURVIVAL ROOM DEFINITION
 // --------------------------------------------------------
-class BuilderPlayer extends Schema {}
-type("string")(BuilderPlayer.prototype, "id");
-type("string")(BuilderPlayer.prototype, "name");
-type("number")(BuilderPlayer.prototype, "x");
-type("number")(BuilderPlayer.prototype, "y");
-type("number")(BuilderPlayer.prototype, "vx");
-type("number")(BuilderPlayer.prototype, "vy");
-type("string")(BuilderPlayer.prototype, "color");
-type("number")(BuilderPlayer.prototype, "hp");
-type("number")(BuilderPlayer.prototype, "maxHp");
-type("number")(BuilderPlayer.prototype, "armorHp");
-type("number")(BuilderPlayer.prototype, "maxArmorHp");
-type("number")(BuilderPlayer.prototype, "armorType");
-type("number")(BuilderPlayer.prototype, "selectedItemType");
+class SurvivalPlayer extends Schema {}
+type("string")(SurvivalPlayer.prototype, "id");
+type("string")(SurvivalPlayer.prototype, "name");
+type("number")(SurvivalPlayer.prototype, "x");
+type("number")(SurvivalPlayer.prototype, "y");
+type("number")(SurvivalPlayer.prototype, "vx");
+type("number")(SurvivalPlayer.prototype, "vy");
+type("string")(SurvivalPlayer.prototype, "color");
+type("number")(SurvivalPlayer.prototype, "hp");
+type("number")(SurvivalPlayer.prototype, "maxHp");
+type("number")(SurvivalPlayer.prototype, "armorHp");
+type("number")(SurvivalPlayer.prototype, "maxArmorHp");
+type("number")(SurvivalPlayer.prototype, "armorType");
+type("number")(SurvivalPlayer.prototype, "selectedItemType");
 
-class BuilderBullet extends Schema {}
-type("string")(BuilderBullet.prototype, "id");
-type("string")(BuilderBullet.prototype, "ownerId");
-type("number")(BuilderBullet.prototype, "x");
-type("number")(BuilderBullet.prototype, "y");
-type("number")(BuilderBullet.prototype, "vx");
-type("number")(BuilderBullet.prototype, "vy");
-type("number")(BuilderBullet.prototype, "damage");
-type("number")(BuilderBullet.prototype, "life");
+class SurvivalBullet extends Schema {}
+type("string")(SurvivalBullet.prototype, "id");
+type("string")(SurvivalBullet.prototype, "ownerId");
+type("number")(SurvivalBullet.prototype, "x");
+type("number")(SurvivalBullet.prototype, "y");
+type("number")(SurvivalBullet.prototype, "vx");
+type("number")(SurvivalBullet.prototype, "vy");
+type("number")(SurvivalBullet.prototype, "damage");
+type("number")(SurvivalBullet.prototype, "life");
 
 class Block extends Schema {}
 type("number")(Block.prototype, "x");
@@ -442,7 +442,7 @@ class Chunk extends Schema {
 }
 type({ map: Block })(Chunk.prototype, "blocks");
 
-class BuilderState extends Schema {
+class SurvivalState extends Schema {
     constructor() {
         super();
         this.players = new MapSchema();
@@ -451,17 +451,17 @@ class BuilderState extends Schema {
         this.bullets = new MapSchema();
     }
 }
-type({ map: BuilderPlayer })(BuilderState.prototype, "players");
-type({ map: Chunk })(BuilderState.prototype, "chunks");
-type({ map: ItemDrop })(BuilderState.prototype, "drops");
-type({ map: BuilderBullet })(BuilderState.prototype, "bullets");
+type({ map: SurvivalPlayer })(SurvivalState.prototype, "players");
+type({ map: Chunk })(SurvivalState.prototype, "chunks");
+type({ map: ItemDrop })(SurvivalState.prototype, "drops");
+type({ map: SurvivalBullet })(SurvivalState.prototype, "bullets");
 
-const BUILDER_TICK_RATE = 20;
+const SURVIVAL_TICK_RATE = 20;
 const TILE_SIZE = 32;
 const CHUNK_SIZE = 16;
-const BUILDER_JUMP_BUFFER_TICKS = 6; // ~120ms at 50Hz
+const SURVIVAL_JUMP_BUFFER_TICKS = 6; // ~120ms at 50Hz
 
-class BuilderRoom extends colyseus.Room {
+class SurvivalRoom extends colyseus.Room {
   onCreate(options) {
     this.maxClients = 50;
     this.autoDispose = true;
@@ -470,7 +470,7 @@ class BuilderRoom extends colyseus.Room {
       : "Public World";
     this.setMetadata({ serverName: this.serverName });
 
-    const state = new BuilderState();
+    const state = new SurvivalState();
     this.setState(state);
 
     this.inputs = {};
@@ -480,7 +480,7 @@ class BuilderRoom extends colyseus.Room {
       if (this.inputs[pId]) {
         this.inputs[pId].left = message.left;
         this.inputs[pId].right = message.right;
-        if (message.upPress) this.inputs[pId].jumpBuffer = BUILDER_JUMP_BUFFER_TICKS;
+        if (message.upPress) this.inputs[pId].jumpBuffer = SURVIVAL_JUMP_BUFFER_TICKS;
       }
     });
 
@@ -560,6 +560,7 @@ class BuilderRoom extends colyseus.Room {
           const key = `${x},${y}`;
           const b = chunk.blocks.get(key);
           if (b) {
+              if (b.type === 29) return; // Bedrock is unbreakable
               const drop = new ItemDrop();
               drop.id = `drop-${Date.now()}-${Math.random()}`;
               drop.x = x * TILE_SIZE + TILE_SIZE / 2;
@@ -669,7 +670,7 @@ class BuilderRoom extends colyseus.Room {
 
         for (let i = 0; i < projectiles; i++) {
             const bulletId = Math.random().toString(36).substring(2, 9);
-            const b = new BuilderBullet();
+            const b = new SurvivalBullet();
             b.id = bulletId;
             b.ownerId = client.sessionId;
             b.x = player.x + TILE_SIZE / 2;
@@ -725,15 +726,15 @@ class BuilderRoom extends colyseus.Room {
     });
 
     this.loadWorld();
-    this.setSimulationInterval(() => this.simulateTick(), BUILDER_TICK_RATE);
+    this.setSimulationInterval(() => this.simulateTick(), SURVIVAL_TICK_RATE);
     this.saveInterval = setInterval(() => this.saveWorld(), 30000); // Save every 30s
     this.syncServerDirectory();
   }
 
   onJoin(client, options) {
-    const p = new BuilderPlayer();
+    const p = new SurvivalPlayer();
     p.id = client.sessionId;
-    p.name = options.name || "Builder";
+    p.name = options.name || "Survival";
 
     const spawnX = Math.floor(Math.random() * 200) - 100;
     const noise = layeredNoise(spawnX, 0, 4, 0.5, 0.05);
@@ -793,7 +794,7 @@ class BuilderRoom extends colyseus.Room {
   onDispose() {
     if (this.saveInterval) clearInterval(this.saveInterval);
     this.saveWorld();
-    builderServerDirectory.delete(this.roomId);
+    survivalServerDirectory.delete(this.roomId);
   }
 
   saveWorld() {
@@ -917,6 +918,16 @@ class BuilderRoom extends colyseus.Room {
             chunk.blocks.set(`${worldX},${y}`, b);
         }
       }
+
+      // Always cap the generated depth with bedrock (unbreakable).
+      const bedrockY = endY - 1;
+      if (bedrockY >= minY && bedrockY < maxY) {
+        const bedrock = new Block();
+        bedrock.x = worldX;
+        bedrock.y = bedrockY;
+        bedrock.type = 29;
+        chunk.blocks.set(`${worldX},${bedrockY}`, bedrock);
+      }
     }
 
     // 2. Deterministic Tree Generation
@@ -982,9 +993,9 @@ class BuilderRoom extends colyseus.Room {
   syncServerDirectory() {
     const players = [];
     this.state.players.forEach((player) => {
-      players.push(player.name || "Builder");
+      players.push(player.name || "Survival");
     });
-    builderServerDirectory.set(this.roomId, {
+    survivalServerDirectory.set(this.roomId, {
       roomId: this.roomId,
       serverName: this.serverName || "Public World",
       clients: this.clients.length,
@@ -1048,7 +1059,7 @@ class BuilderRoom extends colyseus.Room {
         const prevY = p.y;
 
         // Armor Regen (1 hp per second roughly, since tick rate is 20)
-        if (p.hp > 0 && p.armorHp < p.maxArmorHp && Math.random() < (1 / BUILDER_TICK_RATE)) {
+        if (p.hp > 0 && p.armorHp < p.maxArmorHp && Math.random() < (1 / SURVIVAL_TICK_RATE)) {
             p.armorHp++;
         }
 
@@ -1248,11 +1259,11 @@ class VoiceRoom extends colyseus.Room {
 
 gameServer.define("my_game_room", GameRoom);
 gameServer.define("smash_arena", SmashArenaRoom);
-gameServer.define("builder_room", BuilderRoom);
+gameServer.define("survival_room", SurvivalRoom);
 gameServer.define("voice_room", VoiceRoom);
 
-app.get("/builder-servers", (req, res) => {
-  const servers = Array.from(builderServerDirectory.values()).sort((a, b) => {
+app.get("/survival-servers", (req, res) => {
+  const servers = Array.from(survivalServerDirectory.values()).sort((a, b) => {
     if (b.clients !== a.clients) return b.clients - a.clients;
     return a.serverName.localeCompare(b.serverName);
   });


### PR DESCRIPTION
### Motivation
- Organize and rebrand the multiplayer sandbox mode from `Builder` to `Survival` for clearer naming and UX consistency.
- Move survival game code into a dedicated `games/Survival/` folder to separate game modules and simplify maintenance.
- Ensure the generated world has a permanent unbreakable floor to prevent players from digging out the world bottom.
- Prevent clients from breaking that bottom layer so servers remain stable and worlds are bounded.

### Description
- Moved and renamed game files: `games/builder.js` → `games/Survival/survival.js`, `games/builder_tmp.js` → `games/Survival/survival_tmp.js`, `fix_builder.js` → `games/Survival/fix_survival.js`, and `update_builder_icons.js` → `games/Survival/update_survival_icons.js`, and updated imports to `./games/Survival/survival.js` and `initSurvival` usage.
- Replaced client/server identifiers and wiring from `builder`/`Builder` to `survival`/`Survival` including overlay IDs, UI element IDs, `initSurvival`, game catalog entry (`gameCatalog.js`), and the Colyseus room and HTTP endpoints (`survival_room`, `/survival-servers`).
- Added block type `29` as `BEDROCK` in the client block metadata and updated drawing/icon helper scripts to reference the new survival paths.
- Server-side world generation now writes a bedrock block at the bottom of generated chunks and the server `break` handler rejects breaking blocks with `type === 29` (bedrock) to make it unbreakable.

### Testing
- Ran syntax checks with `node --check server.js` which passed.
- Ran syntax checks with `node --check script.js` which passed.
- Ran syntax checks with `node --check games/Survival/survival.js` which passed.
- Ran syntax checks with `node --check gameCatalog.js` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ffec4798832285854b655e3cfa20)