### PR TITLE
Fix furnace validation and server processing logic

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -1212,6 +1212,7 @@ function sendBuildOrBreak(e) {
                             }
                         } else {
                             if (currentItem === undefined) {
+                                if (!canPlaceInFurnaceSlot(slotName, draggedItemType.type)) return;
                                 setSlot(cloneItem(draggedItemType));
                                 draggedItemType = null;
                             } else if (currentItem.type === draggedItemType.type) {
@@ -1223,7 +1224,7 @@ function sendBuildOrBreak(e) {
                                     if (draggedItemType.count <= 0) draggedItemType = null;
                                 }
                             } else {
-                                if (!canPlaceInFurnaceSlot(slotName, currentItem.type)) return;
+                                if (!canPlaceInFurnaceSlot(slotName, draggedItemType.type)) return;
                                 const temp = cloneItem(currentItem);
                                 setSlot(cloneItem(draggedItemType));
                                 draggedItemType = temp;

--- a/server.js
+++ b/server.js
@@ -1374,23 +1374,8 @@ isSolid(x, y) {
         });
     }
 
-    this.state.bullets.forEach((b, id) => {
-        b.x += b.vx;
-        b.y += b.vy;
-        b.life--;
 
-        let hit = false;
-
-        // Block collision
-        const bx = Math.floor(b.x / TILE_SIZE);
-        const by = Math.floor(b.y / TILE_SIZE);
-        if (this.isSolid(bx, by)) {
-            hit = true;
-        }
-
-        // Player collision
-        if (!hit) {
-        // Furnace Smelting Logic
+    // Furnace Smelting Logic
     this.state.furnaces.forEach(furnace => {
         if (furnace.inputCount > 0 && furnace.fuelCount > 0 && furnace.inputItem >= 13 && furnace.inputItem <= 17) {
             // Check if fuel is log/coal
@@ -1406,13 +1391,6 @@ isSolid(x, y) {
                     // Fuel consumption logic: 1 coal smelts 8 items? Let's just do 1:1 for simplicity right now
                     furnace.fuelCount--;
                     if (furnace.fuelCount <= 0) furnace.fuelItem = 0;
-
-                    // Convert Ore -> Ingot/Gem (Using same IDs for simplicity, or we can use armor IDs as ingots. Let's just give them the ingot form of armor, but armor is 18-22... Wait, we need actual ingots or just let them smelt ore -> ingot item. Let's use 18-22 for Ingots, and we'll change the armor recipes to use 18-22 instead of raw ore, and we'll add armor items later, actually armor is 18-22. So let's use 43+ for ingots.)
-                    // 13: Copper Ore -> 43: Copper Ingot
-                    // 14: Iron Ore -> 44: Iron Ingot
-                    // 15: Gold Ore -> 45: Gold Ingot
-                    // 16: Diamond Ore -> 46: Diamond (refined)
-                    // 17: Uranium Ore -> 47: Uranium (refined)
 
                     let outputType = 0;
                     if (furnace.inputItem === 13) outputType = 43;
@@ -1439,7 +1417,23 @@ isSolid(x, y) {
         }
     });
 
-    this.state.players.forEach((p, sessionId) => {
+    this.state.bullets.forEach((b, id) => {
+        b.x += b.vx;
+        b.y += b.vy;
+        b.life--;
+
+        let hit = false;
+
+        // Block collision
+        const bx = Math.floor(b.x / TILE_SIZE);
+        const by = Math.floor(b.y / TILE_SIZE);
+        if (this.isSolid(bx, by)) {
+            hit = true;
+        }
+
+        // Player collision
+        if (!hit) {
+            this.state.players.forEach((p, sessionId) => {
                 if (hit || sessionId === b.ownerId || p.hp <= 0) return;
 
                 if (b.x >= p.x && b.x <= p.x + TILE_SIZE &&

--- a/test_cuj2.py
+++ b/test_cuj2.py
@@ -21,7 +21,7 @@ def run_cuj(page):
     page.wait_for_timeout(2000)
 
     # QUICK JOIN
-    page.get_by_text("QUICK JOIN ANY SERVER").click()
+    page.locator("#btnJoinBuilder").click()
     page.wait_for_timeout(2000)
 
     # In builder, open inventory to show the item icons

--- a/test_cuj4.py
+++ b/test_cuj4.py
@@ -16,7 +16,7 @@ def run_cuj(page):
     page.evaluate("window.launchGame('builder')")
     page.wait_for_timeout(2000)
 
-    page.get_by_text("QUICK JOIN ANY SERVER").click()
+    page.locator("#btnJoinBuilder").click()
     page.wait_for_timeout(2000)
 
     # Wait for game to initialize completely


### PR DESCRIPTION
Fixes the furnace mechanics in the builder game.

**Bugs Addressed:**
1. **Client UI bug:** Players were able to place non-smeltable items (like Dirt) into the Furnace Input and Fuel slots because `canPlaceInFurnaceSlot` was missing for empty slot drops and checked the wrong variable during swaps.
2. **Server loop bug:** Furnaces would only process ticks (smelt items) if a bullet was actively being fired or simulated on the map, because the furnace tick iteration block was accidentally nested deep inside the `this.state.bullets.forEach` collision check logic.

**Test updates:**
- Updated two brittle tests that relied on `page.get_by_text("QUICK JOIN ANY SERVER")` because the front end has multiple buttons with this exact text. Replaced them with the reliable locator `page.locator("#btnJoinBuilder")`. Tests now pass cleanly.

---
*PR created automatically by Jules for task [12350968649601149450](https://jules.google.com/task/12350968649601149450) started by @thefoxssss*