### PR TITLE
Optimize terrain generation and implement chunk memory management in Builder server.

### DIFF
--- a/server.js
+++ b/server.js
@@ -508,6 +508,8 @@ class BuilderRoom extends colyseus.Room {
     this.setState(state);
 
     this.inputs = {};
+    this.offlineChunks = new Map();
+    this.tickCount = 0;
 
     this.onMessage("input", (client, message) => {
       const pId = client.sessionId;
@@ -973,6 +975,9 @@ this.onMessage("hammer", (client, message) => {
           data.chunks[key].push({ x: block.x, y: block.y, type: block.type, meta: block.meta || 0 });
         });
       });
+      this.offlineChunks.forEach((chunkData, key) => {
+        data.chunks[key] = chunkData;
+      });
       this.state.chests.forEach((chest, key) => {
         const items = {};
         chest.items.forEach((item, slot) => {
@@ -1007,16 +1012,7 @@ this.onMessage("hammer", (client, message) => {
         const data = rawData.chunks ? rawData : { chunks: rawData, chests: {}, furnaces: {} }; // backcompat
 
         for (const chunkKey in data.chunks) {
-          const chunk = new Chunk();
-          data.chunks[chunkKey].forEach(bData => {
-            const b = new Block();
-            b.x = bData.x;
-            b.y = bData.y;
-            b.type = bData.type;
-            b.meta = bData.meta || 0;
-            chunk.blocks.set(`${b.x},${b.y}`, b);
-          });
-          this.state.chunks.set(chunkKey, chunk);
+          this.offlineChunks.set(chunkKey, data.chunks[chunkKey]);
         }
         for (const chestKey in data.chests) {
             const chest = new ChestData();
@@ -1088,8 +1084,11 @@ this.onMessage("hammer", (client, message) => {
       const endY = Math.min(maxY, h + 200);
 
       for (let y = startY; y < endY; y++) {
-        const caveNoise = layeredNoise(worldX, y, 3, 0.5, 0.1);
-        const isCave = Math.abs(caveNoise) < 0.08 && y >= h + 25;
+        let isCave = false;
+        if (y >= h + 25) {
+            const caveNoise = layeredNoise(worldX, y, 3, 0.5, 0.1);
+            isCave = Math.abs(caveNoise) < 0.08;
+        }
 
         if (!isCave) {
             const b = new Block();
@@ -1193,8 +1192,25 @@ this.onMessage("hammer", (client, message) => {
     const key = `${cx},${cy}`;
     let chunk = this.state.chunks.get(key);
     if (!chunk) {
-      this.generateChunk(cx, cy);
-      chunk = this.state.chunks.get(key);
+      if (this.offlineChunks.has(key)) {
+        // Load from offline
+        const chunkData = this.offlineChunks.get(key);
+        chunk = new Chunk();
+        chunkData.forEach(bData => {
+          const b = new Block();
+          b.x = bData.x;
+          b.y = bData.y;
+          b.type = bData.type;
+          b.meta = bData.meta || 0;
+          chunk.blocks.set(`${b.x},${b.y}`, b);
+        });
+        this.state.chunks.set(key, chunk);
+        this.offlineChunks.delete(key);
+      } else {
+        // Generate new
+        this.generateChunk(cx, cy);
+        chunk = this.state.chunks.get(key);
+      }
     }
     return chunk;
   }
@@ -1225,6 +1241,33 @@ isSolid(x, y) {
   }
 
   simulateTick() {
+    this.tickCount++;
+    if (this.tickCount % 100 === 0) {
+      // Unload distant chunks
+      const activeChunkKeys = new Set();
+      this.state.players.forEach((p) => {
+        const pCx = Math.floor(p.x / (TILE_SIZE * CHUNK_SIZE));
+        const pCy = Math.floor(p.y / (TILE_SIZE * CHUNK_SIZE));
+        for (let cx = pCx - 3; cx <= pCx + 3; cx++) {
+          for (let cy = pCy - 3; cy <= pCy + 3; cy++) {
+            activeChunkKeys.add(`${cx},${cy}`);
+          }
+        }
+      });
+
+      this.state.chunks.forEach((chunk, key) => {
+        if (!activeChunkKeys.has(key)) {
+          // Serialize and unload
+          const chunkData = [];
+          chunk.blocks.forEach((block) => {
+            chunkData.push({ x: block.x, y: block.y, type: block.type, meta: block.meta || 0 });
+          });
+          this.offlineChunks.set(key, chunkData);
+          this.state.chunks.delete(key);
+        }
+      });
+    }
+
     // Bullet simulation
     // Tree growth (saplings)
     if (Math.random() < 0.05) { // Occasional check


### PR DESCRIPTION
This commit introduces the following server-side optimizations for the Builder game:
1. Cave noise logic in `generateChunk` is now only computed for underground blocks (depth >= 25), significantly reducing initial load CPU usage.
2. A new `offlineChunks` map is introduced in `BuilderRoom` to temporarily hold serialized chunks that are out of active player range.
3. Added chunk unloading logic in `simulateTick()` that sweeps every 100 ticks and offloads chunks that are more than 3 chunk lengths away from all players.
4. `getOrCreateChunk` automatically revitalizes chunks from the `offlineChunks` store when a player approaches.
5. World load/save functions (`loadWorld`/`saveWorld`) updated to persist both active and offloaded chunks safely across reboots without data loss.

---
*PR created automatically by Jules for task [4029190183703500434](https://jules.google.com/task/4029190183703500434) started by @thefoxssss*