### PR TITLE
Fix builder admin flight sync and ladder hold controls

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -725,13 +725,19 @@ const blockColors = {
     function handleKeyDown(e) {
         if (!room) return;
         if (isInputFocused(e)) return;
+        const isUpKey = e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " " || e.code === "Space";
+        const isDownKey = e.key === "Shift" || e.code === "ShiftLeft" || e.code === "ShiftRight";
         if (e.key === "a" || e.key === "A" || e.key === "ArrowLeft") keys.a = true;
         if (e.key === "d" || e.key === "D" || e.key === "ArrowRight") keys.d = true;
-        if (e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " ") {
+        if (isUpKey) {
             if (!keys.w) keys.upPress = true;
             keys.w = true;
+            e.preventDefault();
         }
-        if (e.key === "Shift") keys.shift = true;
+        if (isDownKey) {
+            keys.shift = true;
+            e.preventDefault();
+        }
         if (e.key === "q" || e.key === "Q") {
             const selectedSlotItem = hotbarSlots[selectedHotbarIndex];
             if (selectedSlotItem) {
@@ -846,10 +852,12 @@ const blockColors = {
 
     function handleKeyUp(e) {
         if (!room) return;
+        const isUpKey = e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " " || e.code === "Space";
+        const isDownKey = e.key === "Shift" || e.code === "ShiftLeft" || e.code === "ShiftRight";
         if (e.key === "a" || e.key === "A" || e.key === "ArrowLeft") keys.a = false;
         if (e.key === "d" || e.key === "D" || e.key === "ArrowRight") keys.d = false;
-        if (e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " ") keys.w = false;
-        if (e.key === "Shift") keys.shift = false;
+        if (isUpKey) keys.w = false;
+        if (isDownKey) keys.shift = false;
     }
 
     function handleMouseMove(e) {

--- a/server.js
+++ b/server.js
@@ -1807,6 +1807,8 @@ if (onLadder) {
             }
         }
 
+        p.flightEnabled = !!inp.flight;
+
         if (inp.left) p.vx -= 1.5;
         if (inp.right) p.vx += 1.5;
 
@@ -1897,10 +1899,10 @@ if (onLadder) {
             }
         }
 
-        if (grounded && inp.jumpBuffer > 0) {
+        if (!onLadder && grounded && inp.jumpBuffer > 0) {
             p.vy = -12;
             inp.jumpBuffer = 0;
-        } else if (inp.jumpBuffer > 0) {
+        } else if (!onLadder && inp.jumpBuffer > 0) {
             inp.jumpBuffer--;
         }
     });
@@ -2412,4 +2414,3 @@ app.get("/builder-servers", (req, res) => {
 
 gameServer.listen(port);
 console.log(`Colyseus game server is listening on port ${port}...`);
-        p.flightEnabled = !!inp.flight;


### PR DESCRIPTION
### Motivation
- Restore correct admin/builder flight behavior so flight toggles actually affect player movement in the server simulation.
- Make ladder climbing consistent when players hold climb keys so jump buffering and browser key handling do not interfere.

### Description
- Move per-tick sync of `p.flightEnabled` to the player simulation loop and remove a stray trailing `p.flightEnabled = !!inp.flight;` outside the simulation in `server.js`.
- Prevent jump buffer from triggering while the player is on a ladder by guarding jump logic with `!onLadder` in `server.js`.
- Improve input handling in `games/builder.js` by treating `Space` (and `e.code === "Space"`) and `W`/`ArrowUp` as an up/climb key and both `Shift` keys as down, using `isUpKey`/`isDownKey` helpers.
- Call `e.preventDefault()` for climb keys and normalize keyup handling so holding space/W moves up and holding shift moves down reliably.

### Testing
- Ran `node --check server.js` and it completed without errors.
- Ran `node --check games/builder.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e100e450ac83229a94ca2ca7ce9dee)