### PR TITLE
Fix builder inventory render freeze when opening UI

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -2480,94 +2480,91 @@ if (inventoryOpen) {
                 ctx.fillStyle = "#fff";
                 ctx.fillText("CLOSE", panel.x + panel.width - 70, panel.y + 4);
                 } else {
+                    const size = isCraftingTableOpen ? 3 : 2;
+                    const stride = inventoryLayout.slotSize + inventoryLayout.gap;
 
-            const size = isCraftingTableOpen ? 3 : 2;
-            const stride = inventoryLayout.slotSize + inventoryLayout.gap;
+                    // Draw Crafting Grid
+                    for (let r = 0; r < size; r++) {
+                        for (let c = 0; c < size; c++) {
+                            const slotX = craftStartX + c * stride;
+                            const slotY = craftStartY + r * stride;
 
-            // Draw Crafting Grid
-            for (let r = 0; r < size; r++) {
-                for (let c = 0; c < size; c++) {
-                    const slotX = craftStartX + c * stride;
-                    const slotY = craftStartY + r * stride;
+                            ctx.fillStyle = "#8b8b8b";
+                            ctx.fillRect(slotX, slotY, inventoryLayout.slotSize, inventoryLayout.slotSize);
+
+                            ctx.strokeStyle = "#373737";
+                            ctx.lineWidth = 2;
+                            ctx.beginPath();
+                            ctx.moveTo(slotX, slotY + inventoryLayout.slotSize);
+                            ctx.lineTo(slotX, slotY);
+                            ctx.lineTo(slotX + inventoryLayout.slotSize, slotY);
+                            ctx.stroke();
+
+                            ctx.strokeStyle = "#ffffff";
+                            ctx.beginPath();
+                            ctx.moveTo(slotX + inventoryLayout.slotSize, slotY);
+                            ctx.lineTo(slotX + inventoryLayout.slotSize, slotY + inventoryLayout.slotSize);
+                            ctx.lineTo(slotX, slotY + inventoryLayout.slotSize);
+                            ctx.stroke();
+
+                            const grid = isCraftingTableOpen ? craftingGrid3x3 : craftingGrid2x2;
+                            const item = grid[r * size + c];
+                            if (item) {
+                                const inset = 6;
+                                drawItemIcon(ctx, item.type, slotX + inset, slotY + inset, inventoryLayout.slotSize - (inset * 2));
+
+                                ctx.fillStyle = "#ffffff";
+                                ctx.font = "8px 'Press Start 2P', monospace";
+                                ctx.textAlign = "right";
+                                ctx.fillStyle = "#3f3f3f";
+                                ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 2, slotY + inventoryLayout.slotSize - 4);
+                                ctx.fillStyle = "#ffffff";
+                                ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 3, slotY + inventoryLayout.slotSize - 5);
+                            }
+                        }
+                    }
+
+                    // Draw arrow
+                    ctx.fillStyle = "#3f3f3f";
+                    ctx.font = "12px 'Press Start 2P', monospace";
+                    ctx.textAlign = "center";
+                    ctx.fillText("->", craftStartX + size * stride + 8, craftStartY + Math.floor((size * stride) / 2) + 4);
+
+                    // Draw output slot
+                    const outX = craftStartX + size * stride + 20;
+                    const outY = craftStartY + Math.floor((size * stride) / 2) - inventoryLayout.slotSize / 2;
 
                     ctx.fillStyle = "#8b8b8b";
-                    ctx.fillRect(slotX, slotY, inventoryLayout.slotSize, inventoryLayout.slotSize);
+                    ctx.fillRect(outX, outY, inventoryLayout.slotSize, inventoryLayout.slotSize);
 
                     ctx.strokeStyle = "#373737";
                     ctx.lineWidth = 2;
                     ctx.beginPath();
-                    ctx.moveTo(slotX, slotY + inventoryLayout.slotSize);
-                    ctx.lineTo(slotX, slotY);
-                    ctx.lineTo(slotX + inventoryLayout.slotSize, slotY);
+                    ctx.moveTo(outX, outY + inventoryLayout.slotSize);
+                    ctx.lineTo(outX, outY);
+                    ctx.lineTo(outX + inventoryLayout.slotSize, outY);
                     ctx.stroke();
 
                     ctx.strokeStyle = "#ffffff";
                     ctx.beginPath();
-                    ctx.moveTo(slotX + inventoryLayout.slotSize, slotY);
-                    ctx.lineTo(slotX + inventoryLayout.slotSize, slotY + inventoryLayout.slotSize);
-                    ctx.lineTo(slotX, slotY + inventoryLayout.slotSize);
+                    ctx.moveTo(outX + inventoryLayout.slotSize, outY);
+                    ctx.lineTo(outX + inventoryLayout.slotSize, outY + inventoryLayout.slotSize);
+                    ctx.lineTo(outX, outY + inventoryLayout.slotSize);
                     ctx.stroke();
 
-                    const grid = isCraftingTableOpen ? craftingGrid3x3 : craftingGrid2x2;
-                    const item = grid[r * size + c];
-                    if (item) {
+                    if (craftingOutputSlot) {
                         const inset = 6;
-                        drawItemIcon(ctx, item.type, slotX + inset, slotY + inset, inventoryLayout.slotSize - (inset * 2));
+                        drawItemIcon(ctx, craftingOutputSlot.type, outX + inset, outY + inset, inventoryLayout.slotSize - (inset * 2));
 
                         ctx.fillStyle = "#ffffff";
                         ctx.font = "8px 'Press Start 2P', monospace";
                         ctx.textAlign = "right";
                         ctx.fillStyle = "#3f3f3f";
-                        ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 2, slotY + inventoryLayout.slotSize - 4);
+                        ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 2, outY + inventoryLayout.slotSize - 4);
                         ctx.fillStyle = "#ffffff";
-                        ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 3, slotY + inventoryLayout.slotSize - 5);
+                        ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 3, outY + inventoryLayout.slotSize - 5);
                     }
                 }
