### PR TITLE
Allow crafting planks from all wood types

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -100,8 +100,9 @@ const blockColors = {
         48: "#1b1b1b", // Bedrock
     };
 
+    const WOOD_TYPES_FOR_PLANKS = [4, 7, 41];
     const CRAFTING_RECIPES = [
-        { pattern: [[7]], output: { type: 9, count: 4 } }, // 1 Log -> 4 Planks
+        ...WOOD_TYPES_FOR_PLANKS.map((woodType) => ({ pattern: [[woodType]], output: { type: 9, count: 4 } })), // 1 Wood/Log/Pine Log -> 4 Planks
         { pattern: [[9, 9], [9, 9]], output: { type: 10, count: 1 } }, // 4 Planks -> Crafting Table
         { pattern: [[9], [9]], output: { type: 50, count: 4 } }, // 2 Planks -> 4 Sticks (Let's use 50 for stick, wait stick isn't defined... actually stick isn't in original either, let's just use planks for tools for now)
         // Ladder


### PR DESCRIPTION
### Motivation
- Make planks craftable from every wood variant so players can convert any wood/log block into planks (WOOD, LOG, PINE LOG). 

### Description
- Added `WOOD_TYPES_FOR_PLANKS = [4, 7, 41]` and replaced the single log->planks recipe with one recipe per wood type by mapping that array into `CRAFTING_RECIPES` in `games/builder.js`. 
- The output remains `type: 9` (PLANKS) with `count: 4` per input block. 
- No other crafting behavior or outputs were changed. 

### Testing
- Ran `node --check games/builder.js` to validate syntax and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fca2fd58832bbe882e0c48c037e4)