### PR TITLE
Restore ammo crafting in builder inventory grid

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -128,6 +128,7 @@ const blockColors = {
         { pattern: [[15, 15, 15], [0, 15, 0], [0, 15, 0]], output: { type: 25, count: 1 } }, // Gold Gun
         { pattern: [[16, 16, 16], [0, 16, 0], [0, 16, 0]], output: { type: 26, count: 1 } }, // Diamond Rifle
         { pattern: [[17, 17, 17], [0, 17, 0], [0, 17, 0]], output: { type: 27, count: 1 } }, // Uranium Laser
+        { pattern: [[13, 0], [12, 0]], output: { type: 28, count: 16 } }, // Ammo (2x2 inventory)
         { pattern: [[13, 0, 0], [12, 0, 0], [0, 0, 0]], output: { type: 28, count: 16 } }, // Ammo
     ];
 


### PR DESCRIPTION
### Motivation
- Make Copper Ammo craftable again from the standard 2x2 inventory crafting grid in the Builder so players can create ammo without opening a crafting table.

### Description
- Added a 2x2 recipe entry for ammo to `CRAFTING_RECIPES` in `games/builder.js`: `{ pattern: [[13, 0], [12, 0]], output: { type: 28, count: 16 } }`.
- Left the existing 3x3 ammo recipe in place so crafting table behavior remains unchanged.

### Testing
- Ran a syntax check with `node --check games/builder.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfac3ba0308327a3222580a319b2d7)