### PR TITLE
Fix duplicate `panel` declaration causing SyntaxError in builder.js

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -1023,7 +1023,6 @@ export function initBuilder() {
                 if (handleSlotInteraction(hotbarSlots, hotbarIndex)) return;
             }
 
-            const panel = getInventoryBounds();
             const inventoryIndex = getInventorySlotAt(mouse.x, mouse.y, panel);
             if (inventoryIndex !== null) {
                 if (handleSlotInteraction(inventorySlots, inventoryIndex)) return;


### PR DESCRIPTION
### Motivation
- Prevent a runtime parse error caused by declaring `const panel = getInventoryBounds()` twice in the same `handleMouseDown` block which produced `Uncaught SyntaxError: Identifier 'panel' has already been declared`.

### Description
- Remove the redundant `const panel = getInventoryBounds();` near the inventory slot lookup and reuse the existing `panel` variable declared earlier in the `if (inventoryOpen)` block in `games/builder.js`.

### Testing
- Ran `node --check games/builder.js` and it completed successfully without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81ec687488333a3ddc66b65f27c94)