### PR TITLE
Builder: persist player inventory and add unbreakable bedrock floor

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -72,6 +72,7 @@ export function initBuilder() {
         26: "#00FFFF", // Diamond Rifle
         27: "#39FF14", // Uranium Laser
         28: "#B87333", // Copper Ammo
+        29: "#111111", // Bedrock
     };
 
     const blockNames = {
@@ -103,6 +104,7 @@ export function initBuilder() {
         26: "DIAMOND RIFLE",
         27: "URANIUM LASER",
         28: "COPPER AMMO",
+        29: "BEDROCK",
     };
     const getMergedInventoryType = (type) => type;
     const getMaxStack = (type) => [11, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27].includes(type) ? 1 : 99;
@@ -134,6 +136,8 @@ export function initBuilder() {
     let inventorySlots = new Array(27).fill(undefined).map(cloneItem);
     let armorSlot = undefined;
 
+    loadInventoryState();
+
     // Crafting state
     let craftingGrid2x2 = new Array(4).fill(undefined).map(cloneItem);
     let craftingGrid3x3 = new Array(9).fill(undefined).map(cloneItem);
@@ -163,6 +167,49 @@ export function initBuilder() {
     let buildHoldTimeout = null;
     let buildHoldInterval = null;
     const playerName = () => state.myName || "Player";
+    const getInventoryStorageKey = () => `builder_inventory_v1_${playerName().trim().toLowerCase() || "player"}`;
+    const serializeInventoryState = () => ({
+        hotbarSlots: hotbarSlots.map(cloneItem),
+        inventorySlots: inventorySlots.map(cloneItem),
+        armorSlot: cloneItem(armorSlot),
+        selectedHotbarIndex,
+    });
+    const applyInventoryState = (saved) => {
+        if (!saved || typeof saved !== "object") return;
+        if (Array.isArray(saved.hotbarSlots)) {
+            const nextHotbar = new Array(9).fill(undefined).map((_, idx) => cloneItem(saved.hotbarSlots[idx]));
+            hotbarSlots = nextHotbar;
+        }
+        if (Array.isArray(saved.inventorySlots)) {
+            const nextInventory = new Array(27).fill(undefined).map((_, idx) => cloneItem(saved.inventorySlots[idx]));
+            inventorySlots = nextInventory;
+        }
+        armorSlot = cloneItem(saved.armorSlot);
+        if (Number.isInteger(saved.selectedHotbarIndex)) {
+            selectedHotbarIndex = Math.max(0, Math.min(8, saved.selectedHotbarIndex));
+        }
+        selectedBlockType = hotbarSlots[selectedHotbarIndex] || hotbarSlots[0] || 1;
+    };
+    const loadInventoryState = () => {
+        try {
+            const raw = window.localStorage.getItem(getInventoryStorageKey());
+            if (!raw) return;
+            applyInventoryState(JSON.parse(raw));
+        } catch (err) {
+            console.warn("Failed to load Builder inventory", err);
+        }
+    };
+    let lastSavedInventorySnapshot = "";
+    const saveInventoryState = () => {
+        try {
+            const snapshot = JSON.stringify(serializeInventoryState());
+            if (snapshot === lastSavedInventorySnapshot) return;
+            window.localStorage.setItem(getInventoryStorageKey(), snapshot);
+            lastSavedInventorySnapshot = snapshot;
+        } catch (err) {
+            console.warn("Failed to save Builder inventory", err);
+        }
+    };
     const hotbarLayout = {
         slotSize: 40,
         gap: 4,
@@ -1293,6 +1340,7 @@ export function initBuilder() {
 
     // Prevent context menu on canvas for right click breaking
     canvas.addEventListener("contextmenu", e => e.preventDefault());
+    window.addEventListener("beforeunload", saveInventoryState);
 
     // Send input loop
     setInterval(() => {
@@ -1864,6 +1912,7 @@ export function initBuilder() {
             }
         }
 
+        saveInventoryState();
         animationFrameId = requestAnimationFrame(render);
     }
 
@@ -1958,6 +2007,7 @@ export function initBuilder() {
         canvas.removeEventListener("mousedown", handleMouseDown);
         canvas.removeEventListener("mouseup", handleMouseUp);
         canvas.removeEventListener("mouseleave", handleMouseUp);
+        window.removeEventListener("beforeunload", saveInventoryState);
         clearBuildHoldTimers();
         menu.style.display = "block";
         gameArea.style.display = "none";

--- a/server.js
+++ b/server.js
@@ -460,6 +460,8 @@ const BUILDER_TICK_RATE = 20;
 const TILE_SIZE = 32;
 const CHUNK_SIZE = 16;
 const BUILDER_JUMP_BUFFER_TICKS = 6; // ~120ms at 50Hz
+const BEDROCK_BLOCK_TYPE = 29;
+const BEDROCK_GRADIENT_LAYERS = 4;
 
 class BuilderRoom extends colyseus.Room {
   onCreate(options) {
@@ -560,6 +562,7 @@ class BuilderRoom extends colyseus.Room {
           const key = `${x},${y}`;
           const b = chunk.blocks.get(key);
           if (b) {
+              if (b.type === BEDROCK_BLOCK_TYPE) return;
               const drop = new ItemDrop();
               drop.id = `drop-${Date.now()}-${Math.random()}`;
               drop.x = x * TILE_SIZE + TILE_SIZE / 2;
@@ -879,13 +882,25 @@ class BuilderRoom extends colyseus.Room {
         // Or if layeredNoise returns 0 to 1, say if it's > 0.4 it's a cave.
         // layeredNoise internally uses perlin noise which is typically -1 to 1 but here total is accumulated.
         // Let's use absolute value or sin mapping to get tunnels
-        const isCave = Math.abs(caveNoise) < 0.08 && y >= h + 25;
+        const columnBottomY = h + 200 - 1;
+        const depthFromBottom = columnBottomY - y;
+        const isInBedrockGradient = depthFromBottom >= 0 && depthFromBottom < BEDROCK_GRADIENT_LAYERS;
+        const bedrockChance = depthFromBottom === 0 ? 1
+          : depthFromBottom === 1 ? 0.75
+          : depthFromBottom === 2 ? 0.45
+          : 0.2;
+        const bedrockNoise = Math.abs(Math.sin(worldX * 91.173 + y * 17.913));
+        const shouldPlaceBedrock = isInBedrockGradient && bedrockNoise < bedrockChance;
+
+        const isCave = !shouldPlaceBedrock && Math.abs(caveNoise) < 0.08 && y >= h + 25;
 
         if (!isCave) {
             const b = new Block();
             b.x = worldX;
             b.y = y;
-            if (y === h) {
+            if (shouldPlaceBedrock) {
+              b.type = BEDROCK_BLOCK_TYPE;
+            } else if (y === h) {
               b.type = 1; // Grass
             } else if (y < h + 4) {
               b.type = 2; // Dirt


### PR DESCRIPTION
### Motivation
- Persist each player’s Builder inventory across servers so players keep hotbar/inventory/armor state when switching servers or rejoining.
- Add an unbreakable bedrock layer at the world bottom with a few gradient layers above it to prevent tunneling through the world floor.

### Description
- Client (`games/builder.js`): added local persistence keyed by normalized player name (`builder_inventory_v1_<player>`) and functions `serializeInventoryState`, `applyInventoryState`, `loadInventoryState`, and `saveInventoryState`; load runs on init and saves are deduplicated and written in the render loop and on `beforeunload`, with the unload listener removed on cleanup.
- Client: added block type `29` (`BEDROCK`) to `blockColors` and `blockNames` so bedrock renders and is labeled correctly in UI.
- Server (`server.js`): introduced `BEDROCK_BLOCK_TYPE = 29` and `BEDROCK_GRADIENT_LAYERS = 4`, made `break` ignore bedrock blocks, and updated `generateChunk` to compute a column bottom and deterministically place a solid bedrock layer plus probabilistic gradient layers above it while suppressing cave carving where bedrock is placed.

### Testing
- Ran `node --check games/builder.js` and it succeeded.
- Ran `node --check server.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6024a4fc8832296e27aecf4b50a2c)