### PR TITLE
Fix `localPlayer` ReferenceError in Builder

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -772,7 +772,9 @@ const blockColors = {
     }
 
 function sendBuildOrBreak(e) {
-        if (!room || !localPlayer) return;
+        if (!room || !localPlayerId) return;
+        const localPlayer = room.state.players.get(localPlayerId);
+        if (!localPlayer) return;
 
         const worldX = mouse.x + camera.x;
         const worldY = mouse.y + camera.y;


### PR DESCRIPTION
Fixes the bug that completely prevented building or breaking blocks in the "Builder" game due to an undefined `localPlayer` reference.

---
*PR created automatically by Jules for task [10382469291993148397](https://jules.google.com/task/10382469291993148397) started by @thefoxssss*