### PR TITLE
Adjust Agar camera zoom based on player size

### DIFF
--- a/games/agar.js
+++ b/games/agar.js
@@ -53,6 +53,7 @@ export function initAgar() {
     let cameraY = 0;
     let targetX = 0;
     let targetY = 0;
+    let zoom = 1;
 
     let players = new Map();
     let foods = new Map();
@@ -197,9 +198,18 @@ export function initAgar() {
         const mx = e.clientX - rect.left;
         const my = e.clientY - rect.top;
 
-        targetX = mx + cameraX - CANVAS_WIDTH / 2;
-        targetY = my + cameraY - CANVAS_HEIGHT / 2;
+        targetX = cameraX + (mx - CANVAS_WIDTH / 2) / zoom;
+        targetY = cameraY + (my - CANVAS_HEIGHT / 2) / zoom;
     });
+
+    function calculateZoom(playerRadius) {
+        const MIN_ZOOM = 0.4;
+        const MAX_ZOOM = 1;
+        const baseRadius = 30;
+        const radiusRatio = Math.max(1, playerRadius / baseRadius);
+        const targetZoom = MAX_ZOOM - Math.log2(radiusRatio) * 0.15;
+        return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, targetZoom));
+    }
 
     function updateLeaderboard() {
         if (!leaderboardList) return;
@@ -222,14 +232,19 @@ export function initAgar() {
             // Smooth camera follow
             cameraX += (localPlayer.x - cameraX) * 0.1;
             cameraY += (localPlayer.y - cameraY) * 0.1;
+            zoom += (calculateZoom(localPlayer.radius) - zoom) * 0.08;
+        } else {
+            zoom += (1 - zoom) * 0.08;
         }
 
         ctx.save();
-        ctx.translate(-cameraX + CANVAS_WIDTH / 2, -cameraY + CANVAS_HEIGHT / 2);
+        ctx.translate(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+        ctx.scale(zoom, zoom);
+        ctx.translate(-cameraX, -cameraY);
 
         // Draw grid
         ctx.strokeStyle = "#ccc";
-        ctx.lineWidth = 1;
+        ctx.lineWidth = 1 / zoom;
         ctx.beginPath();
         for (let x = 0; x <= AGAR_MAP_WIDTH; x += 50) {
             ctx.moveTo(x, 0);
@@ -243,7 +258,7 @@ export function initAgar() {
 
         // Map borders
         ctx.strokeStyle = "red";
-        ctx.lineWidth = 5;
+        ctx.lineWidth = 5 / zoom;
         ctx.strokeRect(0, 0, AGAR_MAP_WIDTH, AGAR_MAP_HEIGHT);
 
         // Draw food


### PR DESCRIPTION
### Motivation
- Make the Agar view less zoomed-in for large cells by adding a smooth, dynamic camera zoom that scales out as the local player's radius grows.
- Keep mouse targeting correct when zoom is not 1x so movement and input remain intuitive.

### Description
- Added a `zoom` state variable and a `calculateZoom(playerRadius)` helper that computes a clamped zoom value based on the player's radius.
- Updated mouse-to-world conversion so `targetX`/`targetY` account for the current `zoom` when mapping canvas mouse coordinates to world coordinates.
- Switched rendering transforms to center the camera using `ctx.translate` + `ctx.scale(zoom, zoom)` and adjusted stroke widths (`ctx.lineWidth`) for grid and map borders to remain visually consistent while zooming.
- Changes applied in `games/agar.js` to smoothly interpolate zoom (`zoom += (target - zoom) * factor`) alongside the existing camera follow logic.

### Testing
- Ran `node --check games/agar.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de471066d88327a44b30d61dbb42e0)