### PR TITLE
Add multi-cell Agar mechanics and client interpolation to reduce jitter

### DIFF
--- a/games/agar.js
+++ b/games/agar.js
@@ -56,6 +56,8 @@ export function initAgar() {
 
     let players = new Map();
     let foods = new Map();
+    let cells = new Map();
+    let renderCells = new Map();
     let localPlayerId = null;
 
     const renderServerList = (servers) => {
@@ -97,6 +99,10 @@ export function initAgar() {
     };
 
     const setupRoomListeners = () => {
+        players = new Map();
+        foods = new Map();
+        cells = new Map();
+        renderCells = new Map();
         room.state.players.onAdd((player, sessionId) => {
             players.set(sessionId, player);
             player.onChange(() => {
@@ -119,6 +125,16 @@ export function initAgar() {
         room.state.foods.onRemove((food, id) => {
             foods.delete(id);
         });
+        if (room.state.cells) {
+            room.state.cells.onAdd((cell, id) => {
+                cells.set(id, cell);
+                renderCells.set(id, { x: cell.x, y: cell.y, radius: cell.radius, ownerId: cell.ownerId });
+            });
+            room.state.cells.onRemove((cell, id) => {
+                cells.delete(id);
+                renderCells.delete(id);
+            });
+        }
 
         room.onMessage("died", (message) => {
             if (deathMessage) deathMessage.textContent = `Eaten by ${escapeHtml(message.killer)}`;
@@ -200,6 +216,13 @@ export function initAgar() {
         targetX = mx + cameraX - CANVAS_WIDTH / 2;
         targetY = my + cameraY - CANVAS_HEIGHT / 2;
     });
+    const onKeyDown = (e) => {
+        if (e.code === "Space" && room && players.get(localPlayerId)?.isAlive) {
+            e.preventDefault();
+            room.send("split");
+        }
+    };
+    window.addEventListener("keydown", onKeyDown);
 
     function updateLeaderboard() {
         if (!leaderboardList) return;
@@ -220,8 +243,8 @@ export function initAgar() {
         const localPlayer = players.get(localPlayerId);
         if (localPlayer && localPlayer.isAlive) {
             // Smooth camera follow
-            cameraX += (localPlayer.x - cameraX) * 0.1;
-            cameraY += (localPlayer.y - cameraY) * 0.1;
+            cameraX += (localPlayer.x - cameraX) * 0.18;
+            cameraY += (localPlayer.y - cameraY) * 0.18;
         }
 
         ctx.save();
@@ -254,27 +277,43 @@ export function initAgar() {
             ctx.fill();
         });
 
-        // Draw players
-        const pList = Array.from(players.values()).sort((a, b) => a.radius - b.radius);
-        pList.forEach(p => {
-            if (!p.isAlive) return;
-            ctx.fillStyle = p.color;
-            ctx.beginPath();
-            ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
-            ctx.fill();
+        // Draw cells with interpolation to reduce network jitter
+        const drawCells = [];
+        if (cells.size > 0) {
+            cells.forEach((cell, id) => {
+                const current = renderCells.get(id) || { x: cell.x, y: cell.y, radius: cell.radius, ownerId: cell.ownerId };
+                current.x += (cell.x - current.x) * 0.35;
+                current.y += (cell.y - current.y) * 0.35;
+                current.radius += (cell.radius - current.radius) * 0.3;
+                current.ownerId = cell.ownerId;
+                renderCells.set(id, current);
+                drawCells.push({ id, ...current });
+            });
+        } else {
+            Array.from(players.entries()).forEach(([id, p]) => {
+                if (!p.isAlive) return;
+                drawCells.push({ id: `legacy_${id}`, x: p.x, y: p.y, radius: p.radius, ownerId: id });
+            });
+        }
 
+        drawCells.sort((a, b) => a.radius - b.radius).forEach(c => {
+            const owner = players.get(c.ownerId);
+            if (!owner || !owner.isAlive) return;
+            ctx.fillStyle = owner.color;
+            ctx.beginPath();
+            ctx.arc(c.x, c.y, c.radius, 0, Math.PI * 2);
+            ctx.fill();
             ctx.lineWidth = 3;
             ctx.strokeStyle = "rgba(0,0,0,0.2)";
             ctx.stroke();
 
-            ctx.fillStyle = "white";
-            ctx.font = `${Math.max(10, p.radius / 2)}px 'Space Mono', monospace`;
-            ctx.textAlign = "center";
-            ctx.textBaseline = "middle";
-            ctx.fillText(p.name, p.x, p.y);
-
-            ctx.font = `${Math.max(8, p.radius / 3)}px 'Space Mono', monospace`;
-            ctx.fillText(Math.floor(p.score), p.x, p.y + p.radius / 2);
+            if (c.radius > 18) {
+                ctx.fillStyle = "white";
+                ctx.font = `${Math.max(10, c.radius / 2.6)}px 'Space Mono', monospace`;
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.fillText(owner.name, c.x, c.y);
+            }
         });
 
         ctx.restore();
@@ -289,7 +328,7 @@ export function initAgar() {
         function loop(timestamp) {
             if (!room) return;
 
-            if (timestamp - lastSend > 50) {
+            if (timestamp - lastSend > 33) {
                 if (localPlayerId && players.get(localPlayerId)?.isAlive) {
                     room.send("input", { targetX, targetY });
                 }
@@ -310,12 +349,17 @@ export function initAgar() {
             room.leave();
             room = null;
         }
+        window.removeEventListener("keydown", onKeyDown);
         menu.style.display = "block";
         gameArea.style.display = "none";
         deathScreen.style.display = "none";
         btnJoin.textContent = "QUICK JOIN ANY SERVER";
         if (btnCreateServer) btnCreateServer.textContent = "CREATE SERVER";
         selectedRoomId = null;
+        players.clear();
+        foods.clear();
+        cells.clear();
+        renderCells.clear();
         refreshServerList();
     };
 

--- a/server.js
+++ b/server.js
@@ -104,9 +104,20 @@ type("string")(AgarPlayer.prototype, "color");
 type("number")(AgarPlayer.prototype, "score");
 type("boolean")(AgarPlayer.prototype, "isAlive");
 
+class AgarCell extends Schema {}
+type("string")(AgarCell.prototype, "id");
+type("string")(AgarCell.prototype, "ownerId");
+type("number")(AgarCell.prototype, "x");
+type("number")(AgarCell.prototype, "y");
+type("number")(AgarCell.prototype, "radius");
+type("number")(AgarCell.prototype, "vx");
+type("number")(AgarCell.prototype, "vy");
+type("number")(AgarCell.prototype, "mergeAt");
+
 class AgarState extends Schema {}
 type({ map: AgarPlayer })(AgarState.prototype, "players");
 type({ map: AgarFood })(AgarState.prototype, "foods");
+type({ map: AgarCell })(AgarState.prototype, "cells");
 
 // --------------------------------------------------------
 // SMASH ARENA GAME LOGIC (Moved from client)
@@ -1744,6 +1755,10 @@ const AGAR_MAP_HEIGHT = 4000;
 const AGAR_MAX_FOOD = 500;
 const AGAR_BASE_RADIUS = 20;
 const AGAR_TICK_RATE = 20; // ms per tick
+const AGAR_MAX_CELLS = 8;
+const AGAR_SPLIT_MIN_RADIUS = 24;
+const AGAR_SPLIT_LAUNCH_SPEED = 24;
+const AGAR_MERGE_COOLDOWN_MS = 9000;
 
 const agarServerDirectory = new Map();
 
@@ -1759,10 +1774,12 @@ class AgarRoom extends colyseus.Room {
     const state = new AgarState();
     state.players = new MapSchema();
     state.foods = new MapSchema();
+    state.cells = new MapSchema();
     this.setState(state);
 
     this.inputs = {};
     this.foodCounter = 0;
+    this.cellCounter = 0;
 
     // Initial food spawn
     for (let i = 0; i < AGAR_MAX_FOOD / 2; i++) {
@@ -1777,15 +1794,16 @@ class AgarRoom extends colyseus.Room {
       }
     });
 
+    this.onMessage("split", (client) => {
+      const pId = client.sessionId;
+      if (this.inputs[pId]) this.inputs[pId].splitRequested = true;
+    });
+
     this.onMessage("respawn", (client) => {
       const pId = client.sessionId;
       const player = this.state.players.get(pId);
       if (player && !player.isAlive) {
-        player.x = Math.random() * AGAR_MAP_WIDTH;
-        player.y = Math.random() * AGAR_MAP_HEIGHT;
-        player.radius = AGAR_BASE_RADIUS;
-        player.score = 0;
-        player.isAlive = true;
+        this.spawnPlayerCells(pId, player);
       }
     });
 
@@ -1810,70 +1828,192 @@ class AgarRoom extends colyseus.Room {
     this.state.foods.set(food.id, food);
   }
 
+  createCell(ownerId, x, y, radius, vx = 0, vy = 0, mergeAt = Date.now() + AGAR_MERGE_COOLDOWN_MS) {
+    const c = new AgarCell();
+    c.id = `cell_${this.cellCounter++}`;
+    c.ownerId = ownerId;
+    c.x = x;
+    c.y = y;
+    c.radius = radius;
+    c.vx = vx;
+    c.vy = vy;
+    c.mergeAt = mergeAt;
+    this.state.cells.set(c.id, c);
+    return c;
+  }
+
+  getPlayerCells(playerId) {
+    const cells = [];
+    this.state.cells.forEach((c) => {
+      if (c.ownerId === playerId) cells.push(c);
+    });
+    return cells;
+  }
+
+  updatePlayerAggregate(playerId) {
+    const player = this.state.players.get(playerId);
+    if (!player) return;
+    const cells = this.getPlayerCells(playerId);
+    if (cells.length === 0) {
+      player.isAlive = false;
+      return;
+    }
+    let largest = cells[0];
+    let area = 0;
+    let weightedX = 0;
+    let weightedY = 0;
+    cells.forEach((c) => {
+      const a = c.radius * c.radius;
+      area += a;
+      weightedX += c.x * a;
+      weightedY += c.y * a;
+      if (c.radius > largest.radius) largest = c;
+    });
+    player.x = weightedX / area;
+    player.y = weightedY / area;
+    player.radius = largest.radius;
+    player.score = Math.floor(area);
+    player.isAlive = true;
+  }
+
+  spawnPlayerCells(playerId, player) {
+    const now = Date.now();
+    const x = Math.random() * AGAR_MAP_WIDTH;
+    const y = Math.random() * AGAR_MAP_HEIGHT;
+    this.state.cells.forEach((cell, cellId) => {
+      if (cell.ownerId === playerId) this.state.cells.delete(cellId);
+    });
+    this.createCell(playerId, x, y, AGAR_BASE_RADIUS, 0, 0, now + AGAR_MERGE_COOLDOWN_MS);
+    player.x = x;
+    player.y = y;
+    player.radius = AGAR_BASE_RADIUS;
+    player.score = AGAR_BASE_RADIUS * AGAR_BASE_RADIUS;
+    player.isAlive = true;
+    if (this.inputs[playerId]) {
+      this.inputs[playerId].targetX = x;
+      this.inputs[playerId].targetY = y;
+      this.inputs[playerId].splitRequested = false;
+    }
+  }
+
+  consumeFood(cell) {
+    const foodsToRemove = [];
+    this.state.foods.forEach((food, foodId) => {
+      const dx = cell.x - food.x;
+      const dy = cell.y - food.y;
+      if ((dx * dx + dy * dy) < (cell.radius * cell.radius)) {
+        foodsToRemove.push(foodId);
+        cell.radius += 0.45;
+      }
+    });
+    foodsToRemove.forEach((id) => this.state.foods.delete(id));
+  }
+
+  trySplitPlayer(playerId, input, now) {
+    const owned = this.getPlayerCells(playerId);
+    if (owned.length === 0 || owned.length >= AGAR_MAX_CELLS) return;
+    const nextCells = [...owned].sort((a, b) => b.radius - a.radius);
+    for (const cell of nextCells) {
+      if (this.getPlayerCells(playerId).length >= AGAR_MAX_CELLS) break;
+      if (cell.radius < AGAR_SPLIT_MIN_RADIUS) continue;
+      const dx = (input.targetX ?? cell.x) - cell.x;
+      const dy = (input.targetY ?? cell.y) - cell.y;
+      const dist = Math.hypot(dx, dy) || 1;
+      const dirX = dx / dist;
+      const dirY = dy / dist;
+      const newRadius = cell.radius / Math.sqrt(2);
+      cell.radius = newRadius;
+      const launchDist = newRadius * 2.2;
+      this.createCell(
+        playerId,
+        Math.min(AGAR_MAP_WIDTH, Math.max(0, cell.x + dirX * launchDist)),
+        Math.min(AGAR_MAP_HEIGHT, Math.max(0, cell.y + dirY * launchDist)),
+        newRadius,
+        dirX * AGAR_SPLIT_LAUNCH_SPEED,
+        dirY * AGAR_SPLIT_LAUNCH_SPEED,
+        now + AGAR_MERGE_COOLDOWN_MS
+      );
+      cell.mergeAt = now + AGAR_MERGE_COOLDOWN_MS;
+    }
+  }
+
   simulateTick() {
-    // 1. Move players
+    const now = Date.now();
+    // 1) split requests and movement
     this.state.players.forEach((player, id) => {
       if (!player.isAlive) return;
-
-      const input = this.inputs[id];
-      if (input && (input.targetX !== undefined && input.targetY !== undefined)) {
-        const dx = input.targetX - player.x;
-        const dy = input.targetY - player.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-
-        if (dist > 5) { // Deadzone
-          const speed = Math.max(1, 10 - Math.log(player.radius));
-          player.x += (dx / dist) * speed;
-          player.y += (dy / dist) * speed;
-        }
+      const input = this.inputs[id] || {};
+      if (input.splitRequested) {
+        this.trySplitPlayer(id, input, now);
+        input.splitRequested = false;
       }
-
-      // Bounds
-      if (player.x < 0) player.x = 0;
-      if (player.y < 0) player.y = 0;
-      if (player.x > AGAR_MAP_WIDTH) player.x = AGAR_MAP_WIDTH;
-      if (player.y > AGAR_MAP_HEIGHT) player.y = AGAR_MAP_HEIGHT;
+      const owned = this.getPlayerCells(id);
+      owned.forEach((cell) => {
+        const targetX = input.targetX ?? cell.x;
+        const targetY = input.targetY ?? cell.y;
+        const dx = targetX - cell.x;
+        const dy = targetY - cell.y;
+        const dist = Math.hypot(dx, dy) || 1;
+        if (dist > 1) {
+          const baseSpeed = Math.max(1.2, 12 - Math.log(Math.max(8, cell.radius)) * 2.5);
+          cell.x += (dx / dist) * baseSpeed;
+          cell.y += (dy / dist) * baseSpeed;
+        }
+        if (Math.abs(cell.vx) > 0.01 || Math.abs(cell.vy) > 0.01) {
+          cell.x += cell.vx;
+          cell.y += cell.vy;
+          cell.vx *= 0.83;
+          cell.vy *= 0.83;
+        }
+        if (cell.x < 0) { cell.x = 0; cell.vx = 0; }
+        if (cell.y < 0) { cell.y = 0; cell.vy = 0; }
+        if (cell.x > AGAR_MAP_WIDTH) { cell.x = AGAR_MAP_WIDTH; cell.vx = 0; }
+        if (cell.y > AGAR_MAP_HEIGHT) { cell.y = AGAR_MAP_HEIGHT; cell.vy = 0; }
+      });
     });
 
-    // 2. Check collisions
-    this.state.players.forEach((player, id) => {
-      if (!player.isAlive) return;
+    // 2) food and cell-vs-cell collisions
+    this.state.cells.forEach((cell) => this.consumeFood(cell));
 
-      // Player vs Food
-      const foodsToRemove = [];
-      this.state.foods.forEach((food, foodId) => {
-        const dx = player.x - food.x;
-        const dy = player.y - food.y;
-        const distSq = dx * dx + dy * dy;
-        const rSq = player.radius * player.radius;
-        if (distSq < rSq) {
-          foodsToRemove.push(foodId);
-          player.radius += 0.5;
-          player.score += 10;
-        }
-      });
-      foodsToRemove.forEach(id => this.state.foods.delete(id));
-
-      // Player vs Player
-      this.state.players.forEach((other, otherId) => {
-        if (id === otherId || !other.isAlive || !player.isAlive) return;
-
-        const dx = player.x - other.x;
-        const dy = player.y - other.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-
-        // One must be 1.2x bigger to eat
-        if (dist < player.radius && player.radius > other.radius * 1.2) {
-          // Player eats Other
-          player.radius += other.radius * 0.5;
-          player.score += other.score + 50;
-          other.isAlive = false;
-          const otherClient = this.clients.find(c => c.sessionId === otherId);
-          if (otherClient) {
-             otherClient.send("died", { killer: player.name });
+    const deathBy = new Map();
+    const cellEntries = Array.from(this.state.cells.entries());
+    for (let i = 0; i < cellEntries.length; i++) {
+      const [idA, a] = cellEntries[i];
+      if (!this.state.cells.has(idA)) continue;
+      for (let j = i + 1; j < cellEntries.length; j++) {
+        const [idB, b] = cellEntries[j];
+        if (!this.state.cells.has(idA) || !this.state.cells.has(idB)) continue;
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.hypot(dx, dy);
+        if (a.ownerId === b.ownerId) {
+          if (now >= a.mergeAt && now >= b.mergeAt && dist < Math.max(a.radius, b.radius)) {
+            const larger = a.radius >= b.radius ? a : b;
+            const smaller = larger === a ? b : a;
+            larger.radius = Math.sqrt(larger.radius * larger.radius + smaller.radius * smaller.radius);
+            this.state.cells.delete(smaller.id);
           }
+          continue;
         }
-      });
+        const bigger = a.radius >= b.radius ? a : b;
+        const smaller = bigger === a ? b : a;
+        if (bigger.radius > smaller.radius * 1.15 && dist < (bigger.radius - smaller.radius * 0.3)) {
+          const killerName = this.state.players.get(bigger.ownerId)?.name || "another player";
+          deathBy.set(smaller.ownerId, killerName);
+          bigger.radius = Math.sqrt(bigger.radius * bigger.radius + smaller.radius * smaller.radius);
+          this.state.cells.delete(smaller.id);
+        }
+      }
+    }
+
+    // 3) refresh player aggregates + death notices
+    this.state.players.forEach((player, id) => {
+      const wasAlive = player.isAlive;
+      this.updatePlayerAggregate(id);
+      if (wasAlive && !player.isAlive) {
+        const loserClient = this.clients.find((c) => c.sessionId === id);
+        if (loserClient) loserClient.send("died", { killer: deathBy.get(id) || "another player" });
+      }
     });
 
     // 3. Replenish food occasionally
@@ -1890,16 +2030,20 @@ class AgarRoom extends colyseus.Room {
     p.y = Math.random() * AGAR_MAP_HEIGHT;
     p.radius = AGAR_BASE_RADIUS;
     p.color = "#" + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
-    p.score = 0;
+    p.score = AGAR_BASE_RADIUS * AGAR_BASE_RADIUS;
     p.isAlive = true;
 
     this.state.players.set(client.sessionId, p);
-    this.inputs[client.sessionId] = { targetX: p.x, targetY: p.y };
+    this.inputs[client.sessionId] = { targetX: p.x, targetY: p.y, splitRequested: false };
+    this.spawnPlayerCells(client.sessionId, p);
 
     this.updateMetadata();
   }
 
   onLeave(client, consented) {
+    this.state.cells.forEach((cell, cellId) => {
+      if (cell.ownerId === client.sessionId) this.state.cells.delete(cellId);
+    });
     this.state.players.delete(client.sessionId);
     delete this.inputs[client.sessionId];
     this.updateMetadata();


### PR DESCRIPTION
### Motivation
- The existing Agar implementation used a single circle per player and felt jittery/laggy and lacked split mechanics, so the game was reworked to be more like classic Agar.io with smoother motion and splitting. 
- Server-side authoritative multi-cell state was added to allow accurate simulation of splits, merges, and PvP collisions.

### Description
- Added an `AgarCell` schema and replicated `state.cells` on the server to represent individual blobs, and introduced constants `AGAR_MAX_CELLS`, `AGAR_SPLIT_MIN_RADIUS`, `AGAR_SPLIT_LAUNCH_SPEED`, and `AGAR_MERGE_COOLDOWN_MS` in `server.js`. 
- Implemented cell lifecycle helpers on the server: `createCell`, `spawnPlayerCells`, `getPlayerCells`, `consumeFood`, `trySplitPlayer`, and refactored `simulateTick` to move cells, handle food consumption, cell-vs-cell eating, same-owner merging with cooldown, and aggregate player state from owned cells. 
- Added `split` message handling on the server and client (space key) and death attribution via a `deathBy` map so the `died` message contains the killer name. 
- Updated the client `games/agar.js` to track `cells` + `renderCells`, interpolate replicated cell positions/radii for smoother rendering, tighten camera smoothing, increase input send cadence (~30Hz), and clean up keyboard listeners and maps on stop/leave. 

### Testing
- `node --check games/agar.js` succeeded. 
- `node --check server.js` succeeded. 
- `python3 fix_agar_test.py` was attempted but failed in this environment due to a missing `playwright` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de46c3a92083279903aeed9944a4bc)