### PR TITLE
🧹 remove unused syncChatMinimizeUi and dead variables

### DIFF
--- a/core.js
+++ b/core.js
@@ -5875,8 +5875,6 @@ async function removeChatMessage(tab, messageId) {
 
 // Initialize realtime chat streaming and input handling.
 function initChat() {
-  const chatRoot = document.getElementById("globalChat");
-  const minimizeBtn = document.getElementById("chatMinimizeBtn");
   const moderationBtn = document.getElementById("chatModerationToggleBtn");
 
   const syncChatModerationUi = () => {
@@ -5888,14 +5886,6 @@ function initChat() {
     moderationBtn.setAttribute("aria-pressed", isChatModerationModeEnabled ? "true" : "false");
     moderationBtn.setAttribute("aria-label", isChatModerationModeEnabled ? "Disable moderation mode" : "Enable moderation mode");
     moderationBtn.title = isChatModerationModeEnabled ? "Moderation mode on" : "Moderation mode off";
-  };
-
-  const syncChatMinimizeUi = () => {
-    const isMinimized = chatRoot?.classList.contains("minimized");
-    if (!minimizeBtn) return;
-    minimizeBtn.textContent = isMinimized ? "+" : "−";
-    minimizeBtn.setAttribute("aria-expanded", isMinimized ? "false" : "true");
-    minimizeBtn.setAttribute("aria-label", isMinimized ? "Expand chat" : "Minimize chat");
   };
 
   if (moderationBtn) {


### PR DESCRIPTION
Removed the unused function `syncChatMinimizeUi` and the local variables `chatRoot` and `minimizeBtn` from the `initChat` function in `core.js`. These symbols were identified as dead code since the corresponding DOM element `chatMinimizeBtn` is no longer present in `index.html`.