### PR TITLE
Fix furnace inventory interaction and server sync initialization

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -1132,8 +1132,13 @@ function sendBuildOrBreak(e) {
                 }
                 if (clickedChest) return;
 
-            } else if (isFurnaceOpen && currentFurnaceId && room.state.furnaces && room.state.furnaces.has(currentFurnaceId)) {
-                const furnace = room.state.furnaces.get(currentFurnaceId);
+            } else if (isFurnaceOpen && currentFurnaceId) {
+                const furnace = (room.state.furnaces && room.state.furnaces.get(currentFurnaceId)) || {
+                    inputItem: 0, inputCount: 0,
+                    fuelItem: 0, fuelCount: 0,
+                    outputItem: 0, outputCount: 0,
+                    progress: 0
+                };
                 const craftStartX = panel.x + panel.width - inventoryLayout.padding - 110;
                 const craftStartY = panel.y + 45;
                 const furX = craftStartX + 55;
@@ -2273,9 +2278,14 @@ if (inventoryOpen) {
                         ctx.fillText(`${item.count}`, slotX + 30, slotY + 28);
                     }
                 }
-            } else if (isFurnaceOpen && currentFurnaceId && room.state.furnaces && room.state.furnaces.has(currentFurnaceId)) {
+            } else if (isFurnaceOpen && currentFurnaceId) {
                 // Render Furnace UI
-                const furnace = room.state.furnaces.get(currentFurnaceId);
+                const furnace = (room.state.furnaces && room.state.furnaces.get(currentFurnaceId)) || {
+                    inputItem: 0, inputCount: 0,
+                    fuelItem: 0, fuelCount: 0,
+                    outputItem: 0, outputCount: 0,
+                    progress: 0
+                };
                 const craftStartX = panel.x + panel.width - inventoryLayout.padding - 110;
                 const craftStartY = panel.y + 45;
                 const furX = craftStartX + 55;

--- a/server.js
+++ b/server.js
@@ -678,8 +678,20 @@ this.onMessage("interact", (client, message) => {
         if (!p || p.hp <= 0) return;
 
         const containerId = message.containerId;
-        const furnace = this.state.furnaces.get(containerId);
-        if (!furnace) return;
+        let furnace = this.state.furnaces.get(containerId);
+        if (!furnace) {
+            const [xStr, yStr] = (containerId || "").split(",");
+            const x = Number.parseInt(xStr, 10);
+            const y = Number.parseInt(yStr, 10);
+            if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+            const cx = Math.floor(x / CHUNK_SIZE);
+            const cy = Math.floor(y / CHUNK_SIZE);
+            const chunk = this.state.chunks.get(`${cx},${cy}`);
+            const block = chunk?.blocks.get(`${x},${y}`);
+            if (!block || block.type !== 32) return;
+            furnace = new FurnaceData();
+            this.state.furnaces.set(containerId, furnace);
+        }
 
         furnace.inputItem = message.inputItem || 0;
         furnace.inputCount = message.inputCount || 0;
@@ -1380,7 +1392,7 @@ isSolid(x, y) {
         if (!hit) {
         // Furnace Smelting Logic
     this.state.furnaces.forEach(furnace => {
-        if (furnace.inputCount > 0 && furnace.fuelCount > 0 && furnace.inputItem >= 12 && furnace.inputItem <= 17) {
+        if (furnace.inputCount > 0 && furnace.fuelCount > 0 && furnace.inputItem >= 13 && furnace.inputItem <= 17) {
             // Check if fuel is log/coal
             if (furnace.fuelItem === 12 || furnace.fuelItem === 7 || furnace.fuelItem === 9) {
                 furnace.progress += 1;


### PR DESCRIPTION
### Motivation
- Players could open a furnace UI but be unable to place/take items when the furnace state entry had not replicated yet, causing a race condition between client UI and server state.
- The server previously ignored `furnace_sync` updates if the furnace entry was missing, which dropped user actions during the window before the server created the furnace state.
- Client and server used slightly different ore ID ranges for smelting validation, causing inconsistent behavior.

### Description
- In `games/builder.js` removed the strict `room.state.furnaces.has(currentFurnaceId)` guard and introduced a safe fallback furnace object so UI interactions and rendering work immediately when a furnace is opened without an existing state entry.
- In `server.js` updated the `furnace_sync` handler to lazily create a `FurnaceData` entry when `containerId` points to a valid furnace block, after validating and parsing the `containerId` coordinates.
- Adjusted server-side smelting input validation to use ore IDs `13..17` to match the client-side `canPlaceInFurnaceSlot` rules.
- Kept behavior consistent by writing back the created furnace to `this.state.furnaces` before applying incoming slot values.

### Testing
- Ran `node --check games/builder.js` and it succeeded.
- Ran `node --check server.js` and it succeeded.
- Attempted the automated UI verification `python3 verify_furnace_final.py`, which failed due to a missing `playwright` dependency (module not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaf2f88b0832795c10303ddb58f72)