### PR TITLE
Fix startup import error blocking login

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,7 +47,6 @@ import {
   adminLogAdminActionFromInput,
   adminScheduleTaskFromInput,
   adminGiveBuilderItemFromInput,
-  adminToggleBuilderFlightFromInput,
   adminClearScheduledTasksFromInput,
   adminUnlockAllAchievements,
   trackGamePlay,
@@ -143,7 +142,6 @@ window.adminSetPreferenceFromInput = adminSetPreferenceFromInput;
 window.adminRemoveRestrictionFromInput = adminRemoveRestrictionFromInput;
 window.adminLogAdminActionFromInput = adminLogAdminActionFromInput;
 window.adminGiveBuilderItemFromInput = adminGiveBuilderItemFromInput;
-window.adminToggleBuilderFlightFromInput = adminToggleBuilderFlightFromInput;
 window.adminScheduleTaskFromInput = adminScheduleTaskFromInput;
 window.adminClearScheduledTasksFromInput = adminClearScheduledTasksFromInput;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;


### PR DESCRIPTION
### Motivation
- Resolve a module load failure caused by a non-existent named import that prevented `script.js` from executing and blocked login handlers from binding.

### Description
- Removed the unused/non-existent import `adminToggleBuilderFlightFromInput` from `script.js` and removed its corresponding `window.adminToggleBuilderFlightFromInput` assignment so the module exports match `core.js`.

### Testing
- Ran the import/export check script which reported no missing exports after the change (`python` comparison script). 
- Ran `node --check script.js` and it passed with no syntax/module errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10d02eb54832bb456b93c6f51435e)