### PR TITLE
Fix builder.js syntax error from missing array comma

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -224,7 +224,7 @@ const blockColors = {
         "data/blocks/17.json", "data/items/18.json", "data/items/19.json", "data/items/20.json",
         "data/items/21.json", "data/items/22.json", "data/items/23.json", "data/items/24.json",
         "data/items/25.json", "data/items/26.json", "data/items/27.json", "data/items/28.json",
-        "data/items/48.json", "data/items/49.json", "data/items/50.json", "data/items/51.json"
+        "data/items/48.json", "data/items/49.json", "data/items/50.json", "data/items/51.json",
         "data/blocks/29.json", "data/items/30.json", "data/blocks/31.json", "data/blocks/32.json",
         "data/blocks/33.json", "data/blocks/34.json", "data/blocks/35.json", "data/items/36.json",
         "data/blocks/37.json", "data/blocks/38.json", "data/blocks/39.json", "data/blocks/40.json",


### PR DESCRIPTION
### Motivation
- The `blockDataUrls` array in `games/builder.js` was missing a comma which produced a runtime `Uncaught SyntaxError: Unexpected string` when the file was parsed.

### Description
- Add the missing comma after `"data/items/51.json"` in the `blockDataUrls` array in `games/builder.js` to restore valid JavaScript syntax.

### Testing
- Ran `node --check games/builder.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13cd0df948322b81883bd212b8b39)