### PR TITLE
Fix builder server list player rendering

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -1,4 +1,4 @@
-import { state, isInputFocused, saveStats, builderHotbar, builderInventory, builderArmor, updateBuilderInventoryState, isGodUser } from "../core.js";
+import { state, isInputFocused, saveStats, builderHotbar, builderInventory, builderArmor, updateBuilderInventoryState, isGodUser, escapeHtml } from "../core.js";
 
 export function initBuilder() {
     const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
@@ -551,7 +551,10 @@ const blockColors = {
             row.style.cursor = "pointer";
             row.style.background = selectedRoomId === server.roomId ? "rgba(0, 255, 0, 0.15)" : "transparent";
 
-            const names = (server.players || []).length ? server.players.map(n => escapeHtml(n)).join(", ") : "No players";
+            const playerNames = Array.isArray(server.players) ? server.players : [];
+            const names = playerNames.length
+                ? playerNames.map((name) => escapeHtml(String(name || "Builder"))).join(", ")
+                : "No players";
             row.innerHTML = `
                 <div style="font-size: 11px; color: #0f0;">${escapeHtml(server.serverName || "Public World")}</div>
                 <div style="font-size: 9px; opacity: 0.9; margin-top: 4px;">PLAYERS (${server.clients}/${server.maxClients}): ${names}</div>


### PR DESCRIPTION
### Motivation
- Fix the Builder server list UI which failed to render player names (and could error) when `server.players` was missing or contained non-string values.

### Description
- Import `escapeHtml` from `core.js` and normalize `server.players` to an array while coercing each name to a string with a fallback of `"Builder"` before rendering the list.

### Testing
- Ran `node --check games/builder.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3d5ee8988327962ec7dbd6c34df9)