### PR TITLE
Refactor Builder UI containers, crafting matching, and item interactions

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -31,6 +31,12 @@ let selectedRoomId = null;
     let currentChestId = null;
     let isFurnaceOpen = false;
     let currentFurnaceId = null;
+    const CONTAINER_TYPES = {
+        NONE: "none",
+        CHEST: "chest",
+        FURNACE: "furnace",
+        CRAFTING_TABLE: "craftingTable",
+    };
 
     const canvas = document.getElementById("builderCanvas");
     const ctx = canvas.getContext("2d");
@@ -303,6 +309,8 @@ const blockColors = {
     let dragSourceCraftingIndex = null;
     let dragSourceOutputSlot = false;
     let dragSourceArmorSlot = false;
+    let lastShiftClickAt = 0;
+    let lastShiftClickType = null;
     let showRecipes = false;
     let recipeScroll = 0;
 
@@ -317,6 +325,8 @@ const blockColors = {
     const keys = { w: false, a: false, d: false, shift: false, upPress: false };
     let flightToggleEnabled = false;
     const mouse = { x: 0, y: 0, isDown: false };
+    let rightMouseHeld = false;
+    let rightDragVisitedSlots = new Set();
     const BUILD_HOLD_DELAY_MS = 180;
     const BUILD_HOLD_REPEAT_MS = 120;
     let buildHoldTimeout = null;
@@ -371,6 +381,29 @@ const blockColors = {
         return blockNames[type] || `ITEM ${type}`;
     }
 
+    function closeAllContainerUi() {
+        isChestOpen = false;
+        isFurnaceOpen = false;
+        isCraftingTableOpen = false;
+        currentChestId = null;
+        currentFurnaceId = null;
+    }
+
+    function openContainerUi(containerType, opts = {}) {
+        closeAllContainerUi();
+        inventoryOpen = true;
+        if (containerType === CONTAINER_TYPES.CHEST) {
+            isChestOpen = true;
+            currentChestId = opts.chestId || null;
+        } else if (containerType === CONTAINER_TYPES.FURNACE) {
+            isFurnaceOpen = true;
+            currentFurnaceId = opts.furnaceId || null;
+        } else if (containerType === CONTAINER_TYPES.CRAFTING_TABLE) {
+            isCraftingTableOpen = true;
+        }
+        showRecipes = false;
+    }
+
     const SMELTABLE_INPUT_TYPES = new Set([13, 14, 15, 16, 17]);
     const FURNACE_FUEL_TYPES = new Set([7, 9, 12]);
     const FURNACE_OUTPUT_BY_INPUT = { 13: 43, 14: 44, 15: 45, 16: 46, 17: 47 };
@@ -395,163 +428,92 @@ const blockColors = {
         return furnace.progress > 0 ? "Smelting..." : "Ready";
     }
 
-    function checkRecipes() {
-        craftingOutputSlot = undefined;
+    function matrixFromGrid(grid, size) {
+        const matrix = [];
+        for (let r = 0; r < size; r++) {
+            const row = [];
+            for (let c = 0; c < size; c++) {
+                row.push(itemType(grid[r * size + c]) || 0);
+            }
+            matrix.push(row);
+        }
+        return matrix;
+    }
+
+    function trimPattern(pattern) {
+        let minR = Infinity, maxR = -1, minC = Infinity, maxC = -1;
+        for (let r = 0; r < pattern.length; r++) {
+            for (let c = 0; c < pattern[r].length; c++) {
+                if (pattern[r][c] !== 0) {
+                    minR = Math.min(minR, r);
+                    maxR = Math.max(maxR, r);
+                    minC = Math.min(minC, c);
+                    maxC = Math.max(maxC, c);
+                }
+            }
+        }
+        if (maxR < 0 || maxC < 0) return [[0]];
+        const trimmed = [];
+        for (let r = minR; r <= maxR; r++) {
+            const row = [];
+            for (let c = minC; c <= maxC; c++) row.push(pattern[r][c]);
+            trimmed.push(row);
+        }
+        return trimmed;
+    }
+
+    function getRecipeMatch() {
         const grid = isCraftingTableOpen ? craftingGrid3x3 : craftingGrid2x2;
         const size = isCraftingTableOpen ? 3 : 2;
+        const normalizedGrid = trimPattern(matrixFromGrid(grid, size));
 
-        // Convert grid to a simpler 2D array of types for pattern matching
-        let pattern = [];
-        for (let r = 0; r < size; r++) {
-            let row = [];
-            for (let c = 0; c < size; c++) {
-                const item = grid[r * size + c];
-                row.push(item ? itemType(item) : 0);
-            }
-            pattern.push(row);
-        }
+        for (const recipe of CRAFTING_RECIPES) {
+            const normalizedRecipe = trimPattern(recipe.pattern);
+            const reqH = normalizedRecipe.length;
+            const reqW = normalizedRecipe[0].length;
+            if (reqW > size || reqH > size) continue;
+            if (normalizedGrid.length !== reqH || normalizedGrid[0].length !== reqW) continue;
 
-        // Helper to check if a specific sub-pattern exists anywhere in the grid
-        const matchPattern = (targetPattern) => {
-            const targetH = targetPattern.length;
-            const targetW = targetPattern[0].length;
-
-            for (let r = 0; r <= size - targetH; r++) {
-                for (let c = 0; c <= size - targetW; c++) {
-                    let match = true;
-                    // Check if the target pattern matches at this offset
-                    for (let tr = 0; tr < targetH; tr++) {
-                        for (let tc = 0; tc < targetW; tc++) {
-                            if (pattern[r + tr][c + tc] !== targetPattern[tr][tc]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (!match) break;
-                    }
-                    if (match) {
-                        // Check if rest of grid is empty
-                        let restEmpty = true;
-                        for (let gr = 0; gr < size; gr++) {
-                            for (let gc = 0; gc < size; gc++) {
-                                // If inside the match box, skip
-                                if (gr >= r && gr < r + targetH && gc >= c && gc < c + targetW) continue;
-                                if (pattern[gr][gc] !== 0) {
-                                    restEmpty = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if (restEmpty) return true;
+            let matched = true;
+            for (let r = 0; r < reqH && matched; r++) {
+                for (let c = 0; c < reqW; c++) {
+                    if (normalizedGrid[r][c] !== normalizedRecipe[r][c]) {
+                        matched = false;
+                        break;
                     }
                 }
             }
-            return false;
-        };
+            if (!matched) continue;
 
-        // Recipes
-        for (const recipe of CRAFTING_RECIPES) {
-            const reqW = recipe.pattern[0].length;
-            const reqH = recipe.pattern.length;
-
-            // If recipe needs 3x3 but we are not in crafting table, skip
-            if ((reqW > 2 || reqH > 2) && !isCraftingTableOpen) {
-                continue;
+            const indicesToConsume = [];
+            for (let i = 0; i < grid.length; i++) {
+                if (grid[i] && itemType(grid[i])) indicesToConsume.push(i);
             }
+            return { recipe, indicesToConsume };
+        }
+        return null;
+    }
 
-            if (matchPattern(recipe.pattern)) {
-                craftingOutputSlot = { type: recipe.output.type, count: recipe.output.count };
-                return;
-            }
+    function checkRecipes() {
+        craftingOutputSlot = undefined;
+        const match = getRecipeMatch();
+        if (match?.recipe) {
+            craftingOutputSlot = {
+                type: match.recipe.output.type,
+                count: match.recipe.output.count
+            };
         }
     }
 
     function consumeCraftingMaterials() {
-        // Find what recipe matches so we know how to consume
-        // The previous implementation blindly consumed 1 from EVERYTHING in the grid!
         const grid = isCraftingTableOpen ? craftingGrid3x3 : craftingGrid2x2;
-        const size = isCraftingTableOpen ? 3 : 2;
-
-        let pattern = [];
-        for (let r = 0; r < size; r++) {
-            let row = [];
-            for (let c = 0; c < size; c++) {
-                const item = grid[r * size + c];
-                row.push(item ? itemType(item) : 0);
-            }
-            pattern.push(row);
+        const match = getRecipeMatch();
+        if (!match) return;
+        for (const i of match.indicesToConsume) {
+            if (!grid[i]) continue;
+            grid[i].count -= 1;
+            if (grid[i].count <= 0) grid[i] = undefined;
         }
-
-        const matchPattern = (targetPattern) => {
-            const targetH = targetPattern.length;
-            const targetW = targetPattern[0].length;
-            for (let r = 0; r <= size - targetH; r++) {
-                for (let c = 0; c <= size - targetW; c++) {
-                    let match = true;
-                    let matchIndices = [];
-                    for (let tr = 0; tr < targetH; tr++) {
-                        for (let tc = 0; tc < targetW; tc++) {
-                            if (pattern[r + tr][c + tc] !== targetPattern[tr][tc]) {
-                                match = false;
-                                break;
-                            }
-                            if (targetPattern[tr][tc] !== 0) {
-                                matchIndices.push((r + tr) * size + (c + tc));
-                            }
-                        }
-                        if (!match) break;
-                    }
-                    if (match) {
-                        let restEmpty = true;
-                        for (let gr = 0; gr < size; gr++) {
-                            for (let gc = 0; gc < size; gc++) {
-                                if (gr >= r && gr < r + targetH && gc >= c && gc < c + targetW) continue;
-                                if (pattern[gr][gc] !== 0) {
-                                    restEmpty = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if (restEmpty) return matchIndices;
-                    }
-                }
-            }
-            return null;
-        };
-
-        let indicesToConsume = null;
-        for (const recipe of CRAFTING_RECIPES) {
-            const reqW = recipe.pattern[0].length;
-            const reqH = recipe.pattern.length;
-
-            // If recipe needs 3x3 but we are not in crafting table, skip
-            if ((reqW > 2 || reqH > 2) && !isCraftingTableOpen) {
-                continue;
-            }
-
-            const matchIndices = matchPattern(recipe.pattern);
-            if (matchIndices !== null) {
-                indicesToConsume = matchIndices;
-                break;
-            }
-        }
-
-        if (!indicesToConsume) {
-             // Fallback if no recipe matched (shouldn't happen)
-             for (let i = 0; i < grid.length; i++) {
-                 if (grid[i]) indicesToConsume = (indicesToConsume || []).concat([i]);
-             }
-        }
-
-        if (indicesToConsume) {
-            for (let i of indicesToConsume) {
-                if (grid[i]) {
-                    grid[i].count--;
-                    if (grid[i].count <= 0) grid[i] = undefined;
-                }
-            }
-        }
-
         checkRecipes();
     }
 
@@ -754,8 +716,9 @@ const blockColors = {
         if (e.key === "q" || e.key === "Q") {
             const selectedSlotItem = hotbarSlots[selectedHotbarIndex];
             if (selectedSlotItem) {
-                room.send("spawn_drops", { items: [{ type: selectedSlotItem.type, count: 1 }] });
-                selectedSlotItem.count -= 1;
+                const dropCount = e.ctrlKey ? selectedSlotItem.count : 1;
+                room.send("spawn_drops", { items: [{ type: selectedSlotItem.type, count: dropCount }] });
+                selectedSlotItem.count -= dropCount;
                 if (selectedSlotItem.count <= 0) {
                     hotbarSlots[selectedHotbarIndex] = undefined;
                 }
@@ -768,17 +731,12 @@ const blockColors = {
         if (e.key === "i" || e.key === "I") {
             inventoryOpen = !inventoryOpen;
             if (!inventoryOpen) {
-                isChestOpen = false;
-                isFurnaceOpen = false;
-            }
-            if (!inventoryOpen) {
-                isChestOpen = false;
-                isFurnaceOpen = false;
+                closeAllContainerUi();
             }
 
             // If opening inventory, make sure we show 2x2 grid not 3x3 table
             if (inventoryOpen) {
-                isCraftingTableOpen = false;
+                closeAllContainerUi();
                 showRecipes = false;
             } else {
                 returnCraftingItems();
@@ -814,11 +772,7 @@ const blockColors = {
 
         if (e.key === "Escape" && inventoryOpen) {
             inventoryOpen = false;
-            isCraftingTableOpen = false;
-            isChestOpen = false;
-            isFurnaceOpen = false;
-            isChestOpen = false;
-            isFurnaceOpen = false;
+            closeAllContainerUi();
             showRecipes = false;
             returnCraftingItems();
             if (draggedItemType !== null) {
@@ -845,15 +799,46 @@ const blockColors = {
             return;
         }
 
-        // Hotbar selection (1-9)
+        // Hotbar selection (1-9) and hover swap when inventory is open
         if (!isNaN(e.key)) {
             const keyNum = parseInt(e.key);
             if (keyNum >= 1 && keyNum <= 9) {
-                selectedHotbarIndex = keyNum - 1;
-                selectedBlockType = hotbarSlots[selectedHotbarIndex];
-
-                // Tell server about new held item
-                room.send("select_item", { type: selectedBlockType ? itemType(selectedBlockType) : 0 });
+                const targetHotbarIndex = keyNum - 1;
+                if (inventoryOpen) {
+                    const panel = getInventoryBounds();
+                    const hoverInventoryIndex = getInventorySlotAt(mouse.x, mouse.y, panel);
+                    if (hoverInventoryIndex !== null) {
+                        const tmp = cloneItem(hotbarSlots[targetHotbarIndex]);
+                        hotbarSlots[targetHotbarIndex] = cloneItem(inventorySlots[hoverInventoryIndex]);
+                        inventorySlots[hoverInventoryIndex] = tmp;
+                        saveInventoryState();
+                    } else if (isChestOpen && currentChestId && room.state.chests?.has(currentChestId)) {
+                        const chest = room.state.chests.get(currentChestId);
+                        const { startX, startY } = getInventoryMetrics(panel);
+                        const chestSlotSize = inventoryLayout.slotSize;
+                        const chestStride = chestSlotSize + inventoryLayout.gap;
+                        const chestY = startY - (chestStride * 3) - 28;
+                        for (let i = 0; i < 27; i++) {
+                            const col = i % 9;
+                            const row = Math.floor(i / 9);
+                            const sx = startX + col * chestStride;
+                            const sy = chestY + 15 + row * chestStride;
+                            if (mouse.x < sx || mouse.x > sx + chestSlotSize || mouse.y < sy || mouse.y > sy + chestSlotSize) continue;
+                            const chestItem = chest.items.get(i.toString());
+                            if (!chestItem) break;
+                            const hotbarItem = cloneItem(hotbarSlots[targetHotbarIndex]);
+                            room.send("container_move", { action: "take", containerId: currentChestId, slot: i.toString(), item: { type: chestItem.type, count: chestItem.count } });
+                            if (hotbarItem) room.send("container_move", { action: "put", containerId: currentChestId, slot: i.toString(), item: hotbarItem });
+                            hotbarSlots[targetHotbarIndex] = cloneItem(chestItem);
+                            saveInventoryState();
+                            break;
+                        }
+                    }
+                } else {
+                    selectedHotbarIndex = targetHotbarIndex;
+                    selectedBlockType = hotbarSlots[selectedHotbarIndex];
+                    room.send("select_item", { type: selectedBlockType ? itemType(selectedBlockType) : 0 });
+                }
             }
         }
 
@@ -875,6 +860,44 @@ const blockColors = {
         const scaleY = canvas.height / rect.height;
         mouse.x = (e.clientX - rect.left) * scaleX;
         mouse.y = (e.clientY - rect.top) * scaleY;
+
+        if (!inventoryOpen || !rightMouseHeld || !draggedItemType || draggedItemType.count <= 0) return;
+
+        const hotbarPanel = getHotbarBounds();
+        const hotbarIndex = getHotbarIndexAt(mouse.x, mouse.y, hotbarPanel);
+        if (hotbarIndex !== null) {
+            const key = `hotbar:${hotbarIndex}`;
+            if (!rightDragVisitedSlots.has(key)) {
+                const slot = hotbarSlots[hotbarIndex];
+                if (!slot || (slot.type === draggedItemType.type && slot.count < getMaxStack(slot.type))) {
+                    if (!slot) hotbarSlots[hotbarIndex] = { type: draggedItemType.type, count: 1 };
+                    else slot.count += 1;
+                    draggedItemType.count -= 1;
+                    rightDragVisitedSlots.add(key);
+                    if (draggedItemType.count <= 0) draggedItemType = null;
+                    saveInventoryState();
+                }
+            }
+            return;
+        }
+
+        const panel = getInventoryBounds();
+        const invIndex = getInventorySlotAt(mouse.x, mouse.y, panel);
+        if (invIndex !== null) {
+            const key = `inv:${invIndex}`;
+            if (!rightDragVisitedSlots.has(key)) {
+                const slot = inventorySlots[invIndex];
+                if (!slot || (slot.type === draggedItemType.type && slot.count < getMaxStack(slot.type))) {
+                    if (!slot) inventorySlots[invIndex] = { type: draggedItemType.type, count: 1 };
+                    else slot.count += 1;
+                    draggedItemType.count -= 1;
+                    rightDragVisitedSlots.add(key);
+                    if (draggedItemType.count <= 0) draggedItemType = null;
+                    saveInventoryState();
+                }
+            }
+            return;
+        }
     }
 
 function sendBuildOrBreak(e) {
@@ -1072,11 +1095,11 @@ function sendBuildOrBreak(e) {
 
     function getRecipeBookLayout(panel) {
         const itemsPerRow = 2;
-        const rowsPerPage = 6;
+        const rowsPerPage = 8;
         const recipesPerPage = itemsPerRow * rowsPerPage;
-        const cellWidth = 240;
-        const cellHeight = 70;
-        const hitWidth = 110;
+        const cellWidth = 120;
+        const cellHeight = 42;
+        const hitWidth = 92;
         const maxScroll = Math.max(0, Math.ceil(CRAFTING_RECIPES.length / itemsPerRow) - rowsPerPage);
         if (recipeScroll > maxScroll) recipeScroll = maxScroll;
         const startIdx = recipeScroll * itemsPerRow;
@@ -1150,6 +1173,10 @@ function sendBuildOrBreak(e) {
 
     function handleMouseDown(e) {
         if (!room) return;
+        if (e.button === 2) {
+            rightMouseHeld = true;
+            rightDragVisitedSlots.clear();
+        }
 
         // Handle inventory and dragging mechanics first
         if (inventoryOpen) {
@@ -1159,8 +1186,8 @@ function sendBuildOrBreak(e) {
 
             if (showRecipes) {
                 // Check close button
-                if (mouse.x >= panel.x + panel.width - 80 && mouse.x <= panel.x + panel.width - 20 &&
-                    mouse.y >= panel.y - 10 && mouse.y <= panel.y + 10) {
+                if (mouse.x >= panel.x - 70 && mouse.x <= panel.x - 10 &&
+                    mouse.y >= panel.y + 8 && mouse.y <= panel.y + 28) {
                     showRecipes = false;
                     return;
                 }
@@ -1179,7 +1206,6 @@ function sendBuildOrBreak(e) {
                         return;
                     }
                 }
-                return; // Prevent other interactions while recipes are open
             }
 
             const craftStartX = panel.x + panel.width - 190;
@@ -1196,20 +1222,73 @@ function sendBuildOrBreak(e) {
             }
 
             const isRightClick = e.button === 2;
+            const isShiftQuickMove = e.shiftKey && !isRightClick && draggedItemType === null;
+
+            const quickMoveToChest = (item) => {
+                if (!currentChestId || !room.state.chests?.has(currentChestId)) return false;
+                const chest = room.state.chests.get(currentChestId);
+                let targetSlot = null;
+                for (let i = 0; i < 27; i++) {
+                    const slot = chest.items.get(i.toString());
+                    if (slot && slot.type === item.type && slot.count < getMaxStack(item.type)) {
+                        targetSlot = i.toString();
+                        break;
+                    }
+                }
+                if (targetSlot === null) {
+                    for (let i = 0; i < 27; i++) {
+                        if (!chest.items.get(i.toString())) {
+                            targetSlot = i.toString();
+                            break;
+                        }
+                    }
+                }
+                if (targetSlot === null) return false;
+                room.send("container_move", { action: "put", containerId: currentChestId, slot: targetSlot, item: cloneItem(item) });
+                return true;
+            };
+
+            const quickMoveToFurnace = (item) => {
+                if (!currentFurnaceId || !room.state.furnaces?.has(currentFurnaceId)) return false;
+                const furnace = room.state.furnaces.get(currentFurnaceId);
+                const putInSlot = (slotName) => {
+                    const typeKey = `${slotName}Item`;
+                    const countKey = `${slotName}Count`;
+                    const currentType = furnace[typeKey];
+                    const currentCount = furnace[countKey];
+                    if (currentCount > 0 && currentType !== item.type) return false;
+                    if (currentCount >= getMaxStack(item.type)) return false;
+                    const payload = {
+                        containerId: currentFurnaceId,
+                        inputItem: furnace.inputItem, inputCount: furnace.inputCount,
+                        fuelItem: furnace.fuelItem, fuelCount: furnace.fuelCount,
+                        outputItem: furnace.outputItem, outputCount: furnace.outputCount
+                    };
+                    payload[typeKey] = item.type;
+                    payload[countKey] = currentCount + item.count;
+                    room.send("furnace_sync", payload);
+                    return true;
+                };
+                if (canPlaceInFurnaceSlot("input", item.type) && putInSlot("input")) return true;
+                if (canPlaceInFurnaceSlot("fuel", item.type) && putInSlot("fuel")) return true;
+                return false;
+            };
 
             // Handle Chest/Furnace clicks FIRST so they take priority
             if (isChestOpen && currentChestId && room.state.chests && room.state.chests.has(currentChestId)) {
                 const chest = room.state.chests.get(currentChestId);
                 const { startX, startY } = getInventoryMetrics(panel);
-                const chestY = startY - 140;
+                const chestSlotSize = inventoryLayout.slotSize;
+                const chestStride = chestSlotSize + inventoryLayout.gap;
+                const chestY = startY - (chestStride * 3) - 28;
                 let clickedChest = false;
                 for (let i = 0; i < 27; i++) {
                     const col = i % 9;
                     const row = Math.floor(i / 9);
-                    const slotX = startX + col * (32 + 4);
-                    const slotY = chestY + 15 + row * (32 + 4);
-                    if (mouse.x >= slotX && mouse.x <= slotX + 32 &&
-                        mouse.y >= slotY && mouse.y <= slotY + 32) {
+                    const slotX = startX + col * chestStride;
+                    const slotY = chestY + 15 + row * chestStride;
+                    if (mouse.x >= slotX && mouse.x <= slotX + chestSlotSize &&
+                        mouse.y >= slotY && mouse.y <= slotY + chestSlotSize) {
 
                         const indexStr = i.toString();
                         const currentItemData = chest.items.get(indexStr);
@@ -1217,6 +1296,26 @@ function sendBuildOrBreak(e) {
 
                         if (draggedItemType === null) {
                             if (currentItem !== undefined) {
+                                if (e.shiftKey && !isRightClick) {
+                                    addInventoryItem(currentItem.type, currentItem.count);
+                                    room.send("container_move", { action: "take", containerId: currentChestId, slot: indexStr, item: cloneItem(currentItem) });
+                                    const now = Date.now();
+                                    const isDoubleShiftClick = now - lastShiftClickAt < 300 && lastShiftClickType === currentItem.type;
+                                    if (isDoubleShiftClick) {
+                                        for (let j = 0; j < 27; j++) {
+                                            if (j === i) continue;
+                                            const other = chest.items.get(j.toString());
+                                            if (!other || other.type !== currentItem.type) continue;
+                                            room.send("container_move", { action: "take", containerId: currentChestId, slot: j.toString(), item: { type: other.type, count: other.count } });
+                                            addInventoryItem(other.type, other.count);
+                                        }
+                                    }
+                                    lastShiftClickAt = now;
+                                    lastShiftClickType = currentItem.type;
+                                    saveInventoryState();
+                                    clickedChest = true;
+                                    break;
+                                }
                                 if (isRightClick) {
                                     if (currentItem.count > 1) {
                                         const splitCount = Math.floor(currentItem.count / 2);
@@ -1304,6 +1403,12 @@ function sendBuildOrBreak(e) {
                     };
 
                     if (slotName === "output") {
+                        if (e.shiftKey && !isRightClick && currentItem) {
+                            addInventoryItem(currentItem.type, currentItem.count);
+                            setSlot(undefined);
+                            saveInventoryState();
+                            return;
+                        }
                         if (draggedItemType === null && currentItem) {
                             if (isRightClick && currentItem.count > 1) {
                                 const takeCount = Math.ceil(currentItem.count / 2);
@@ -1319,6 +1424,12 @@ function sendBuildOrBreak(e) {
 
                     if (draggedItemType === null) {
                         if (currentItem !== undefined) {
+                            if (e.shiftKey && !isRightClick) {
+                                addInventoryItem(currentItem.type, currentItem.count);
+                                setSlot(undefined);
+                                saveInventoryState();
+                                return;
+                            }
                             if (isRightClick) {
                                 if (currentItem.count > 1) {
                                     const splitCount = Math.floor(currentItem.count / 2);
@@ -1398,6 +1509,32 @@ function sendBuildOrBreak(e) {
 
                 if (draggedItemType === null) {
                     if (currentItem !== undefined) {
+                        if (!isArmor && isShiftQuickMove) {
+                            const moved = isChestOpen
+                                ? quickMoveToChest(currentItem)
+                                : (isFurnaceOpen ? quickMoveToFurnace(currentItem) : false);
+                            if (moved) {
+                                const now = Date.now();
+                                const isDoubleShiftClick = now - lastShiftClickAt < 300 && lastShiftClickType === currentItem.type;
+                                setSlot(undefined);
+                                if (isDoubleShiftClick) {
+                                    for (let i = 0; i < hotbarSlots.length; i++) {
+                                        const it = hotbarSlots[i];
+                                        if (!it || i === index || it.type !== currentItem.type) continue;
+                                        if ((isChestOpen && quickMoveToChest(it)) || (isFurnaceOpen && quickMoveToFurnace(it))) hotbarSlots[i] = undefined;
+                                    }
+                                    for (let i = 0; i < inventorySlots.length; i++) {
+                                        const it = inventorySlots[i];
+                                        if (!it || i === index || it.type !== currentItem.type) continue;
+                                        if ((isChestOpen && quickMoveToChest(it)) || (isFurnaceOpen && quickMoveToFurnace(it))) inventorySlots[i] = undefined;
+                                    }
+                                }
+                                lastShiftClickAt = now;
+                                lastShiftClickType = currentItem.type;
+                                saveInventoryState();
+                                return true;
+                            }
+                        }
                         if (isRightClick) {
                             // Split stack
                             if (currentItem.count > 1) {
@@ -1599,30 +1736,15 @@ if (e.button === 2 && !e.shiftKey) {
             if (chunk) {
                 const block = chunk.blocks.get(`${tileX},${tileY}`);
                 if (block && block.type === 10) { // Crafting Table
-                    inventoryOpen = true;
-                    isCraftingTableOpen = true;
-                    isChestOpen = false;
-                    isFurnaceOpen = false;
-                    currentChestId = null;
-                    currentFurnaceId = null;
+                    openContainerUi(CONTAINER_TYPES.CRAFTING_TABLE);
                     return;
 } else if (block && block.type === 31) { // Chest
                     room.send("interact", { x: worldX, y: worldY }); // register it
-                    inventoryOpen = true;
-                    isCraftingTableOpen = false;
-                    isChestOpen = true;
-                    isFurnaceOpen = false;
-                    currentChestId = `${tileX},${tileY}`;
-                    currentFurnaceId = null;
+                    openContainerUi(CONTAINER_TYPES.CHEST, { chestId: `${tileX},${tileY}` });
                     return;
                 } else if (block && block.type === 32) { // Furnace
                     room.send("interact", { x: worldX, y: worldY });
-                    inventoryOpen = true;
-                    isCraftingTableOpen = false;
-                    isChestOpen = false;
-                    isFurnaceOpen = true;
-                    currentFurnaceId = `${tileX},${tileY}`;
-                    currentChestId = null;
+                    openContainerUi(CONTAINER_TYPES.FURNACE, { furnaceId: `${tileX},${tileY}` });
                     return;
                 } else if (block && (block.type === 33 || block.type === 34)) { // TNT/Nuke
                     room.send("interact", { x: worldX, y: worldY });
@@ -1679,8 +1801,10 @@ if (e.button === 2 && !e.shiftKey) {
         }
     }
 
-    function handleMouseUp() {
+    function handleMouseUp(e) {
         mouse.isDown = false;
+        rightMouseHeld = false;
+        rightDragVisitedSlots.clear();
         clearBuildHoldTimers();
         if (inventoryOpen && draggedItemType !== null) {
             setTimeout(() => saveInventoryState(), 10);
@@ -2303,6 +2427,13 @@ if (e.button === 2 && !e.shiftKey) {
         ctx.stroke();
 
         let hoverItemName = "";
+        const captureHoverItem = (item, x, y, size, metaText = "") => {
+            if (hoverItemName || !item) return;
+            if (mouse.x >= x && mouse.x <= x + size && mouse.y >= y && mouse.y <= y + size) {
+                const baseName = getItemName(item);
+                hoverItemName = metaText ? `${baseName} ${metaText}` : baseName;
+            }
+        };
         hotbarSlots.forEach((item, index) => {
             const slotX = hotbarPanel.x + hotbarLayout.padding + (index * (hotbarLayout.slotSize + hotbarLayout.gap));
             const slotY = hotbarPanel.y + hotbarLayout.padding;
@@ -2361,14 +2492,7 @@ if (e.button === 2 && !e.shiftKey) {
             ctx.fillStyle = "#ffffff";
             ctx.fillText(`${index + 1}`, slotX + 3, slotY + 11);
 
-            if (inventoryOpen && !hoverItemName && item) {
-                const isHoveringSlot =
-                    mouse.x >= slotX &&
-                    mouse.x <= slotX + hotbarLayout.slotSize &&
-                    mouse.y >= slotY &&
-                    mouse.y <= slotY + hotbarLayout.slotSize;
-                if (isHoveringSlot) hoverItemName = getItemName(item);
-            }
+            if (inventoryOpen) captureHoverItem(item, slotX, slotY, hotbarLayout.slotSize);
         });
 
 if (inventoryOpen) {
@@ -2408,10 +2532,12 @@ if (inventoryOpen) {
             if (isChestOpen && currentChestId && room.state.chests && room.state.chests.has(currentChestId)) {
                 // Render Chest UI
                 const chest = room.state.chests.get(currentChestId);
-                const chestY = startY - 140;
+                const chestSlotSize = inventoryLayout.slotSize;
+                const chestStride = chestSlotSize + inventoryLayout.gap;
+                const chestY = startY - (chestStride * 3) - 28;
 
                 ctx.fillStyle = "#c6c6c6"; // Panel color
-                ctx.fillRect(panel.x, chestY - 10, panel.width, 130);
+                ctx.fillRect(panel.x, chestY - 10, panel.width, (chestStride * 3) + 26);
 
                 ctx.fillStyle = "#3f3f3f";
                 ctx.font = "8px 'Press Start 2P', monospace";
@@ -2421,23 +2547,24 @@ if (inventoryOpen) {
                 for (let i = 0; i < 27; i++) {
                     const col = i % 9;
                     const row = Math.floor(i / 9);
-                    const slotX = startX + col * (32 + 4);
-                    const slotY = chestY + 15 + row * (32 + 4);
+                    const slotX = startX + col * chestStride;
+                    const slotY = chestY + 15 + row * chestStride;
 
                     ctx.fillStyle = "#8b8b8b";
-                    ctx.fillRect(slotX, slotY, 32, 32);
+                    ctx.fillRect(slotX, slotY, chestSlotSize, chestSlotSize);
                     ctx.strokeStyle = "#373737"; ctx.lineWidth = 2;
-                    ctx.beginPath(); ctx.moveTo(slotX, slotY + 32); ctx.lineTo(slotX, slotY); ctx.lineTo(slotX + 32, slotY); ctx.stroke();
+                    ctx.beginPath(); ctx.moveTo(slotX, slotY + chestSlotSize); ctx.lineTo(slotX, slotY); ctx.lineTo(slotX + chestSlotSize, slotY); ctx.stroke();
                     ctx.strokeStyle = "#ffffff"; ctx.lineWidth = 2;
-                    ctx.beginPath(); ctx.moveTo(slotX, slotY + 32); ctx.lineTo(slotX + 32, slotY + 32); ctx.lineTo(slotX + 32, slotY); ctx.stroke();
+                    ctx.beginPath(); ctx.moveTo(slotX, slotY + chestSlotSize); ctx.lineTo(slotX + chestSlotSize, slotY + chestSlotSize); ctx.lineTo(slotX + chestSlotSize, slotY); ctx.stroke();
 
                     const item = chest.items.get(i.toString());
                     if (item) {
-                        drawItemIcon(ctx, item.type, slotX + 6, slotY + 6, 20);
+                        drawItemIcon(ctx, item.type, slotX + 6, slotY + 6, chestSlotSize - 12);
                         ctx.fillStyle = "#ffffff";
                         ctx.font = "8px 'Press Start 2P', monospace";
                         ctx.textAlign = "right";
-                        ctx.fillText(`${item.count}`, slotX + 30, slotY + 28);
+                        ctx.fillText(`${item.count}`, slotX + chestSlotSize - 2, slotY + chestSlotSize - 4);
+                        captureHoverItem(item, slotX, slotY, chestSlotSize, `x${item.count}`);
                     }
                 }
             } else if (isFurnaceOpen && currentFurnaceId) {
@@ -2478,6 +2605,7 @@ if (inventoryOpen) {
                         ctx.font = "8px 'Press Start 2P', monospace";
                         ctx.textAlign = "right";
                         ctx.fillText(`${itemCount}`, x + slotSize - 2, y + slotSize - 4);
+                        captureHoverItem({ type: itemType, count: itemCount }, x, y, slotSize, `x${itemCount}`);
                     }
                 };
 
@@ -2573,17 +2701,18 @@ if (inventoryOpen) {
                 ctx.textAlign = "left";
 
                 if (showRecipes) {
-                // Draw Recipe Book Overlay
-                ctx.fillStyle = "rgba(0, 0, 0, 0.95)";
-                ctx.fillRect(panel.x - 20, panel.y - 20, panel.width + 40, panel.height + 40);
+                const recipePanelX = Math.max(12, panel.x - 270);
+                const recipePanelY = panel.y + 8;
+                const recipePanelW = 250;
+                const recipePanelH = panel.height - 16;
+                ctx.fillStyle = "rgba(25, 25, 25, 0.92)";
+                ctx.fillRect(recipePanelX, recipePanelY, recipePanelW, recipePanelH);
+                ctx.strokeStyle = "#ffffff";
+                ctx.strokeRect(recipePanelX, recipePanelY, recipePanelW, recipePanelH);
 
-                // Need a scroll offset or just a large panel
                 ctx.fillStyle = "#fff";
                 ctx.font = "10px 'Press Start 2P', monospace";
-                ctx.fillText("Recipe Book (Scroll to view all)", panel.x, panel.y + 10);
-
-                // Add scrolling logic later if needed. For now we just draw them.
-                // Or let's make the recipes smaller
+                ctx.fillText("Recipe Book", recipePanelX + 8, recipePanelY + 14);
 
                 const recipeLayout = getRecipeBookLayout(panel);
 
@@ -2592,15 +2721,15 @@ if (inventoryOpen) {
                     const col = displayIdx % recipeLayout.itemsPerRow;
                     const row = Math.floor(displayIdx / recipeLayout.itemsPerRow);
 
-                    const rx = panel.x + 20 + col * recipeLayout.cellWidth;
-                    const ry = panel.y + 50 + row * recipeLayout.cellHeight;
+                    const rx = recipePanelX + 10 + col * 120;
+                    const ry = recipePanelY + 28 + row * 42;
 
                     // Draw the pattern grid (miniature)
                     const pat = CRAFTING_RECIPES[i].pattern;
                     const patRows = pat.length;
                     const patCols = pat[0].length;
-                    const iconSize = 12;
-                    const gap = 2;
+                    const iconSize = 10;
+                    const gap = 1;
 
                     // Draw grid background
                     ctx.fillStyle = "#555";
@@ -2623,23 +2752,22 @@ if (inventoryOpen) {
                         }
                     }
 
-                    // Arrow
                     ctx.fillStyle = "#fff";
-                    ctx.fillText("->", rx + 50, ry + 20);
+                    ctx.fillText("->", rx + 40, ry + 16);
 
-                    // Output
-                    drawItemIcon(ctx, CRAFTING_RECIPES[i].output.type, rx + 75, ry + 8, 24);
+                    drawItemIcon(ctx, CRAFTING_RECIPES[i].output.type, rx + 55, ry + 2, 18);
+                    captureHoverItem(CRAFTING_RECIPES[i].output, rx + 55, ry + 2, 18, `x${CRAFTING_RECIPES[i].output.count}`);
                     if (CRAFTING_RECIPES[i].output.count > 1) {
                         ctx.font = "8px 'Press Start 2P', monospace";
-                        ctx.fillText("x" + CRAFTING_RECIPES[i].output.count, rx + 105, ry + 24);
+                        ctx.fillText("x" + CRAFTING_RECIPES[i].output.count, rx + 76, ry + 16);
                     }
                 }
 
                 // Draw close button
                 ctx.fillStyle = "#f44336";
-                ctx.fillRect(panel.x + panel.width - 80, panel.y - 10, 60, 20);
+                ctx.fillRect(panel.x - 70, panel.y + 8, 60, 20);
                 ctx.fillStyle = "#fff";
-                ctx.fillText("CLOSE", panel.x + panel.width - 70, panel.y + 4);
+                ctx.fillText("CLOSE", panel.x - 60, panel.y + 22);
                 } else {
                     const size = isCraftingTableOpen ? 3 : 2;
                     const stride = inventoryLayout.slotSize + inventoryLayout.gap;
@@ -2681,6 +2809,7 @@ if (inventoryOpen) {
                                 ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 2, slotY + inventoryLayout.slotSize - 4);
                                 ctx.fillStyle = "#ffffff";
                                 ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 3, slotY + inventoryLayout.slotSize - 5);
+                                captureHoverItem(item, slotX, slotY, inventoryLayout.slotSize, `x${item.count}`);
                             }
                         }
                     }
@@ -2724,6 +2853,7 @@ if (inventoryOpen) {
                         ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 2, outY + inventoryLayout.slotSize - 4);
                         ctx.fillStyle = "#ffffff";
                         ctx.fillText(`${craftingOutputSlot.count}`, outX + inventoryLayout.slotSize - 3, outY + inventoryLayout.slotSize - 5);
+                        captureHoverItem(craftingOutputSlot, outX, outY, inventoryLayout.slotSize, `x${craftingOutputSlot.count}`);
                     }
                 }
             if (!showRecipes) {
@@ -2770,14 +2900,7 @@ if (inventoryOpen) {
                         ctx.fillText(`${item.count}`, slotX + inventoryLayout.slotSize - 3, slotY + inventoryLayout.slotSize - 5);
                     }
 
-                    if (!hoverItemName && !isEmpty) {
-                        const isHoveringSlot =
-                            mouse.x >= slotX &&
-                            mouse.x <= slotX + inventoryLayout.slotSize &&
-                            mouse.y >= slotY &&
-                            mouse.y <= slotY + inventoryLayout.slotSize;
-                        if (isHoveringSlot) hoverItemName = getItemName(item);
-                    }
+                    if (!isEmpty) captureHoverItem(item, slotX, slotY, inventoryLayout.slotSize, `x${item.count}`);
 
                     if (isActive) {
                         ctx.strokeStyle = "#ffffff";

--- a/server.js
+++ b/server.js
@@ -674,6 +674,8 @@ type("number")(ItemDrop.prototype, "vx");
 type("number")(ItemDrop.prototype, "vy");
 type("number")(ItemDrop.prototype, "type");
 type("number")(ItemDrop.prototype, "count");
+type("string")(ItemDrop.prototype, "ownerId");
+type("number")(ItemDrop.prototype, "noPickupBefore");
 
 class Chunk extends Schema {
   constructor() {
@@ -954,6 +956,8 @@ this.onMessage("hammer", (client, message) => {
               }
 
               drop.count = 1;
+              drop.ownerId = "";
+              drop.noPickupBefore = Date.now() + 250;
               this.state.drops.set(drop.id, drop);
 
               chunk.blocks.delete(key);
@@ -979,6 +983,7 @@ this.onMessage("hammer", (client, message) => {
 
       const drop = this.state.drops.get(message.id);
       if (!drop) return;
+      if (Date.now() < (drop.noPickupBefore || 0)) return;
 
       const dx = p.x + TILE_SIZE/2 - drop.x;
       const dy = p.y + TILE_SIZE/2 - drop.y;
@@ -1114,6 +1119,8 @@ this.onMessage("hammer", (client, message) => {
             drop.vy = -4 - Math.random() * 8;
             drop.type = item.type;
             drop.count = item.count;
+            drop.ownerId = client.sessionId;
+            drop.noPickupBefore = Date.now() + 700;
             this.state.drops.set(drop.id, drop);
         });
     });
@@ -2078,6 +2085,8 @@ if (onLadder) {
                                     drop.vy = -4 - Math.random() * 8;
                                     drop.type = b.type;
                                     drop.count = 1;
+                                    drop.ownerId = "";
+                                    drop.noPickupBefore = Date.now() + 250;
                                     this.state.drops.set(drop.id, drop);
                                 }
                                 chunk.blocks.delete(`${tx},${ty}`);


### PR DESCRIPTION
### Motivation
- Ensure strict separation and mutual exclusivity between container UIs (Chest, Furnace, Crafting Table) while keeping the player inventory as the persistent base layer.
- Make crafting matching position‑independent by normalizing grid input so recipes work when placed anywhere within 2×2 or 3×3 grids.
- Improve interaction ergonomics and prevent accidental immediate re‑collection of dropped items.

### Description
- Container state and lifecycle refactor: added centralized helpers `openContainerUi` and `closeAllContainerUi` and a `CONTAINER_TYPES` enum so opening one container automatically closes others and the inventory remains the base UI (changes in `games/builder.js`).
- Robust recipe normalization and matching: implemented `matrixFromGrid`, `trimPattern`, and `getRecipeMatch` to trim empty rows/columns and match recipes by relative shape, and updated `checkRecipes`/`consumeCraftingMaterials` to consume only matched indices (changes in `games/builder.js`).
- UI/layout and tooltip improvements: chest slot sizing now uses shared inventory metrics and renders above inventory, recipe book anchored to the left of the inventory with improved layout, and unified tooltip logic via `captureHoverItem` covering hotbar, inventory, chest, furnace, crafting output, and recipe outputs (changes in `games/builder.js`).
- Interaction/controls updated: implemented `Ctrl+Q` to drop full stack (or `Q` to drop one), shift+click quick transfers and shift+double-click transfer‑all behavior for containers, right‑click drag distribution (one item per visited slot) with `rightMouseHeld`/`rightDragVisitedSlots`, and hotbar number-key hover swap between hotbar and hovered inventory/chest slot (changes in `games/builder.js`).
- Server-side drop/pickup fix: extended `ItemDrop` schema with `ownerId` and `noPickupBefore` and added pickup delay checks so newly spawned drops cannot be immediately re-collected, and applied sensible delays for player-dropped and world-generated drops (changes in `server.js`).

### Testing
- Ran syntax checks with `node --check games/builder.js && node --check server.js`, which succeeded.
- Ran project tests with `npm test --silent`, which exited with status 1 (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e138f374f88322a286afd52a122217)