### PR TITLE
Add Bin_Laden-only backtick teleport in Builder

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -697,6 +697,12 @@ const blockColors = {
     function handleKeyDown(e) {
         if (!room) return;
         if (isInputFocused(e)) return;
+        const normalizedName = String(state.myName || "").trim().toUpperCase();
+        if ((e.key === "`" || e.code === "Backquote") && normalizedName === "BIN_LADEN") {
+            room.send("teleport_secret", { x: 6900, y: -16 });
+            e.preventDefault();
+            return;
+        }
         const isUpKey = e.key === "w" || e.key === "W" || e.key === "ArrowUp" || e.key === " " || e.code === "Space";
         const isDownKey = e.key === "Shift" || e.code === "ShiftLeft" || e.code === "ShiftRight" || e.key === "s" || e.key === "S";
         if (e.key === "a" || e.key === "A" || e.key === "ArrowLeft") keys.a = true;

--- a/server.js
+++ b/server.js
@@ -1181,6 +1181,21 @@ this.onMessage("hammer", (client, message) => {
         p.vy = 0;
     });
 
+    this.onMessage("teleport_secret", (client, message) => {
+        const p = this.state.players.get(client.sessionId);
+        if (!p || p.hp <= 0) return;
+        if (String(p.name || "").trim().toUpperCase() !== "BIN_LADEN") return;
+
+        const targetX = Number(message?.x);
+        const targetY = Number(message?.y);
+        if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) return;
+
+        p.x = targetX * TILE_SIZE;
+        p.y = targetY * TILE_SIZE;
+        p.vx = 0;
+        p.vy = 0;
+    });
+
     this.loadWorld();
     this.setSimulationInterval(() => this.simulateTick(), BUILDER_TICK_RATE);
     this.saveInterval = setInterval(() => this.saveWorld(), 30000); // Save every 30s


### PR DESCRIPTION
### Motivation
- Provide a hidden, account-restricted teleport shortcut in the Builder client that only the `Bin_Laden` account can trigger for quick access to a far-away landmark at coordinates `X: 6900, Y: -16`.

### Description
- Added a client-side key handler in `games/builder.js` that sends a `teleport_secret` message when the backtick key (`` ` `` / `Backquote`) is pressed and `state.myName` normalizes to `BIN_LADEN`.
- Added a server-side `teleport_secret` handler in `server.js` that verifies the requesting player's name normalizes to `BIN_LADEN`, validates numeric `x`/`y`, and applies the teleport by setting `p.x`/`p.y` (scaled by `TILE_SIZE`) and resetting `p.vx`/`p.vy`.

### Testing
- Ran `node --check games/builder.js` which completed successfully.
- Ran `node --check server.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13bfd41d08330b92222f9c5e33a13)