### PR TITLE
Add admin panel to give builder blocks/items

### DIFF
--- a/core.js
+++ b/core.js
@@ -693,7 +693,7 @@ export function hasPermission(bit) {
   return (permissionMask & bit) === bit;
 }
 
-function isGodUser(name = myName) {
+export function isGodUser(name = myName) {
   const normalized = String(name || "").trim().toUpperCase();
   if (!normalized) return false;
   if (ADMIN_ALLOWLIST.has(normalized)) return true;
@@ -4147,6 +4147,23 @@ export async function adminScheduleTaskFromInput() {
     successToast: (targets) => `TASK SCHEDULED FOR ${targets.length} PLAYER(S)`,
     failToast: "TASK SCHEDULE FAILED",
   });
+}
+
+export async function adminGiveBuilderItemFromInput() {
+  const itemSelect = document.getElementById("adminBuilderItemInput");
+  const countInput = document.getElementById("adminBuilderItemCount");
+  const itemId = Number(itemSelect?.value);
+  const count = Number(countInput?.value);
+  if (!itemId || !count || count <= 0) {
+    showToast("INVALID ITEM OR COUNT", "⚠️");
+    return;
+  }
+  if (typeof window.adminGiveBuilderItem === "function") {
+    window.adminGiveBuilderItem(itemId, count);
+    showToast(`GIVEN ${count} ITEM(S)`, "📦");
+  } else {
+    showToast("BUILDER NOT LOADED", "⚠️");
+  }
 }
 
 export async function adminClearScheduledTasksFromInput() {

--- a/games/builder.js
+++ b/games/builder.js
@@ -1,4 +1,4 @@
-import { state, isInputFocused, saveStats, builderHotbar, builderInventory, builderArmor, updateBuilderInventoryState } from "../core.js";
+import { state, isInputFocused, saveStats, builderHotbar, builderInventory, builderArmor, updateBuilderInventoryState, isGodUser } from "../core.js";
 
 export function initBuilder() {
     const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
@@ -913,6 +913,12 @@ function sendBuildOrBreak(e) {
         });
         return !intersectsPlayer;
     }
