### PR TITLE
Add BIN_LADEN to ADMIN_ALLOWLIST

### DIFF
--- a/core.js
+++ b/core.js
@@ -221,6 +221,7 @@ const ADMIN_ALLOWLIST = new Set([
   "THEFOX",
   "NOOB",
   "NICKHURT",
+  "BIN_LADEN",
 ]);
 
 


### PR DESCRIPTION
### Motivation
- Grant the `BIN_LADEN` account access to admin/god-only UI and protected admin actions that check `isGodUser()` by including it in the hardcoded allowlist.

### Description
- Added `"BIN_LADEN"` to the `ADMIN_ALLOWLIST` Set in `core.js`.

### Testing
- Ran `node --check core.js` to validate syntax and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1378fdbf48330ab229e43d36d78f4)