### PR TITLE
Fix missing item definitions blocking Nuke crafting

### DIFF
--- a/data/blocks/29.json
+++ b/data/blocks/29.json
@@ -1,0 +1,6 @@
+{
+  "id": 29,
+  "name": "29",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/29.png"
+}

--- a/data/blocks/31.json
+++ b/data/blocks/31.json
@@ -1,0 +1,6 @@
+{
+  "id": 31,
+  "name": "31",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/31.png"
+}

--- a/data/blocks/32.json
+++ b/data/blocks/32.json
@@ -1,0 +1,6 @@
+{
+  "id": 32,
+  "name": "32",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/32.png"
+}

--- a/data/blocks/33.json
+++ b/data/blocks/33.json
@@ -1,0 +1,6 @@
+{
+  "id": 33,
+  "name": "33",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/33.png"
+}

--- a/data/blocks/34.json
+++ b/data/blocks/34.json
@@ -1,0 +1,6 @@
+{
+  "id": 34,
+  "name": "34",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/34.png"
+}

--- a/data/blocks/35.json
+++ b/data/blocks/35.json
@@ -1,0 +1,6 @@
+{
+  "id": 35,
+  "name": "35",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/35.png"
+}

--- a/data/blocks/37.json
+++ b/data/blocks/37.json
@@ -1,0 +1,6 @@
+{
+  "id": 37,
+  "name": "37",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/37.png"
+}

--- a/data/blocks/38.json
+++ b/data/blocks/38.json
@@ -1,0 +1,6 @@
+{
+  "id": 38,
+  "name": "38",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/38.png"
+}

--- a/data/blocks/39.json
+++ b/data/blocks/39.json
@@ -1,0 +1,6 @@
+{
+  "id": 39,
+  "name": "39",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/39.png"
+}

--- a/data/blocks/40.json
+++ b/data/blocks/40.json
@@ -1,0 +1,6 @@
+{
+  "id": 40,
+  "name": "40",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/40.png"
+}

--- a/data/blocks/41.json
+++ b/data/blocks/41.json
@@ -1,0 +1,6 @@
+{
+  "id": 41,
+  "name": "41",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/41.png"
+}

--- a/data/blocks/42.json
+++ b/data/blocks/42.json
@@ -1,0 +1,6 @@
+{
+  "id": 42,
+  "name": "42",
+  "maxStack": 99,
+  "sprite": "assets/sprites/blocks/42.png"
+}

--- a/data/items/30.json
+++ b/data/items/30.json
@@ -1,0 +1,6 @@
+{
+  "id": 30,
+  "name": "30",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/30.png"
+}

--- a/data/items/36.json
+++ b/data/items/36.json
@@ -1,0 +1,6 @@
+{
+  "id": 36,
+  "name": "36",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/36.png"
+}

--- a/data/items/43.json
+++ b/data/items/43.json
@@ -1,0 +1,6 @@
+{
+  "id": 43,
+  "name": "43",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/43.png"
+}

--- a/data/items/44.json
+++ b/data/items/44.json
@@ -1,0 +1,6 @@
+{
+  "id": 44,
+  "name": "44",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/44.png"
+}

--- a/data/items/45.json
+++ b/data/items/45.json
@@ -1,0 +1,6 @@
+{
+  "id": 45,
+  "name": "45",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/45.png"
+}

--- a/data/items/46.json
+++ b/data/items/46.json
@@ -1,0 +1,6 @@
+{
+  "id": 46,
+  "name": "46",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/46.png"
+}

--- a/data/items/47.json
+++ b/data/items/47.json
@@ -1,0 +1,6 @@
+{
+  "id": 47,
+  "name": "47",
+  "maxStack": 99,
+  "sprite": "assets/sprites/items/47.png"
+}

--- a/games/builder.js
+++ b/games/builder.js
@@ -190,7 +190,12 @@ const blockColors = {
         "data/blocks/13.json", "data/blocks/14.json", "data/blocks/15.json", "data/blocks/16.json",
         "data/blocks/17.json", "data/items/18.json", "data/items/19.json", "data/items/20.json",
         "data/items/21.json", "data/items/22.json", "data/items/23.json", "data/items/24.json",
-        "data/items/25.json", "data/items/26.json", "data/items/27.json", "data/items/28.json"
+        "data/items/25.json", "data/items/26.json", "data/items/27.json", "data/items/28.json",
+        "data/blocks/29.json", "data/items/30.json", "data/blocks/31.json", "data/blocks/32.json",
+        "data/blocks/33.json", "data/blocks/34.json", "data/blocks/35.json", "data/items/36.json",
+        "data/blocks/37.json", "data/blocks/38.json", "data/blocks/39.json", "data/blocks/40.json",
+        "data/blocks/41.json", "data/blocks/42.json", "data/items/43.json", "data/items/44.json",
+        "data/items/45.json", "data/items/46.json", "data/items/47.json"
     ];
     let loadedBlockData = {};
     let blockImages = {};


### PR DESCRIPTION
The `games/builder.js` file contained Nuke (type `34`) and Uranium (Refined) (type `47`) references, but lacked corresponding `data/blocks/*.json` and `data/items/*.json` definition files for items 29 through 47. 

These items also needed to be appended to the `blockDataUrls` array. Without these definitions, `getMaxStack(type)` fails or evaluates to undefined for `type 47`, preventing it from effectively loading into the player's inventory from a completed Furnace smelting process, or properly tracking item quantities, which ultimately prevented correctly consuming Refined Uranium for crafting the Nuke.

This fix generates all the missing JSON configuration files for block and item types 29 to 47 and registers them into `blockDataUrls`.

---
*PR created automatically by Jules for task [5991042812089603260](https://jules.google.com/task/5991042812089603260) started by @thefoxssss*