### PR TITLE
Add online/offline status indicators in Season and Crew panels

### DIFF
--- a/core.js
+++ b/core.js
@@ -240,17 +240,21 @@ let seasonBoardUnsub = null;
 let activeSeasonTab = "";
 let activeSeasonSubTab = "solo";
 let cachedSeasonBoards = { solo: [], gang: [] };
+let hideStatus = false;
+let stopChatPresenceSync = null;
+let chatPresenceByUser = {};
 
-function isUserMarkedOnline(lastLogin) {
+function getUserStatusState(lastLogin, isHidden = false) {
+  if (isHidden) return "hidden";
   const ts = Number(lastLogin || 0);
-  if (!Number.isFinite(ts) || ts <= 0) return false;
-  return Date.now() - ts <= ONLINE_STATUS_WINDOW_MS;
+  if (!Number.isFinite(ts) || ts <= 0) return "offline";
+  return Date.now() - ts <= ONLINE_STATUS_WINDOW_MS ? "online" : "offline";
 }
 
-function renderOnlineStatusBadge(isOnline) {
-  const cls = isOnline ? "online" : "offline";
-  const label = isOnline ? "ONLINE" : "OFFLINE";
-  return `<span class="online-status ${cls}">${label}</span>`;
+function renderStatusDot(state = "offline") {
+  const safeState = ["online", "offline", "hidden"].includes(state) ? state : "offline";
+  const label = safeState.toUpperCase();
+  return `<span class="status-dot ${safeState}" title="${label}" aria-label="${label}"></span>`;
 }
 
 // Centralized mutable state wrapper (keeps consumers consistent).
@@ -2320,7 +2324,7 @@ function renderSeasonBoard() {
             if (activeSeasonSubTab === "gang") {
               return `<div class="score-item"><div>#${idx + 1} ${logoHtml}[${escapeHtml(row.tag)}]</div> <div>$${Math.round(row.money)} // ${row.members} OPS</div></div>`;
             } else {
-              return `<div class="score-item"><div>#${idx + 1} ${escapeHtml(row.name)} ${renderOnlineStatusBadge(Boolean(row.online))} <span style="opacity:.7">${row.crewTag !== "SOLO" ? logoHtml : ""}${escapeHtml(row.crewTag)}</span></div> <div>$${Math.round(row.money)}</div></div>`;
+              return `<div class="score-item"><div>#${idx + 1} ${escapeHtml(row.name)} ${renderStatusDot(row.status)} <span style="opacity:.7">${row.crewTag !== "SOLO" ? logoHtml : ""}${escapeHtml(row.crewTag)}</span></div> <div>$${Math.round(row.money)}</div></div>`;
             }
           })
           .join("")
@@ -2401,7 +2405,7 @@ function getLiveSeasonBoardRows(mode = "solo") {
     money: localMoney,
     crewTag: normalizedCrewTag,
     logo: crewData.logo || DEFAULT_CREW_LOGO,
-    online: true,
+    status: hideStatus ? "hidden" : "online",
   });
   return soloRows.sort((a, b) => b.money - a.money);
 }
@@ -2494,7 +2498,7 @@ function loadSeasonLeaderboards() {
         name: playerName,
         money: playerMoney,
         crewTag: crewTag || "SOLO",
-        online: isUserMarkedOnline(data.lastLogin),
+        status: getUserStatusState(data.lastLogin, Boolean(data.hideStatus)),
         _logoRaw: validLogo,
       });
       if (crewTag) {
@@ -2552,7 +2556,7 @@ async function syncCrewData() {
           money: data.money || 0,
           role: data.crewData.role || "MEMBER",
         });
