### PR TITLE
Treat 'S' as downward input and remove admin builder flight toggle export

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -853,7 +853,7 @@ const blockColors = {
     function handleKeyUp(e) {
         if (!room) return;
         const isUpKey = e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " " || e.code === "Space";
-        const isDownKey = e.key === "Shift" || e.code === "ShiftLeft" || e.code === "ShiftRight";
+        const isDownKey = e.key === "Shift" || e.code === "ShiftLeft" || e.code === "ShiftRight" || e.key === "s" || e.key === "S";
         if (e.key === "a" || e.key === "A" || e.key === "ArrowLeft") keys.a = false;
         if (e.key === "d" || e.key === "D" || e.key === "ArrowRight") keys.d = false;
         if (isUpKey) keys.w = false;

--- a/script.js
+++ b/script.js
@@ -47,7 +47,6 @@ import {
   adminLogAdminActionFromInput,
   adminScheduleTaskFromInput,
   adminGiveBuilderItemFromInput,
-  adminToggleBuilderFlightFromInput,
   adminClearScheduledTasksFromInput,
   adminUnlockAllAchievements,
   trackGamePlay,
@@ -143,7 +142,6 @@ window.adminSetPreferenceFromInput = adminSetPreferenceFromInput;
 window.adminRemoveRestrictionFromInput = adminRemoveRestrictionFromInput;
 window.adminLogAdminActionFromInput = adminLogAdminActionFromInput;
 window.adminGiveBuilderItemFromInput = adminGiveBuilderItemFromInput;
-window.adminToggleBuilderFlightFromInput = adminToggleBuilderFlightFromInput;
 window.adminScheduleTaskFromInput = adminScheduleTaskFromInput;
 window.adminClearScheduledTasksFromInput = adminClearScheduledTasksFromInput;
 window.adminUnlockAllAchievements = adminUnlockAllAchievements;


### PR DESCRIPTION
### Motivation
- Ensure the builder game's downward input is recognized from both the `Shift` and `S` keys and remove an admin-facing flight toggle binding that is no longer intended to be exposed.

### Description
- Update `games/builder.js` so the `handleKeyUp` logic considers `"s"`/`"S"` as part of the down-key check (`isDownKey`) so releasing `S` clears the same down flag used for `Shift`.
- Remove the `adminToggleBuilderFlightFromInput` export and global binding from `script.js` so the admin flight toggle is no longer attached to `window` or imported.

### Testing
- No automated tests were added or changed for these edits and no automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10d02eb54832bb456b93c6f51435e)