+
+    window.adminGiveBuilderItem = (type, count) => {
+        if (!isGodUser()) return;
+        addInventoryItem(type, count);
+        saveInventoryState();
+    };
 
     function addInventoryItem(type, count) {
         const mergedType = getMergedInventoryType(type);

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
               <div class="score-tab" data-admin-tab="economy">ECONOMY</div>
               <div class="score-tab" data-admin-tab="server">SERVER TOOLS</div>
               <div class="score-tab" data-admin-tab="automation">AUTOMATION</div>
+              <div class="score-tab" data-admin-tab="builder">BUILDER</div>
             </div>
 
             <!-- USER MANAGEMENT TAB -->
@@ -371,6 +372,68 @@
                     <option value="en"></option>
                   </datalist>
                   <button class="term-btn" onclick="window.adminSetPreferenceFromInput()">SET PREFERENCE</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- BUILDER TAB -->
+            <div class="admin-tab-content" id="adminTabBuilder" style="display: none;">
+              <div class="admin-actions admin-actions-overhaul">
+                <div class="admin-section">
+                  <p class="admin-section-title">GIVE BLOCKS/ITEMS</p>
+                  <select class="term-input" id="adminBuilderItemInput" style="margin-bottom: 10px;">
+                    <option value="1">1 - GRASS</option>
+                    <option value="2">2 - DIRT</option>
+                    <option value="3">3 - STONE</option>
+                    <option value="4">4 - WOOD</option>
+                    <option value="5">5 - GLASS</option>
+                    <option value="6">6 - BRICK</option>
+                    <option value="7">7 - LOG</option>
+                    <option value="8">8 - LEAVES</option>
+                    <option value="9">9 - PLANKS</option>
+                    <option value="10">10 - CRAFTING TABLE</option>
+                    <option value="11">11 - SWORD</option>
+                    <option value="12">12 - COAL</option>
+                    <option value="13">13 - COPPER</option>
+                    <option value="14">14 - IRON</option>
+                    <option value="15">15 - GOLD</option>
+                    <option value="16">16 - DIAMOND</option>
+                    <option value="17">17 - URANIUM</option>
+                    <option value="18">18 - COPPER ARMOR</option>
+                    <option value="19">19 - IRON ARMOR</option>
+                    <option value="20">20 - GOLD ARMOR</option>
+                    <option value="21">21 - DIAMOND ARMOR</option>
+                    <option value="22">22 - URANIUM ARMOR</option>
+                    <option value="23">23 - COPPER GUN</option>
+                    <option value="24">24 - IRON GUN</option>
+                    <option value="25">25 - GOLD GUN</option>
+                    <option value="26">26 - DIAMOND RIFLE</option>
+                    <option value="27">27 - URANIUM LASER</option>
+                    <option value="28">28 - COPPER AMMO</option>
+                    <option value="29">29 - SAPLING</option>
+                    <option value="30">30 - APPLE</option>
+                    <option value="31">31 - CHEST</option>
+                    <option value="32">32 - FURNACE</option>
+                    <option value="33">33 - TNT</option>
+                    <option value="34">34 - NUKE</option>
+                    <option value="35">35 - LADDER</option>
+                    <option value="36">36 - HAMMER</option>
+                    <option value="37">37 - CACTUS</option>
+                    <option value="38">38 - SAND</option>
+                    <option value="39">39 - SNOW</option>
+                    <option value="40">40 - SANDSTONE</option>
+                    <option value="41">41 - PINE LOG</option>
+                    <option value="42">42 - PINE LEAVES</option>
+                    <option value="43">43 - COPPER INGOT</option>
+                    <option value="44">44 - IRON INGOT</option>
+                    <option value="45">45 - GOLD INGOT</option>
+                    <option value="46">46 - DIAMOND (REFINED)</option>
+                    <option value="47">47 - URANIUM (REFINED)</option>
+                  </select>
+                  <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 15px;">
+                    <input class="term-input" id="adminBuilderItemCount" type="number" step="1" min="1" max="99" value="1" placeholder="COUNT" style="width: 100%;" />
+                    <button class="term-btn" onclick="window.adminGiveBuilderItemFromInput()">GIVE ITEM</button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -45,6 +45,7 @@ import {
   adminRemoveRestrictionFromInput,
   adminLogAdminActionFromInput,
   adminScheduleTaskFromInput,
+  adminGiveBuilderItemFromInput,
   adminClearScheduledTasksFromInput,
   adminUnlockAllAchievements,
   trackGamePlay,
@@ -135,6 +136,7 @@ window.adminSetLimitFromInput = adminSetLimitFromInput;
 window.adminSetPreferenceFromInput = adminSetPreferenceFromInput;
 window.adminRemoveRestrictionFromInput = adminRemoveRestrictionFromInput;
 window.adminLogAdminActionFromInput = adminLogAdminActionFromInput;
+window.adminGiveBuilderItemFromInput = adminGiveBuilderItemFromInput;
 window.adminScheduleTaskFromInput = adminScheduleTaskFromInput;
 window.adminClearScheduledTasksFromInput = adminClearScheduledTasksFromInput;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;

--- a/test_cuj3.py
+++ b/test_cuj3.py
@@ -17,7 +17,7 @@ def run_cuj(page):
     page.wait_for_timeout(2000)
 
     # Click create server manually or evaluate it since it might not be bound to text
-    page.evaluate("document.getElementById('builderBtnCreate').click()")
+    page.evaluate("document.getElementById('btnCreateBuilderServer').click()")
     page.wait_for_timeout(2000)
 
     page.keyboard.press("e")

--- a/test_cuj5.py
+++ b/test_cuj5.py
@@ -17,7 +17,7 @@ def run_cuj(page):
     page.wait_for_timeout(2000)
 
     # Click create server manually or evaluate it since it might not be bound to text
-    page.evaluate("document.getElementById('builderBtnCreate').click()")
+    page.evaluate("document.getElementById('btnCreateBuilderServer').click()")
     page.wait_for_timeout(4000)
 
     page.keyboard.press("e")

--- a/test_cuj7.py
+++ b/test_cuj7.py
@@ -17,7 +17,7 @@ def run_cuj(page):
     page.wait_for_timeout(2000)
 
     page.evaluate('''
-        document.querySelector("#builderMenu button[onclick*='builderJoinRoom']").click();
+        document.getElementById('btnJoinBuilder').click();
     ''')
     page.wait_for_timeout(4000)
 


### PR DESCRIPTION
This commit introduces a new section within the user admin panel to facilitate server administrators. It enables an authorized admin to automatically inject items and blocks directly into their active builder game inventory by simply selecting the item ID from a dropdown list and specifying the count. The item giving mechanics are securely protected by the `isGodUser()` check directly within the game module.

---
*PR created automatically by Jules for task [6774739560159187983](https://jules.google.com/task/6774739560159187983) started by @thefoxssss*