### PR TITLE
Add admin-only bedrock block (type 48) and make it unbreakable

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -97,6 +97,7 @@ const blockColors = {
         45: "#FFD700", // Gold Ingot
         46: "#00FFFF", // Diamond (Refined)
         47: "#39FF14", // Uranium (Refined)
+        48: "#1b1b1b", // Bedrock
     };
 
     const CRAFTING_RECIPES = [
@@ -180,6 +181,7 @@ const blockColors = {
         45: "GOLD INGOT",
         46: "DIAMOND (REFINED)",
         47: "URANIUM (REFINED)",
+        48: "BEDROCK",
     };
     const getMergedInventoryType = (type) => type;
     const getMaxStack = (type) => loadedBlockData[type] ? loadedBlockData[type].maxStack : ([11, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27].includes(type) ? 1 : 99);

--- a/index.html
+++ b/index.html
@@ -444,6 +444,7 @@
                     <option value="45">45 - GOLD INGOT</option>
                     <option value="46">46 - DIAMOND (REFINED)</option>
                     <option value="47">47 - URANIUM (REFINED)</option>
+                    <option value="48">48 - BEDROCK</option>
                   </select>
                   <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 15px;">
                     <input class="term-input" id="adminBuilderItemCount" type="number" step="1" min="1" max="99" value="1" placeholder="COUNT" style="width: 100%;" />

--- a/server.js
+++ b/server.js
@@ -894,6 +894,7 @@ this.onMessage("hammer", (client, message) => {
         if (chunk) {
             const b = chunk.blocks.get(`${x},${y}`);
             if (b) {
+                if (b.type === 48) return; // Bedrock cannot be reshaped
                 // Cycle meta: 0 (full) -> 1 (bottom slab) -> 2 (top slab) -> 3 (left slope) -> 4 (right slope)
                 b.meta = ((b.meta || 0) + 1) % 5;
             }
@@ -924,6 +925,7 @@ this.onMessage("hammer", (client, message) => {
           const key = `${x},${y}`;
           const b = chunk.blocks.get(key);
           if (b) {
+              if (b.type === 48) return; // Bedrock is unbreakable
               const drop = new ItemDrop();
               drop.id = `drop-${Date.now()}-${Math.random()}`;
               drop.x = x * TILE_SIZE + TILE_SIZE / 2;
@@ -1802,6 +1804,7 @@ if (onLadder) {
                         if (chunk) {
                             const b = chunk.blocks.get(`${tx},${ty}`);
                             if (b) {
+                                if (b.type === 48) continue; // Bedrock is blast-proof
                                 // Destroy and maybe drop item
                                 if (Math.random() < (isNuke ? 0.2 : 0.5)) {
                                     const drop = new ItemDrop();


### PR DESCRIPTION
### Motivation
- Provide an admin-only, unbreakable block called "Bedrock" for the Builder tool so admins can place indestructible structure pieces without adding world-generation or spawn logic.

### Description
- Added `48: "BEDROCK"` to the client `blockNames` and `48: "#1b1b1b"` to `blockColors` so Bedrock displays correctly in the Builder UI (`games/builder.js`).
- Exposed `48 - BEDROCK` in the Admin → Builder → Give Blocks/Items dropdown so it remains admin-only and available from the admin tab (`index.html`).
- Enforced unbreakable behavior on the server by skipping Bedrock in the hammer reshape handler, the manual break handler, and explosion destruction loops (`server.js`).
- No world generation or automatic spawning was added; Bedrock must be given via the admin tab as requested.

### Testing
- Ran static syntax checks with `node --check games/builder.js`, `node --check server.js`, and `node --check core.js`, all of which succeeded.
- No runtime integration tests were added; changes are limited to UI metadata and simple server-side guards which are unit-check friendly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f5f5fdd8832283673d74c3a0189e)