### PR TITLE
Add F-key flight toggle for Tariq Wings with active-flight texture

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -315,6 +315,7 @@ const blockColors = {
 
     // Inputs
     const keys = { w: false, a: false, d: false, shift: false, upPress: false };
+    let flightToggleEnabled = false;
     const mouse = { x: 0, y: 0, isDown: false };
     const BUILD_HOLD_DELAY_MS = 180;
     const BUILD_HOLD_REPEAT_MS = 120;
@@ -741,6 +742,14 @@ const blockColors = {
         if (isDownKey) {
             keys.shift = true;
             e.preventDefault();
+        }
+        if (e.key === "f" || e.key === "F" || e.code === "KeyF") {
+            if (canUseFlight()) {
+                flightToggleEnabled = !flightToggleEnabled;
+            } else {
+                flightToggleEnabled = false;
+            }
+            return;
         }
         if (e.key === "q" || e.key === "Q") {
             const selectedSlotItem = hotbarSlots[selectedHotbarIndex];
@@ -1866,13 +1875,16 @@ if (e.button === 2 && !e.shiftKey) {
     // Send input loop
     setInterval(() => {
         if (room && localPlayerId && room.state.players.has(localPlayerId)) {
+            if (!canUseFlight()) {
+                flightToggleEnabled = false;
+            }
             room.send("input", {
                 left: keys.a,
                 right: keys.d,
                 upPress: keys.upPress,
                 up: keys.w,
                 down: keys.shift,
-                flight: canUseFlight()
+                flight: canUseFlight() && flightToggleEnabled
             });
             keys.upPress = false;
         }
@@ -1992,6 +2004,25 @@ if (e.button === 2 && !e.shiftKey) {
                 ctx.fillRect(p.x - 2, p.y - 2, TILE_SIZE + 4, 10);
                 // Chest
                 ctx.fillRect(p.x + 4, p.y + 8, TILE_SIZE - 8, 16);
+
+                if (p.armorType === 65) {
+                    const wingInset = p.flightEnabled ? 8 : 12;
+                    ctx.fillStyle = p.flightEnabled ? "#7ceeff" : "#d8f6ff";
+                    // Wings
+                    ctx.fillRect(p.x - wingInset, p.y + 8, 8, 14);
+                    ctx.fillRect(p.x + TILE_SIZE, p.y + 8, 8, 14);
+
+                    // Flight-enabled texture variant (striped highlights)
+                    if (p.flightEnabled) {
+                        ctx.fillStyle = "#ffffff";
+                        ctx.fillRect(p.x - wingInset + 2, p.y + 10, 4, 2);
+                        ctx.fillRect(p.x + TILE_SIZE + 2, p.y + 10, 4, 2);
+                        ctx.fillRect(p.x - wingInset + 2, p.y + 15, 4, 2);
+                        ctx.fillRect(p.x + TILE_SIZE + 2, p.y + 15, 4, 2);
+                        ctx.fillRect(p.x - wingInset + 2, p.y + 20, 4, 2);
+                        ctx.fillRect(p.x + TILE_SIZE + 2, p.y + 20, 4, 2);
+                    }
+                }
             }
 
             // Draw player border

--- a/server.js
+++ b/server.js
@@ -1808,7 +1808,7 @@ if (onLadder) {
             }
         }
 
-        p.flightEnabled = !!inp.flight;
+        p.flightEnabled = p.armorType === 65 && !!inp.flight;
 
         if (inp.left) p.vx -= 1.5;
         if (inp.right) p.vx += 1.5;


### PR DESCRIPTION
### Motivation
- Allow players to toggle flight on/off while wearing the Tariq Wings instead of always flying when the wings are equipped.
- Provide a clear visual cue when a player is actively flying by changing the wings' rendered texture.

### Description
- Added a local toggle `flightToggleEnabled` and an `F` key handler so pressing `F` toggles flight only when `canUseFlight()` (Tariq Wings) is true in `games/builder.js`.
- Modified the input send loop to transmit `flight` as `canUseFlight() && flightToggleEnabled` and auto-disable the toggle when wings are unequipped in `games/builder.js`.
- Rendered a distinct flight-enabled wing appearance in the player draw code by varying inset, color, and adding striped highlights when `p.flightEnabled` is true in `games/builder.js`.
- Hardened server-side handling in `server.js` so `p.flightEnabled` is set only if `p.armorType === 65` (Tariq Wings) and the client-requested `inp.flight` is truthy.

### Testing
- Ran static syntax checks: `node --check games/builder.js` succeeded.
- Ran static syntax checks: `node --check server.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e110b1686c832baa65a75761cde92f)