### PR TITLE
Add Tariq Wings item (65) with crafting, equip and flight support

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -103,6 +103,7 @@ const blockColors = {
         62: "#9afaff", // TariqCore Armor
         63: "#46bfd1", // TariqCore Beam
         64: "#eefbff", // Cloud Platform
+        65: "#d8f6ff", // Tariq Wings
     };
 
     const WOOD_TYPES_FOR_PLANKS = [4, 7, 41];
@@ -140,6 +141,7 @@ const blockColors = {
         { pattern: [[60, 60, 60], [0, 60, 0], [0, 9, 0]], output: { type: 61, count: 1 } }, // TariqCore Blade
         { pattern: [[60, 60, 60], [60, 0, 60], [0, 0, 0]], output: { type: 62, count: 1 } }, // TariqCore Armor
         { pattern: [[60, 60, 60], [0, 9, 0], [0, 60, 0]], output: { type: 63, count: 1 } }, // TariqCore Beam
+        { pattern: [[35, 64, 35], [64, 60, 64], [0, 0, 0]], output: { type: 65, count: 1 } }, // Tariq Wings (Ladders + Clouds + TariqCore)
     ];
 
     const blockNames = {
@@ -196,9 +198,11 @@ const blockColors = {
         62: "TARIQCORE ARMOR",
         63: "TARIQCORE BEAM",
         64: "CLOUD PLATFORM",
+        65: "TARIQ WINGS",
     };
     const getMergedInventoryType = (type) => type;
-    const getMaxStack = (type) => loadedBlockData[type] ? loadedBlockData[type].maxStack : ([11, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 61, 62, 63].includes(type) ? 1 : 99);
+    const getMaxStack = (type) => loadedBlockData[type] ? loadedBlockData[type].maxStack : ([11, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 61, 62, 63, 65].includes(type) ? 1 : 99);
+    const canUseFlight = () => isGodUser() || itemType(armorSlot) === 65;
 
     const blockDataUrls = [
         "data/blocks/1.json", "data/blocks/2.json", "data/blocks/3.json", "data/blocks/4.json",
@@ -844,7 +848,7 @@ const blockColors = {
             }
         }
 
-        if ((e.key === "f" || e.key === "F") && isGodUser()) {
+        if ((e.key === "f" || e.key === "F") && canUseFlight()) {
             keys.flight = !keys.flight;
             window.__builderFlightEnabled = keys.flight;
         }
@@ -1337,7 +1341,7 @@ function sendBuildOrBreak(e) {
                     // We are holding an item
 
                     // Armor slot restriction: only armor (18-22)
-                    if (isArmor && ![18, 19, 20, 21, 22, 62].includes(draggedItemType.type)) {
+                    if (isArmor && ![18, 19, 20, 21, 22, 62, 65].includes(draggedItemType.type)) {
                         return true;
                     }
 
@@ -1635,7 +1639,7 @@ if (e.button === 2 && !e.shiftKey) {
 
             if (isArmorSlotDrop && !dragSourceOutputSlot) {
                 // Check if dragging an armor item (18-22)
-                if ([18, 19, 20, 21, 22, 62].includes(draggedItemType.type)) {
+                if ([18, 19, 20, 21, 22, 62, 65].includes(draggedItemType.type)) {
                     const existingItem = cloneItem(armorSlot);
                     armorSlot = cloneItem(draggedItemType);
                     room.send("equip_armor", { type: armorSlot.type });
@@ -1668,7 +1672,7 @@ if (e.button === 2 && !e.shiftKey) {
                     } else if (dragSourceInventoryIndex !== null) {
                         inventorySlots[dragSourceInventoryIndex] = cloneItem(existingItem);
                     } else if (dragSourceArmorSlot) {
-                        if ([18, 19, 20, 21, 22, 62].includes(existingItem.type)) {
+                        if ([18, 19, 20, 21, 22, 62, 65].includes(existingItem.type)) {
                             armorSlot = cloneItem(existingItem);
                             room.send("equip_armor", { type: armorSlot.type });
                         } else {
@@ -1726,7 +1730,7 @@ if (e.button === 2 && !e.shiftKey) {
                     } else if (dragSourceHotbarIndex !== null) {
                         hotbarSlots[dragSourceHotbarIndex] = cloneItem(existingItem);
                     } else if (dragSourceArmorSlot) {
-                        if ([18, 19, 20, 21, 22, 62].includes(existingItem.type)) {
+                        if ([18, 19, 20, 21, 22, 62, 65].includes(existingItem.type)) {
                             armorSlot = cloneItem(existingItem);
                             room.send("equip_armor", { type: armorSlot.type });
                         } else {
@@ -1772,7 +1776,7 @@ if (e.button === 2 && !e.shiftKey) {
                     if (dragSourceHotbarIndex !== null) hotbarSlots[dragSourceHotbarIndex] = cloneItem(existingItem);
                     else if (dragSourceInventoryIndex !== null) inventorySlots[dragSourceInventoryIndex] = cloneItem(existingItem);
                     else if (dragSourceArmorSlot) {
-                        if ([18, 19, 20, 21, 22, 62].includes(existingItem.type)) {
+                        if ([18, 19, 20, 21, 22, 62, 65].includes(existingItem.type)) {
                             armorSlot = cloneItem(existingItem);
                             room.send("equip_armor", { type: armorSlot.type });
                         } else {
@@ -1878,7 +1882,7 @@ if (e.button === 2 && !e.shiftKey) {
                 upPress: keys.upPress,
                 up: keys.w,
                 down: keys.shift,
-                flight: keys.flight && isGodUser()
+                flight: keys.flight && canUseFlight()
             });
             keys.upPress = false;
         }
@@ -1992,7 +1996,7 @@ if (e.button === 2 && !e.shiftKey) {
             ctx.fillRect(p.x, p.y, TILE_SIZE, TILE_SIZE);
 
             // Draw armor if equipped
-            if ([18, 19, 20, 21, 22, 62].includes(p.armorType)) {
+            if ([18, 19, 20, 21, 22, 62, 65].includes(p.armorType)) {
                 ctx.fillStyle = blockColors[p.armorType];
                 // Helmet
                 ctx.fillRect(p.x - 2, p.y - 2, TILE_SIZE + 4, 10);

--- a/index.html
+++ b/index.html
@@ -450,6 +450,7 @@
                     <option value="62">62 - TARIQCORE ARMOR</option>
                     <option value="63">63 - TARIQCORE BEAM</option>
                     <option value="64">64 - CLOUD PLATFORM</option>
+                    <option value="65">65 - TARIQ WINGS</option>
                   </select>
                   <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 15px;">
                     <input class="term-input" id="adminBuilderItemCount" type="number" step="1" min="1" max="99" value="1" placeholder="COUNT" style="width: 100%;" />


### PR DESCRIPTION
### Motivation

- Introduce a new wearable item "Tariq Wings" that can be crafted and equipped as armor and grants flight when worn or when the user is god-mode. 

### Description

- Add block type `65` with color and name entries (`TARIQ WINGS`) and expose it in the admin builder UI selection. 
- Add a crafting recipe that produces type `65` from Ladders (`35`), Cloud Platforms (`64`) and TariqCore (`60`).
- Treat type `65` as single-stack armor by including it in the `getMaxStack` single-item list and allowing it in armor-slot checks and swap logic across inventory, hotbar and crafting interactions. 
- Allow flight when `canUseFlight()` returns true (either `isGodUser()` or wearing `65`) and use that helper in the flight toggle, input send loop, and related checks; render `65` as armor in player draw logic. 

### Testing

- Ran the client build and UI smoke checks to ensure no runtime errors occurred during inventory, equip, and crafting interactions. 
- Executed the repository's automated test suite with `npm test` and linting with `npm run lint`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e104c8199c832bb3b41c93dfee53e6)