### PR TITLE
Add global maintenance mode feature

### DIFF
--- a/core.js
+++ b/core.js
@@ -209,6 +209,8 @@ const LOCAL_CREW_STORAGE_KEY = "goonerCrewData";
 const LOCAL_SEASON_STORAGE_KEY = "goonerSeasonData";
 let hasAdminClaim = false;
 let permissionMask = 0;
+let isMaintenanceMode = false;
+let stopMaintenanceSync = null;
 const CHAT_BLOCKLIST_KEY = "goonerChatBlocklist";
 const CHAT_MUTED_KEY = "goonerChatMuted";
 const CHAT_BAD_WORDS = ["slur1", "slur2", "idiot", "stupid"];
@@ -1227,6 +1229,26 @@ function subscribeToGlobalMarket() {
   stopMarketSync = onSnapshot(ref, (snap) => {
     if (!snap.exists()) return;
     applyMarketPayload(snap.data());
+  }, () => {});
+}
+
+function subscribeToMaintenanceMode() {
+  if (stopMaintenanceSync) return;
+  const ref = doc(db, GLOBAL_MARKET_COLLECTION, "maintenance_mode");
+  stopMaintenanceSync = onSnapshot(ref, (snap) => {
+    isMaintenanceMode = snap.exists() ? Boolean(snap.data().active) : false;
+    const maintenanceOverlay = document.getElementById("overlayMaintenance");
+    if (maintenanceOverlay) {
+      if (isMaintenanceMode && !isGodUser()) {
+        maintenanceOverlay.classList.add("active");
+        document.body.classList.add("overlay-open");
+      } else {
+        maintenanceOverlay.classList.remove("active");
+        // Only toggle overlay-open if no other overlays are active
+        const hasActiveOverlay = Boolean(document.querySelector(".overlay.active:not(#overlayMaintenance)"));
+        document.body.classList.toggle("overlay-open", hasActiveOverlay);
+      }
+    }
   }, () => {});
 }
 
@@ -3103,6 +3125,7 @@ onAuthStateChanged(auth, async (u) => {
     updateAdminMenu();
     await ensureGlobalMarket();
     subscribeToGlobalMarket();
+    subscribeToMaintenanceMode();
     initChat();
     refreshTrendingGames();
     refreshTrendingMonthGraph();
@@ -4150,6 +4173,19 @@ export async function adminClearRecentChatFromInput() {
     showToast(`REMOVED ${snap.docs.length} CHAT MESSAGE(S)`, "🧹");
   } catch {
     showToast("CHAT CLEAR FAILED", "⚠️", "Try again shortly.");
+  }
+}
+
+export async function adminToggleMaintenance() {
+  if (!isGodUser()) return;
+  try {
+    const ref = doc(db, GLOBAL_MARKET_COLLECTION, "maintenance_mode");
+    const snap = await getDoc(ref);
+    const currentlyActive = snap.exists() ? Boolean(snap.data().active) : false;
+    await setDoc(ref, { active: !currentlyActive }, { merge: true });
+    showToast(`MAINTENANCE MODE ${!currentlyActive ? 'ON' : 'OFF'}`, "🔧");
+  } catch (error) {
+    showToast("FAILED TO TOGGLE MAINTENANCE", "⚠️");
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -78,6 +78,16 @@
 
     <div class="dropdown-content" id="menuDropdown"></div>
 
+    <div class="overlay menu-overlay" id="overlayMaintenance">
+      <div class="maintenance-box">
+        <h1 style="color: #f66; text-align: center; margin-bottom: 20px; font-size: 2.5rem; text-shadow: 0 0 15px rgba(255, 102, 102, 0.5);">MAINTENANCE MODE</h1>
+        <p style="text-align: center; color: var(--accent); font-size: 1.2rem; line-height: 1.6;">
+          THE SYSTEM IS CURRENTLY UNDERGOING ROUTINE MAINTENANCE OR EMERGENCY REPAIRS.<br/>
+          PLEASE CHECK BACK SHORTLY.
+        </p>
+      </div>
+    </div>
+
     <div class="overlay menu-overlay" id="overlayTrending">
       <div class="score-box panel-overlay-box">
         <h2>TRENDING GAMES // MONTHLY GRAPH</h2>
@@ -372,6 +382,11 @@
                     <option value="en"></option>
                   </datalist>
                   <button class="term-btn" onclick="window.adminSetPreferenceFromInput()">SET PREFERENCE</button>
+                </div>
+
+                <div class="admin-section admin-section-danger">
+                  <p class="admin-section-title">GLOBAL MAINTENANCE</p>
+                  <button class="term-btn" style="border-color: #f66; color: #f66;" onclick="window.adminToggleMaintenance()">TOGGLE MAINTENANCE MODE</button>
                 </div>
               </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -33,6 +33,7 @@ import {
   adminSendChatAnnouncement,
   adminSendChatSystemMessage,
   adminClearRecentChatFromInput,
+  adminToggleMaintenance,
   adminApplySettingActionFromInput,
   adminSetRoleFromInput,
   adminSetStatusFromInput,
@@ -128,6 +129,7 @@ window.adminMarketMultiplyFromInput = adminMarketMultiplyFromInput;
 window.adminSendChatAnnouncement = adminSendChatAnnouncement;
 window.adminSendChatSystemMessage = adminSendChatSystemMessage;
 window.adminClearRecentChatFromInput = adminClearRecentChatFromInput;
+window.adminToggleMaintenance = adminToggleMaintenance;
 window.adminApplySettingActionFromInput = adminApplySettingActionFromInput;
 window.adminSetRoleFromInput = adminSetRoleFromInput;
 window.adminSetStatusFromInput = adminSetStatusFromInput;

--- a/styles.css
+++ b/styles.css
@@ -2752,6 +2752,22 @@ canvas {
   padding-bottom: 5px;
 }
 
+/* Maintenance */
+#overlayMaintenance {
+  z-index: 9999 !important;
+  background: rgba(0, 0, 0, 0.95);
+  backdrop-filter: blur(8px);
+}
+
+.maintenance-box {
+  border: 2px solid #f66;
+  background: rgba(20, 0, 0, 0.9);
+  padding: 40px;
+  box-shadow: 0 0 30px rgba(255, 102, 102, 0.3);
+  max-width: 600px;
+  width: 90vw;
+}
+
 /* Config */
 .config-box {
   width: min(260px, 92vw);


### PR DESCRIPTION
- Added `#overlayMaintenance` full-screen overlay in `index.html`.
- Styled the overlay and box in `styles.css`.
- Added a "TOGGLE MAINTENANCE MODE" button to the Server Tools admin tab in `index.html`.
- Implemented `adminToggleMaintenance` and `subscribeToMaintenanceMode` in `core.js` to manage the state via Firestore.
- Exposed the toggle function to the global `window` object in `script.js`.
- Automatically applied the overlay for regular users (`!isGodUser()`) when active, while allowing admins to continue testing the site unaffected.

---
*PR created automatically by Jules for task [15233115633973813794](https://jules.google.com/task/15233115633973813794) started by @thefoxssss*