### PR TITLE
Add recall to spawn feature in Builder game

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -700,6 +700,9 @@ const blockColors = {
                 saveInventoryState();
             }
         }
+        if (e.key === "r" || e.key === "R") {
+            room.send("recall");
+        }
         if (e.key === "i" || e.key === "I") {
             inventoryOpen = !inventoryOpen;
 

--- a/server.js
+++ b/server.js
@@ -886,6 +886,20 @@ this.onMessage("hammer", (client, message) => {
         p.selectedItemType = 0;
     });
 
+    this.onMessage("recall", (client) => {
+        const p = this.state.players.get(client.sessionId);
+        if (!p || p.hp <= 0) return;
+
+        // Recall player to spawn (0, 0 area)
+        const spawnX = Math.floor(Math.random() * 20) - 10;
+        const noise = layeredNoise(spawnX, 0, 4, 0.5, 0.05);
+        const spawnY = Math.floor(20 + noise * 15) - 2;
+        p.x = spawnX * TILE_SIZE;
+        p.y = spawnY * TILE_SIZE;
+        p.vx = 0;
+        p.vy = 0;
+    });
+
     this.loadWorld();
     this.setSimulationInterval(() => this.simulateTick(), BUILDER_TICK_RATE);
     this.saveInterval = setInterval(() => this.saveWorld(), 30000); // Save every 30s

--- a/test_recall.py
+++ b/test_recall.py
@@ -1,0 +1,64 @@
+from playwright.sync_api import sync_playwright
+import time
+
+def run_cuj(page):
+    page.goto("http://localhost:8001/index.html?local=1")
+    page.wait_for_timeout(1500)
+
+    page.evaluate('''
+        window.myName = "TEST_USER";
+        document.getElementById("overlayLogin").classList.remove("active");
+        document.getElementById("matrixCanvas").style.opacity = 0;
+        document.getElementById("hackOverlay").style.display = "none";
+        document.body.classList.remove("flicker-on");
+    ''')
+    page.wait_for_timeout(500)
+
+    page.evaluate("window.launchGame('builder')")
+    page.wait_for_timeout(2000)
+
+    # Click the quick join button using the element ID
+    page.evaluate('''
+        document.getElementById("btnJoinBuilder").click();
+    ''')
+    page.wait_for_timeout(3000)
+
+    page.keyboard.down("d")
+    page.wait_for_timeout(3000)
+    page.keyboard.up("d")
+
+    # Store old position
+    old_x = page.evaluate("localPlayer.x")
+    old_y = page.evaluate("localPlayer.y")
+
+    print(f"Old pos: {old_x}, {old_y}")
+
+    # Trigger recall
+    page.keyboard.press("r")
+    page.wait_for_timeout(1000)
+
+    # Store new position
+    new_x = page.evaluate("localPlayer.x")
+    new_y = page.evaluate("localPlayer.y")
+
+    print(f"New pos: {new_x}, {new_y}")
+
+    assert old_x != new_x or old_y != new_y
+    assert abs(new_x) < 500
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={'width': 1280, 'height': 720}
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+            print("TEST PASSED")
+        except Exception as e:
+            print("TEST FAILED")
+            print(e)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
This commit introduces the ability for a user to recall back to the spawn location (near 0 0) in the Builder game without losing health or dropping items.

- `games/builder.js`: Added a keydown listener for the 'r' or 'R' keys. When pressed (and no input is focused), it sends a new `recall` message to the server.
- `server.js`: Added the `recall` message handler. It calculates the spawn area using the same generation noise as `respawn` and teleports the player there by changing their coordinates and resetting velocity.

Testing:
- Playwright end-to-end tests correctly navigate into the game and verify teleportation using `test_recall.py`.
- Syntax checked on both edited files.

---
*PR created automatically by Jules for task [17753764539457455061](https://jules.google.com/task/17753764539457455061) started by @thefoxssss*