-                }
-            }
-
-            // Draw arrow
-            ctx.fillStyle = "#3f3f3f";
-            ctx.font = "12px 'Press Start 2P', monospace";
-            ctx.textAlign = "center";
-            ctx.fillText("->", craftStartX + size * stride + 8, craftStartY + Math.floor((size * stride) / 2) + 4);
-
-            // Draw output slot
-            const outX = craftStartX + size * stride + 20;
-            const outY = craftStartY + Math.floor((size * stride) / 2) - inventoryLayout.slotSize / 2;
-
-            ctx.fillStyle = "#8b8b8b";
-            ctx.fillRect(outX, outY, inventoryLayout.slotSize, inventoryLayout.slotSize);
-
-            ctx.strokeStyle = "#373737";
-            ctx.lineWidth = 2;
-            ctx.beginPath();
-            ctx.moveTo(outX, outY + inventoryLayout.slotSize);
-            ctx.lineTo(outX, outY);
-            ctx.lineTo(outX + inventoryLayout.slotSize, outY);
-            ctx.stroke();
-
-            ctx.strokeStyle = "#ffffff";
-            ctx.beginPath();
-            ctx.moveTo(outX + inventoryLayout.slotSize, outY);
-            ctx.lineTo(outX + inventoryLayout.slotSize, outY + inventoryLayout.slotSize);
-            ctx.lineTo(outX, outY + inventoryLayout.slotSize);
-            ctx.stroke();
-
-            if (craftingOutputSlot) {
-                const inset = 6;
-                drawItemIcon(ctx, craftingOutputSlot.type, outX + inset, outY + inset, inventoryLayout.slotSize - (inset * 2));
-
-                ctx.fillStyle = "#ffffff";
-                ctx.font = "8px 'Press Start 2P', monospace";
-                ctx.textAlign = "right";
-                ctx.fillStyle = "#3f3f3f";
-                ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 2, outY + inventoryLayout.slotSize - 4);
-                ctx.fillStyle = "#ffffff";
-                ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 3, outY + inventoryLayout.slotSize - 5);
-            }
-
-
             for (let index = 0; index < totalSlots; index += 1) {
                 const item = inventorySlots[index];
                 const col = index % inventoryLayout.cols;


### PR DESCRIPTION
### Motivation
- Opening the builder inventory caused the UI to freeze and inventory slots to not render because crafting/layout drawing could run in the wrong branch and reference variables out of scope. 

### Description
- Reorganized the inventory rendering branch in `games/builder.js` so crafting-grid and recipe-book drawing only execute inside the correct `showRecipes`/non-recipe path. 
- Scoped `size`, `stride`, `outX`, and `outY` and related crafting output drawing to the crafting branch to avoid referencing crafting variables when the recipe overlay is active. 
- Kept the main inventory slot loop outside the crafting/recipe block so inventory slots always render when `inventoryOpen` is true. 

### Testing
- Ran `node --check games/builder.js` which reported no syntax errors. 
- Ran `pytest -q test_cuj11.py` which failed to collect tests due to the environment missing the `playwright` dependency (test run aborted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd420e71b08327b7a27c87e1c5746b)