### PR TITLE
Fix furnace UI showing crafting table state in builder

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -735,6 +735,7 @@ const blockColors = {
 
         if (e.key === "Escape" && inventoryOpen) {
             inventoryOpen = false;
+            isCraftingTableOpen = false;
             isChestOpen = false;
             isFurnaceOpen = false;
             isChestOpen = false;
@@ -1387,18 +1388,28 @@ if (e.button === 2 && !e.shiftKey) {
                 if (block && block.type === 10) { // Crafting Table
                     inventoryOpen = true;
                     isCraftingTableOpen = true;
+                    isChestOpen = false;
+                    isFurnaceOpen = false;
+                    currentChestId = null;
+                    currentFurnaceId = null;
                     return;
 } else if (block && block.type === 31) { // Chest
                     room.send("interact", { x: worldX, y: worldY }); // register it
                     inventoryOpen = true;
+                    isCraftingTableOpen = false;
                     isChestOpen = true;
+                    isFurnaceOpen = false;
                     currentChestId = `${tileX},${tileY}`;
+                    currentFurnaceId = null;
                     return;
                 } else if (block && block.type === 32) { // Furnace
                     room.send("interact", { x: worldX, y: worldY });
                     inventoryOpen = true;
+                    isCraftingTableOpen = false;
+                    isChestOpen = false;
                     isFurnaceOpen = true;
                     currentFurnaceId = `${tileX},${tileY}`;
+                    currentChestId = null;
                     return;
                 } else if (block && (block.type === 33 || block.type === 34)) { // TNT/Nuke
                     room.send("interact", { x: worldX, y: worldY });


### PR DESCRIPTION
### Motivation
- The builder UI could display the crafting-table interface when opening a furnace or chest because container state flags and current container IDs were left stale and not mutually exclusive.
- Closing inventory with `Escape` did not always reset the crafting-table mode, allowing stale crafting UI state across open/close cycles.

### Description
- When right-clicking a crafting table, chest, or furnace, explicitly set the corresponding `isCraftingTableOpen`, `isChestOpen`, and `isFurnaceOpen` flags so only the active container is true and the others are set to false.
- Clear stale container IDs by setting `currentChestId` or `currentFurnaceId` to `null` when switching to a different container type.
- Ensure pressing `Escape` while inventory is open also resets `isCraftingTableOpen` to prevent lingering crafting-table UI state.
- Changes are in `games/builder.js` around the right-click interaction handler and the `Escape` key handling.

### Testing
- Ran a JavaScript syntax check with `node --check games/builder.js`, which succeeded.
- Ran `python3 -m pytest -q verify_furnace_final.py`, which failed in this environment due to a missing `playwright` dependency and not because of the UI fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf61a442c8327a959090fd139e6b1)