-        memberPresence[memberName.toUpperCase()] = isUserMarkedOnline(data.lastLogin);
+        memberPresence[memberName.toUpperCase()] = getUserStatusState(data.lastLogin, Boolean(data.hideStatus));
         totalBank += Number(data.crewData.bank || 0);
 
         if (data.crewData.wins >= maxWins) {
@@ -2625,7 +2629,7 @@ async function renderCrewPanel() {
       list.innerHTML = crewData.members.map(member =>
         `<div class="crew-roster-item">
            <span class="crew-roster-name">${escapeHtml(member)}</span>
-           ${renderOnlineStatusBadge(Boolean(crewData.memberPresence?.[String(member || "").toUpperCase()]))}
+           ${renderStatusDot(crewData.memberPresence?.[String(member || "").toUpperCase()] || "offline")}
            ${String(member || "").toUpperCase() === String(myName || "").toUpperCase() ? '<span class="crew-roster-you">(YOU)</span>' : ''}
          </div>`
       ).join("");
@@ -3476,6 +3480,7 @@ function loadProfile(data) {
   jobData = data.jobs || { cooldowns: {}, completed: { cashier: 0, frontdesk: 0, delivery: 0, stocker: 0, janitor: 0, barista: 0 } };
   loanData = data.loanData || { debt: 0, rate: 0, lastInterestAt: 0 };
   adminSettings = data.adminSettings || {};
+  hideStatus = Boolean(data.hideStatus);
   stockData = data.stockData || { holdings: {}, selected: "GOON", buyMultiplier: 1 };
   crewData = { tag: "", role: "SOLO", motto: "", recruitmentOpen: true, goal: 5000, bank: 0, wins: 0, members: [], logo: DEFAULT_CREW_LOGO, ...(data.crewData || crewData || {}) };
   seasonData = { id: getSeasonId(), xp: 0, hall: [], ...(data.seasonData || seasonData || {}) };
@@ -3514,6 +3519,7 @@ function loadProfile(data) {
   updateDoc(doc(db, "gooner_users", myName), { lastLogin: now });
   updateMatrixToggle();
   updateAdminMenu();
+  applyStatusVisibilityToggle(hideStatus);
 }
 
 // Render all user-facing UI fields based on the latest state.
@@ -3597,6 +3603,7 @@ async function register(username, pin) {
     builderInventory: null,
     builderHotbar: null,
     builderArmor: null,
+    hideStatus: false,
   };
 
   const localProfile = getLocalProfile(normalized);
@@ -4493,6 +4500,7 @@ export async function saveStats() {
     crewData,
     seasonData,
     adminSettings,
+    hideStatus,
     lastLogin: Date.now(),
   };
   saveLocalProfileSnapshot(snapshot);
@@ -4513,6 +4521,7 @@ export async function saveStats() {
         crewData,
         seasonData,
     adminSettings,
+        hideStatus,
       }),
     "SAVE PROFILE",
     "Progress saved locally; cloud sync retry pending."
@@ -5534,6 +5543,12 @@ function applyReducedMotion(enabled) {
   const motionToggle = document.getElementById("motionToggle");
   if (motionToggle) motionToggle.textContent = enabled ? "ON" : "OFF";
 }
+
+function applyStatusVisibilityToggle(hidden) {
+  hideStatus = Boolean(hidden);
+  const statusToggle = document.getElementById("statusVisibilityToggle");
+  if (statusToggle) statusToggle.textContent = hideStatus ? "HIDDEN" : "VISIBLE";
+}
 // Open the shared games panel from top navigation and keep menu-mash tracking.
 const menuToggleBtn = document.getElementById("menuToggle");
 const menuDropdownEl = document.getElementById("menuDropdown");
@@ -5642,6 +5657,17 @@ document.getElementById("motionToggle").onclick = () => {
   writeUiConfig({ reducedMotion: enabled });
 };
 
+document.getElementById("statusVisibilityToggle").onclick = async () => {
+  applyStatusVisibilityToggle(!hideStatus);
+  writeUiConfig({ hideStatus });
+  if (myName !== "ANON") {
+    await saveStats();
+    if (isChatInitialized) renderChatTab();
+    renderSeasonPanel();
+    renderCrewPanel();
+  }
+};
+
 (function hydrateUiConfig() {
   const config = readUiConfig();
   const uiScale = Number(config.uiScale || 1);
@@ -5650,6 +5676,7 @@ document.getElementById("motionToggle").onclick = () => {
   applyUiTextSize(uiTextSize);
   applyContrastMode(Boolean(config.highContrast));
   applyReducedMotion(Boolean(config.reducedMotion));
+  applyStatusVisibilityToggle(Boolean(config.hideStatus));
   const uiScaleSlider = document.getElementById("uiScaleSlider");
   const uiTextSlider = document.getElementById("uiTextSlider");
   if (uiScaleSlider) uiScaleSlider.value = String(Math.round(uiScale * 100));
@@ -5846,6 +5873,35 @@ let globallyMutedUsers = new Set();
 let isChatInitialized = false;
 let isChatModerationModeEnabled = true;
 
+function getStatusStateForUser(username) {
+  const normalized = normalizeUsername(username || "");
+  if (!normalized) return "offline";
+  if (normalized === normalizeUsername(myName)) {
+    return hideStatus ? "hidden" : "online";
+  }
+  return chatPresenceByUser[normalized] || "offline";
+}
+
+function renderChatUserLabel(username, label = username) {
+  return `${renderStatusDot(getStatusStateForUser(username))}<span class="chat-user">${escapeHtml(String(label || "ANON"))}:</span>`;
+}
+
+function startChatPresenceSync() {
+  if (stopChatPresenceSync) return;
+  const q = query(collection(db, "gooner_users"), orderBy("name"), limit(200));
+  stopChatPresenceSync = onSnapshot(q, (snap) => {
+    const nextPresence = {};
+    snap.forEach((row) => {
+      const data = row.data() || {};
+      const user = normalizeUsername(data.name || row.id || "");
+      if (!user) return;
+      nextPresence[user] = getUserStatusState(data.lastLogin, Boolean(data.hideStatus));
+    });
+    chatPresenceByUser = nextPresence;
+    if (isChatInitialized) renderChatTab();
+  });
+}
+
 function canUseChatModeration() {
   return isGodUser() && isChatModerationModeEnabled;
 }
@@ -5892,7 +5948,7 @@ function getChatTabConfig(tab) {
         const mine = sender === normalizeUsername(myName);
         const partner = mine ? to || "UNKNOWN" : sender;
         const prefix = activeDmUser ? (mine ? "YOU" : `@${sender}`) : `${mine ? "YOU" : `@${sender}`} → @${partner}`;
-        return `<span class="chat-user">${escapeHtml(prefix)}:</span> ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+        return `${renderStatusDot(getStatusStateForUser(sender))}<span class="chat-user">${escapeHtml(prefix)}:</span> ${escapeHtml(filterChatMessage(m.msg || ""))}`;
       }
     },
     global: {
@@ -5903,7 +5959,7 @@ function getChatTabConfig(tab) {
       send: (txt) => ({ payload: { user: myName, msg: filterChatMessage(txt).slice(0, 60), ts: Date.now() }, collectionName: "gooner_global_chat" }),
       renderMessage: (m) => {
         const user = String(m.user || "ANON").toUpperCase();
-        return `<span class="chat-user">${escapeHtml(user)}:</span> ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+        return `${renderChatUserLabel(m.user || "ANON", user)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
       }
     },
     crew: {
@@ -5921,7 +5977,7 @@ function getChatTabConfig(tab) {
       },
       renderMessage: (m) => {
         const user = String(m.user || "ANON").toUpperCase();
-        return `<span class="chat-user">${escapeHtml(user)}:</span> ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+        return `${renderChatUserLabel(m.user || "ANON", user)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
       }
     }
   };
@@ -5986,7 +6042,7 @@ function renderChatTab() {
       text.className = "chat-msg-text";
       if (isLocallyMuted || isGloballyMuted) {
         const muteScope = isGloballyMuted ? "GLOBAL" : "LOCAL";
-        text.innerHTML = `<span class="chat-user">${escapeHtml(user)}:</span> <span class="chat-muted-placeholder">[${escapeHtml(muteScope)} MUTED MESSAGE]</span>`;
+        text.innerHTML = `${renderChatUserLabel(user, user)} <span class="chat-muted-placeholder">[${escapeHtml(muteScope)} MUTED MESSAGE]</span>`;
       } else {
         text.innerHTML = tabConfig.renderMessage(m);
       }
@@ -6136,6 +6192,7 @@ function initChat() {
     });
   });
   initGlobalChatMutes();
+  startChatPresenceSync();
   renderChatTab();
   isChatInitialized = true;
   document.getElementById("chatInput").addEventListener("keydown", async (e) => {

--- a/core.js
+++ b/core.js
@@ -198,6 +198,7 @@ let adminSettings = {};
 const MIN_LOAN_AMOUNT = 100;
 const MAX_LOAN_AMOUNT = 10000;
 const SEASON_STARTING_MONEY = 1000;
+const ONLINE_STATUS_WINDOW_MS = 120000;
 const STOCK_MULTIPLIERS = [1, 5, 10, 25, "MAX"];
 const GLOBAL_MARKET_COLLECTION = "gooner_meta";
 const GLOBAL_MARKET_DOC_ID = "stock_market";
@@ -239,6 +240,18 @@ let seasonBoardUnsub = null;
 let activeSeasonTab = "";
 let activeSeasonSubTab = "solo";
 let cachedSeasonBoards = { solo: [], gang: [] };
+
+function isUserMarkedOnline(lastLogin) {
+  const ts = Number(lastLogin || 0);
+  if (!Number.isFinite(ts) || ts <= 0) return false;
+  return Date.now() - ts <= ONLINE_STATUS_WINDOW_MS;
+}
+
+function renderOnlineStatusBadge(isOnline) {
+  const cls = isOnline ? "online" : "offline";
+  const label = isOnline ? "ONLINE" : "OFFLINE";
+  return `<span class="online-status ${cls}">${label}</span>`;
+}
 
 // Centralized mutable state wrapper (keeps consumers consistent).
 export const state = {
@@ -2307,7 +2320,7 @@ function renderSeasonBoard() {
             if (activeSeasonSubTab === "gang") {
               return `<div class="score-item"><div>#${idx + 1} ${logoHtml}[${escapeHtml(row.tag)}]</div> <div>$${Math.round(row.money)} // ${row.members} OPS</div></div>`;
             } else {
-              return `<div class="score-item"><div>#${idx + 1} ${escapeHtml(row.name)} <span style="opacity:.7">${row.crewTag !== "SOLO" ? logoHtml : ""}${escapeHtml(row.crewTag)}</span></div> <div>$${Math.round(row.money)}</div></div>`;
+              return `<div class="score-item"><div>#${idx + 1} ${escapeHtml(row.name)} ${renderOnlineStatusBadge(Boolean(row.online))} <span style="opacity:.7">${row.crewTag !== "SOLO" ? logoHtml : ""}${escapeHtml(row.crewTag)}</span></div> <div>$${Math.round(row.money)}</div></div>`;
             }
           })
           .join("")
@@ -2383,7 +2396,13 @@ function getLiveSeasonBoardRows(mode = "solo") {
   }
 
   const soloRows = (cachedSeasonBoards.solo || []).filter((row) => String(row.name || "").toUpperCase() !== normalizedName);
-  soloRows.push({ name: normalizedName, money: localMoney, crewTag: normalizedCrewTag, logo: crewData.logo || DEFAULT_CREW_LOGO });
+  soloRows.push({
+    name: normalizedName,
+    money: localMoney,
+    crewTag: normalizedCrewTag,
+    logo: crewData.logo || DEFAULT_CREW_LOGO,
+    online: true,
+  });
   return soloRows.sort((a, b) => b.money - a.money);
 }
 
@@ -2471,7 +2490,13 @@ function loadSeasonLeaderboards() {
       const validLogo = (playerCrew.logo && playerCrew.logo.palette) ? playerCrew.logo : null;
       const wins = Number(playerCrew.wins || 0);
       const currentMembers = playerCrew.members?.length || 1;
-      players.push({ name: playerName, money: playerMoney, crewTag: crewTag || "SOLO", _logoRaw: validLogo });
+      players.push({
+        name: playerName,
+        money: playerMoney,
+        crewTag: crewTag || "SOLO",
+        online: isUserMarkedOnline(data.lastLogin),
+        _logoRaw: validLogo,
+      });
       if (crewTag) {
         if (!crews[crewTag]) {
           crews[crewTag] = { tag: crewTag, money: 0, members: 0, logo: validLogo, maxWins: -1, repMembers: -1 };
@@ -2513,6 +2538,7 @@ async function syncCrewData() {
     const snap = await getDocs(q);
 
     const matchingMembers = [];
+    const memberPresence = {};
     let authUser = null;
     let maxWins = -1;
     let totalBank = 0;
@@ -2520,7 +2546,13 @@ async function syncCrewData() {
     snap.forEach((docSnap) => {
       const data = docSnap.data();
       if (data.crewData) {
-        matchingMembers.push({ name: data.name, money: data.money || 0, role: data.crewData.role || "MEMBER" });
+        const memberName = String(data.name || docSnap.id || "ANON");
+        matchingMembers.push({
+          name: memberName,
+          money: data.money || 0,
+          role: data.crewData.role || "MEMBER",
+        });
+        memberPresence[memberName.toUpperCase()] = isUserMarkedOnline(data.lastLogin);
         totalBank += Number(data.crewData.bank || 0);
 
         if (data.crewData.wins >= maxWins) {
@@ -2545,6 +2577,7 @@ async function syncCrewData() {
     });
 
     crewData.members = matchingMembers.map(m => m.name);
+    crewData.memberPresence = memberPresence;
     saveCrewData();
 
   } catch (err) {
@@ -2592,7 +2625,8 @@ async function renderCrewPanel() {
       list.innerHTML = crewData.members.map(member =>
         `<div class="crew-roster-item">
            <span class="crew-roster-name">${escapeHtml(member)}</span>
-           ${member === myName ? '<span class="crew-roster-you">(YOU)</span>' : ''}
+           ${renderOnlineStatusBadge(Boolean(crewData.memberPresence?.[String(member || "").toUpperCase()]))}
+           ${String(member || "").toUpperCase() === String(myName || "").toUpperCase() ? '<span class="crew-roster-you">(YOU)</span>' : ''}
          </div>`
       ).join("");
     }

--- a/index.html
+++ b/index.html
@@ -1267,6 +1267,10 @@
           <span>REDUCED MOTION</span
           ><button class="menu-btn" id="motionToggle">OFF</button>
         </div>
+        <div class="config-row">
+          <span>STATUS VISIBILITY</span
+          ><button class="menu-btn" id="statusVisibilityToggle">VISIBLE</button>
+        </div>
         <button
           class="term-btn"
           id="btnLogout"

--- a/styles.css
+++ b/styles.css
@@ -1287,6 +1287,30 @@ body::before {
   color: #fff;
 }
 
+.online-status {
+  font-size: 9px;
+  letter-spacing: 0.6px;
+  border: 1px solid;
+  padding: 1px 5px;
+  border-radius: 999px;
+  margin-left: 6px;
+  vertical-align: middle;
+  display: inline-flex;
+  align-items: center;
+}
+
+.online-status.online {
+  color: #7dff7d;
+  border-color: rgba(125, 255, 125, 0.65);
+  background: rgba(40, 120, 40, 0.2);
+}
+
+.online-status.offline {
+  color: #ffa3a3;
+  border-color: rgba(255, 120, 120, 0.55);
+  background: rgba(140, 40, 40, 0.2);
+}
+
 .crew-roster-you {
   color: var(--accent);
 }

--- a/styles.css
+++ b/styles.css
@@ -1287,28 +1287,51 @@ body::before {
   color: #fff;
 }
 
-.online-status {
-  font-size: 9px;
-  letter-spacing: 0.6px;
-  border: 1px solid;
-  padding: 1px 5px;
+.status-dot {
+  width: 8px;
+  height: 8px;
   border-radius: 999px;
+  display: inline-block;
   margin-left: 6px;
+  margin-right: 6px;
   vertical-align: middle;
-  display: inline-flex;
-  align-items: center;
+  box-shadow: 0 0 4px currentColor;
 }
 
-.online-status.online {
-  color: #7dff7d;
-  border-color: rgba(125, 255, 125, 0.65);
-  background: rgba(40, 120, 40, 0.2);
+.status-dot.online {
+  background: #62ff62;
+  color: #62ff62;
 }
 
-.online-status.offline {
-  color: #ffa3a3;
-  border-color: rgba(255, 120, 120, 0.55);
-  background: rgba(140, 40, 40, 0.2);
+.status-dot.offline {
+  background: #ff6a6a;
+  color: #ff6a6a;
+}
+
+.status-dot.hidden {
+  background: #a1a1a1;
+  color: #a1a1a1;
+}
+
+.crew-roster-item .status-dot {
+  margin-left: auto;
+}
+
+.chat-msg .status-dot {
+  margin-left: 0;
+}
+
+.chat-msg .chat-user {
+  vertical-align: middle;
+}
+
+/* Legacy badge selector retained for compatibility with older cached markup. */
+.online-status {
+  border: 1px solid;
+  padding: 0;
+  border-radius: 50%;
+  width: 8px;
+  height: 8px;
 }
 
 .crew-roster-you {


### PR DESCRIPTION
### Motivation
- Provide a quick visual presence indicator next to player names in the Season leaderboard and Crew roster so users can see who is currently active.

### Description
- Added a 2-minute presence window constant `ONLINE_STATUS_WINDOW_MS` and helper `isUserMarkedOnline(lastLogin)` in `core.js` to compute presence from each user's `lastLogin` timestamp.
- Added `renderOnlineStatusBadge(isOnline)` to produce consistent badge markup and updated `renderSeasonBoard` to include the badge next to each solo player name and ensured the local player row is marked online in merged live rows.
- Updated `loadSeasonLeaderboards` to attach `online` state from `data.lastLogin` and updated `syncCrewData` to build a `memberPresence` map used by `renderCrewPanel` to show per-member badges.
- Added `.online-status`, `.online-status.online`, and `.online-status.offline` styles to `styles.css` for distinct visual states.

### Testing
- Verified JavaScript syntax/type checks with `node --check core.js`, `node --check script.js`, and `node --check server.js`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f10b24f483228ea5a9c39770dead)