### PR TITLE
Enable fullscreen control for Agar overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -383,6 +383,7 @@ const GAME_TEMPLATE_OVERLAY_IDS = [
   "overlayUltimatettt",
   "overlaySmasharena",
   "overlayBuilder",
+  "overlayAgar",
   "overlayVideopoker",
   "overlayCraps",
   "overlayBaccarat",


### PR DESCRIPTION
### Motivation
- Allow the Agar game overlay to use the shared fullscreen button and canvas resizing behavior that other games already use.

### Description
- Added `"overlayAgar"` to `GAME_TEMPLATE_OVERLAY_IDS` in `script.js` so the per-game fullscreen button injection and global resize/fullscreen logic will apply to the Agar overlay.

### Testing
- Ran `node --check script.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de46f5ec9483278a69bfc72d484148)