### PR TITLE
Fix builder inventory initialization for partial saved data

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -231,21 +231,36 @@ const blockColors = {
     let selectedHotbarIndex = 0;
 
     // Map initial available blocks, empty for the rest
+    const normalizeSlots = (sourceSlots, targetLength, fallbackSlots = []) => {
+        const normalized = new Array(targetLength).fill(undefined);
+        for (let i = 0; i < targetLength; i++) {
+            const sourceItem = sourceSlots?.[i];
+            if (sourceItem !== undefined) {
+                normalized[i] = cloneItem(sourceItem);
+                continue;
+            }
+            if (i < fallbackSlots.length) {
+                normalized[i] = cloneItem(fallbackSlots[i]);
+            }
+        }
+        return normalized;
+    };
+
     let hotbarSlots;
-    if (builderHotbar) {
-        hotbarSlots = builderHotbar.map(cloneItem);
+    if (Array.isArray(builderHotbar)) {
+        hotbarSlots = normalizeSlots(builderHotbar, 9, [1, 2, 3, 4, 7, 8, 5, 6, undefined]);
     } else {
-        hotbarSlots = [1, 2, 3, 4, 7, 8, 5, 6, undefined].map(cloneItem);
+        hotbarSlots = normalizeSlots([], 9, [1, 2, 3, 4, 7, 8, 5, 6, undefined]);
     }
 
     let selectedBlockType = hotbarSlots[0] || 1;
     let localPlayerId = null;
 
     let inventorySlots;
-    if (builderInventory) {
-        inventorySlots = builderInventory.map(cloneItem);
+    if (Array.isArray(builderInventory)) {
+        inventorySlots = normalizeSlots(builderInventory, 27);
     } else {
-        inventorySlots = new Array(27).fill(undefined).map(cloneItem);
+        inventorySlots = normalizeSlots([], 27);
     }
 
     let armorSlot = builderArmor ? cloneItem(builderArmor) : undefined;


### PR DESCRIPTION
### Motivation
- Persisted builder hotbar/inventory arrays from profiles could be short or legacy-shaped, leaving the builder UI with missing slots and breaking inventory behavior. 
- Normalize saved slot data to stable lengths so the builder always has the expected number of hotbar and inventory slots.

### Description
- Add `normalizeSlots(sourceSlots, targetLength, fallbackSlots)` to produce fixed-length slot arrays and clone entries with `cloneItem` so saved items are normalized. 
- Initialize `hotbarSlots` using `normalizeSlots(..., 9, [...])` to always produce exactly 9 hotbar slots and preserve fallback starter items when saved slots are missing. 
- Initialize `inventorySlots` using `normalizeSlots(..., 27)` to always produce exactly 27 inventory slots even for partial or missing saved arrays.

### Testing
- Ran `node --check games/builder.js` which succeeded with no syntax errors. 
- Ran `pytest -q test_cuj2.py` which failed to collect tests due to the environment missing `playwright` (`ModuleNotFoundError: No module named 'playwright'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd404b64a08327955345ddbf5a7155)