### PR TITLE
builder: longer nuke fuse, blast-range warning, and right-click bomb defuse

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -1629,6 +1629,21 @@ if (e.button === 2 && !e.shiftKey) {
                     return;
                 }
             }
+
+            // No block here, but we may be clicking a live explosive.
+            let clickedLiveBomb = false;
+            room.state.explosives.forEach((exp) => {
+                if (clickedLiveBomb) return;
+                const expTileX = Math.floor(exp.x / TILE_SIZE);
+                const expTileY = Math.floor(exp.y / TILE_SIZE);
+                if (expTileX === tileX && expTileY === tileY) {
+                    clickedLiveBomb = true;
+                }
+            });
+            if (clickedLiveBomb) {
+                room.send("interact", { x: worldX, y: worldY });
+                return;
+            }
         }
 
         mouse.isDown = true;
@@ -2234,6 +2249,48 @@ if (e.button === 2 && !e.shiftKey) {
         }
 
         ctx.restore();
+
+        // Draw blast warning if the local player is in range of any live explosive.
+        if (localPlayer) {
+            const playerCenterX = localPlayer.x + TILE_SIZE / 2;
+            const playerCenterY = localPlayer.y + TILE_SIZE / 2;
+            let nearestThreat = null;
+
+            room.state.explosives.forEach((exp) => {
+                const isNuke = exp.type === 34;
+                const blastRadius = isNuke ? (TILE_SIZE * 1000) : (TILE_SIZE * 5);
+                const dx = playerCenterX - exp.x;
+                const dy = playerCenterY - exp.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                if (dist <= blastRadius) {
+                    if (!nearestThreat || exp.timer < nearestThreat.timer) {
+                        nearestThreat = { isNuke, timer: exp.timer };
+                    }
+                }
+            });
+
+            if (nearestThreat) {
+                const secondsLeft = Math.max(0, nearestThreat.timer / 50).toFixed(1);
+                const warningText = nearestThreat.isNuke
+                    ? `⚠ NUKE BLAST RANGE (${secondsLeft}s)`
+                    : `⚠ TNT BLAST RANGE (${secondsLeft}s)`;
+                const warningWidth = Math.max(300, ctx.measureText(warningText).width + 24);
+                const warningX = (canvas.width - warningWidth) / 2;
+                const warningY = 46;
+
+                ctx.save();
+                ctx.fillStyle = "rgba(120, 0, 0, 0.85)";
+                ctx.fillRect(warningX, warningY, warningWidth, 26);
+                ctx.strokeStyle = "#ff6b6b";
+                ctx.lineWidth = 2;
+                ctx.strokeRect(warningX, warningY, warningWidth, 26);
+                ctx.fillStyle = "#ffffff";
+                ctx.font = "12px 'Press Start 2P', monospace";
+                ctx.textAlign = "center";
+                ctx.fillText(warningText, canvas.width / 2, warningY + 17);
+                ctx.restore();
+            }
+        }
 
         // Draw HP Hearts
         if (localPlayer) {

--- a/server.js
+++ b/server.js
@@ -805,6 +805,32 @@ this.onMessage("interact", (client, message) => {
         const distSq = (p.x+TILE_SIZE/2 - message.x)**2 + (p.y+TILE_SIZE/2 - message.y)**2;
         if (distSq > (TILE_SIZE * 6)**2) return;
 
+        // Right-clicking a live bomb (TNT / Nuke) defuses it and places the block back.
+        let explosiveIdToDefuse = null;
+        let explosiveToDefuse = null;
+        this.state.explosives.forEach((exp, expId) => {
+            if (explosiveIdToDefuse) return;
+            const expTileX = Math.floor(exp.x / TILE_SIZE);
+            const expTileY = Math.floor(exp.y / TILE_SIZE);
+            if (expTileX === x && expTileY === y) {
+                explosiveIdToDefuse = expId;
+                explosiveToDefuse = exp;
+            }
+        });
+        if (explosiveIdToDefuse && explosiveToDefuse) {
+            const chunk = this.getOrCreateChunk(cx, cy);
+            const blockKey = `${x},${y}`;
+            if (!chunk.blocks.get(blockKey)) {
+                const b = new Block();
+                b.x = x;
+                b.y = y;
+                b.type = explosiveToDefuse.type;
+                chunk.blocks.set(blockKey, b);
+            }
+            this.state.explosives.delete(explosiveIdToDefuse);
+            return;
+        }
+
         const chunk = this.state.chunks.get(`${cx},${cy}`);
         if (chunk) {
             const b = chunk.blocks.get(`${x},${y}`);
@@ -814,7 +840,7 @@ this.onMessage("interact", (client, message) => {
                 explosive.x = x * TILE_SIZE + TILE_SIZE/2;
                 explosive.y = y * TILE_SIZE + TILE_SIZE/2;
                 explosive.type = b.type;
-                explosive.timer = b.type === 34 ? 100 : 60; // Nuke takes longer
+                explosive.timer = b.type === 34 ? 200 : 60; // Nuke takes longer
                 this.state.explosives.set(`exp-${Date.now()}-${Math.random()}`, explosive);
 
                 chunk.blocks.delete(`${x},${y}`);


### PR DESCRIPTION
### Motivation
- Make nukes less immediately lethal by increasing their fuse so players have more time to react. 
- Provide players a clear on-screen warning when they are inside the blast radius of any live explosive. 
- Allow players to right-click a live TNT/Nuke to safely defuse it while keeping the explosive block placed.

### Description
- Increased the nuke live fuse timer on ignition in `server.js` from `100` ticks to `200` ticks. 
- Implemented server-side defuse logic in `server.js` so an `interact` on a tile with a live explosive removes the active explosive and restores the TNT/Nuke block at that tile. 
- Updated client right-click handling in `games/builder.js` to detect clicks on live explosives (even when no block is present) and send `interact` to trigger defuse. 
- Added a client-side HUD banner in `games/builder.js` that shows a blast-range warning and a countdown when the local player is inside any live explosive's blast radius.

### Testing
- Ran syntax checks: `node --check server.js` and `node --check games/builder.js`, and both checks passed. 
- Verified files were updated and committed (changes to `server.js` and `games/builder.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1394fe6488322aec8d89c7cb7d923)