### PR TITLE
Give players 99 nukes in hotbar

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -238,6 +238,9 @@ const blockColors = {
         hotbarSlots = [1, 2, 3, 4, 7, 8, 5, 6, undefined].map(cloneItem);
     }
 
+    // Give everyone 99 nukes in the last hotbar slot
+    hotbarSlots[8] = { type: 34, count: 99 };
+
     let selectedBlockType = hotbarSlots[0] || 1;
     let localPlayerId = null;
 


### PR DESCRIPTION
This change modifies `games/builder.js` so that during hotbar initialization, whether loading from a saved state or using the defaults, the player is automatically granted 99 Nukes in their 9th hotbar slot (index 8). This satisfies a temporary requirement to give everyone 99 nukes for now.

---
*PR created automatically by Jules for task [11901495434539735357](https://jules.google.com/task/11901495434539735357) started by @thefoxssss*