### PR TITLE
Add in-world Builder chat bubbles and terminal chat sender grouping

### DIFF
--- a/core.js
+++ b/core.js
@@ -5873,6 +5873,8 @@ let activeDmUser = "";
 let globallyMutedUsers = new Set();
 let isChatInitialized = false;
 let isChatModerationModeEnabled = true;
+const emittedBubbleMessageKeys = new Set();
+const MAX_EMITTED_BUBBLE_KEYS = 400;
 
 function getStatusStateForUser(username) {
   const normalized = normalizeUsername(username || "");
@@ -5885,6 +5887,38 @@ function getStatusStateForUser(username) {
 
 function renderChatUserLabel(username, label = username) {
   return `${renderStatusDot(getStatusStateForUser(username))}<span class="chat-user">${escapeHtml(String(label || "ANON"))}:</span>`;
+}
+
+function renderCrewAffiliationTag(message = {}) {
+  const inferredCrew = normalizeCrewTag(message.crewTag || message?.crew?.tag || "");
+  const safeCrew = inferredCrew || "SOLO";
+  return `<span class="chat-crew-tag">[${escapeHtml(safeCrew)}]</span>`;
+}
+
+function emitBuilderChatBubbleMessage(tab, message) {
+  if (!message || !message.msg) return;
+  const msgId = String(message.id || `${message.user || "ANON"}:${message.ts || 0}:${message.msg || ""}`);
+  const eventKey = `${tab}:${msgId}`;
+  if (emittedBubbleMessageKeys.has(eventKey)) return;
+  emittedBubbleMessageKeys.add(eventKey);
+  if (emittedBubbleMessageKeys.size > MAX_EMITTED_BUBBLE_KEYS) {
+    const oldest = emittedBubbleMessageKeys.values().next().value;
+    if (oldest) emittedBubbleMessageKeys.delete(oldest);
+  }
+  window.dispatchEvent(
+    new CustomEvent("gooner:builder-chat-message", {
+      detail: {
+        id: msgId,
+        tab,
+        user: normalizeUsername(message.user || "ANON"),
+        msg: String(message.msg || ""),
+        ts: Number(message.ts || Date.now()),
+        to: normalizeUsername(message.to || ""),
+        crewTag: normalizeCrewTag(message.crewTag || ""),
+        participants: Array.isArray(message.participants) ? message.participants.map((entry) => normalizeUsername(entry || "")) : [],
+      },
+    })
+  );
 }
 
 function startChatPresenceSync() {
@@ -5949,8 +5983,9 @@ function getChatTabConfig(tab) {
         const mine = sender === normalizeUsername(myName);
         const partner = mine ? to || "UNKNOWN" : sender;
         const prefix = activeDmUser ? (mine ? "YOU" : `@${sender}`) : `${mine ? "YOU" : `@${sender}`} → @${partner}`;
-        return `${renderStatusDot(getStatusStateForUser(sender))}<span class="chat-user">${escapeHtml(prefix)}:</span> ${escapeHtml(filterChatMessage(m.msg || ""))}`;
-      }
+        return `${renderStatusDot(getStatusStateForUser(sender))}<span class="chat-user">${escapeHtml(prefix)}:</span> ${renderCrewAffiliationTag(m)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+      },
+      renderMessageBody: (m) => escapeHtml(filterChatMessage(m.msg || "")),
     },
     global: {
       label: "GLOBAL",
@@ -5960,8 +5995,9 @@ function getChatTabConfig(tab) {
       send: (txt) => ({ payload: { user: myName, msg: filterChatMessage(txt).slice(0, 60), ts: Date.now() }, collectionName: "gooner_global_chat" }),
       renderMessage: (m) => {
         const user = String(m.user || "ANON").toUpperCase();
-        return `${renderChatUserLabel(m.user || "ANON", user)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
-      }
+        return `${renderChatUserLabel(m.user || "ANON", user)} ${renderCrewAffiliationTag(m)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+      },
+      renderMessageBody: (m) => escapeHtml(filterChatMessage(m.msg || "")),
     },
     crew: {
       label: "CREW",
@@ -5978,8 +6014,9 @@ function getChatTabConfig(tab) {
       },
       renderMessage: (m) => {
         const user = String(m.user || "ANON").toUpperCase();
-        return `${renderChatUserLabel(m.user || "ANON", user)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
-      }
+        return `${renderChatUserLabel(m.user || "ANON", user)} ${renderCrewAffiliationTag(m)} ${escapeHtml(filterChatMessage(m.msg || ""))}`;
+      },
+      renderMessageBody: (m) => escapeHtml(filterChatMessage(m.msg || "")),
     }
   };
   return configs[tab] || configs.global;
@@ -6029,28 +6066,41 @@ function renderChatTab() {
     const muted = getChatSet(CHAT_MUTED_KEY);
     const msgs = [];
     snap.forEach((d) => msgs.push({ id: d.id, ...d.data() }));
+    let previousVisibleSender = "";
     msgs
       .sort((a, b) => Number(a?.ts || 0) - Number(b?.ts || 0))
       .forEach((m) => {
       const user = normalizeUsername(m.user || "ANON");
       if (blocklist.has(user)) return;
+      const isContinuation = previousVisibleSender === user;
+      previousVisibleSender = user;
       const isLocallyMuted = muted.has(user);
       const isGloballyMuted = globallyMutedUsers.has(user);
       const row = document.createElement("div");
       row.className = "chat-msg";
+      row.classList.toggle("chat-msg-continuation", isContinuation);
 
       const text = document.createElement("div");
       text.className = "chat-msg-text";
       if (isLocallyMuted || isGloballyMuted) {
         const muteScope = isGloballyMuted ? "GLOBAL" : "LOCAL";
-        text.innerHTML = `${renderChatUserLabel(user, user)} <span class="chat-muted-placeholder">[${escapeHtml(muteScope)} MUTED MESSAGE]</span>`;
+        if (isContinuation) {
+          text.innerHTML = `<span class="chat-muted-placeholder">[${escapeHtml(muteScope)} MUTED MESSAGE]</span>`;
+        } else {
+          text.innerHTML = `${renderChatUserLabel(user, user)} <span class="chat-muted-placeholder">[${escapeHtml(muteScope)} MUTED MESSAGE]</span>`;
+        }
       } else {
-        text.innerHTML = tabConfig.renderMessage(m);
+        if (isContinuation && typeof tabConfig.renderMessageBody === "function") {
+          text.innerHTML = tabConfig.renderMessageBody(m);
+        } else {
+          text.innerHTML = tabConfig.renderMessage(m);
+        }
+        emitBuilderChatBubbleMessage(currentTab, m);
       }
       row.appendChild(text);
 
       const canTargetUser = user && user !== "ANON" && user !== normalizeUsername(myName);
-      if (canTargetUser) {
+      if (canTargetUser && !isContinuation) {
         const canModerateChat = canUseChatModeration();
 
         const localMuteBtn = document.createElement("button");

--- a/games/builder.js
+++ b/games/builder.js
@@ -342,6 +342,137 @@ const blockColors = {
     const BUILD_HOLD_REPEAT_MS = 120;
     let buildHoldTimeout = null;
     let buildHoldInterval = null;
+    const CHAT_BUBBLE_EVENT = "gooner:builder-chat-message";
+    const CHAT_BUBBLE_MAX_STACK = 5;
+    const CHAT_BUBBLE_NEARBY_RANGE = TILE_SIZE * 14;
+    const CHAT_BUBBLE_DURATION_MS = 6500;
+    const CHAT_BUBBLE_FADE_MS = 900;
+    const CHAT_BUBBLE_BASE_OFFSET = 24;
+    const CHAT_BUBBLE_SPACING = 24;
+    const CHAT_BUBBLE_TRANSITION_SMOOTHING = 0.22;
+    const inWorldChatBubblesByUser = new Map();
+    const normalizedName = (name) => String(name || "").trim().toUpperCase();
+    const readLocalCrewTag = () => {
+        try {
+            const parsed = JSON.parse(localStorage.getItem("goonerCrewData") || "{}");
+            return normalizedName(parsed?.tag || "");
+        } catch (_err) {
+            return "";
+        }
+    };
+    const findPlayerByNormalizedName = (name) => {
+        if (!room || !room.state?.players || !name) return null;
+        let found = null;
+        room.state.players.forEach((player, sessionId) => {
+            if (found) return;
+            if (normalizedName(player?.name) === name) {
+                found = { player, sessionId };
+            }
+        });
+        return found;
+    };
+    const shouldRenderBubbleForMessage = (message, localPlayer, senderPlayer) => {
+        if (!message || !senderPlayer || !localPlayer) return false;
+        const tab = String(message.tab || "global");
+        const me = normalizedName(state.myName || "");
+        const sender = normalizedName(message.user);
+        if (!sender || !message.msg) return false;
+        if (tab === "global") {
+            const dx = (senderPlayer.x + TILE_SIZE / 2) - (localPlayer.x + TILE_SIZE / 2);
+            const dy = (senderPlayer.y + TILE_SIZE / 2) - (localPlayer.y + TILE_SIZE / 2);
+            return (dx * dx) + (dy * dy) <= CHAT_BUBBLE_NEARBY_RANGE * CHAT_BUBBLE_NEARBY_RANGE;
+        }
+        if (tab === "crew") {
+            const localCrew = readLocalCrewTag();
+            const msgCrew = normalizedName(message.crewTag || "");
+            return Boolean(localCrew && msgCrew && localCrew === msgCrew);
+        }
+        if (tab === "dm") {
+            const to = normalizedName(message.to || "");
+            return sender === me || to === me;
+        }
+        return false;
+    };
+    const handleIncomingChatBubbleEvent = (event) => {
+        const detail = event?.detail;
+        if (!detail || !room || !localPlayerId || !room.state?.players?.has(localPlayerId)) return;
+        const senderName = normalizedName(detail.user);
+        if (!senderName) return;
+        const senderEntry = findPlayerByNormalizedName(senderName);
+        const localPlayer = room.state.players.get(localPlayerId);
+        if (!senderEntry || !localPlayer) return;
+        if (!shouldRenderBubbleForMessage(detail, localPlayer, senderEntry.player)) return;
+        const now = Date.now();
+        const stack = inWorldChatBubblesByUser.get(senderName) || [];
+        stack.push({
+            id: detail.id || `${senderName}:${detail.ts || now}`,
+            text: String(detail.msg || "").slice(0, 80),
+            createdAt: now,
+            expiresAt: now + CHAT_BUBBLE_DURATION_MS,
+            yOffset: CHAT_BUBBLE_BASE_OFFSET,
+            targetOffset: CHAT_BUBBLE_BASE_OFFSET,
+        });
+        while (stack.length > CHAT_BUBBLE_MAX_STACK) stack.shift();
+        inWorldChatBubblesByUser.set(senderName, stack);
+    };
+    const updateAndDrawInWorldChatBubbles = (localPlayer) => {
+        if (!room || !localPlayer) return;
+        const now = Date.now();
+        inWorldChatBubblesByUser.forEach((stack, name) => {
+            const playerEntry = findPlayerByNormalizedName(name);
+            if (!playerEntry || !Array.isArray(stack) || stack.length === 0) {
+                inWorldChatBubblesByUser.delete(name);
+                return;
+            }
+            const filtered = stack.filter((bubble) => bubble.expiresAt > now);
+            if (filtered.length === 0) {
+                inWorldChatBubblesByUser.delete(name);
+                return;
+            }
+            for (let i = filtered.length - 1; i >= 0; i -= 1) {
+                const bubble = filtered[i];
+                const fromNewest = filtered.length - 1 - i;
+                bubble.targetOffset = CHAT_BUBBLE_BASE_OFFSET + (fromNewest * CHAT_BUBBLE_SPACING);
+                bubble.yOffset += (bubble.targetOffset - bubble.yOffset) * CHAT_BUBBLE_TRANSITION_SMOOTHING;
+            }
+            inWorldChatBubblesByUser.set(name, filtered);
+            filtered.forEach((bubble) => {
+                const remaining = bubble.expiresAt - now;
+                const alpha = remaining >= CHAT_BUBBLE_FADE_MS ? 1 : Math.max(0, remaining / CHAT_BUBBLE_FADE_MS);
+                if (alpha <= 0.01) return;
+                const anchorX = playerEntry.player.x + (TILE_SIZE / 2);
+                const anchorY = playerEntry.player.y - bubble.yOffset;
+                const bubblePaddingX = 6;
+                const bubbleHeight = 16;
+                ctx.font = "8px 'Press Start 2P', monospace";
+                const maxTextWidth = 190;
+                const rawText = bubble.text;
+                let drawText = rawText;
+                while (ctx.measureText(drawText).width > maxTextWidth && drawText.length > 4) {
+                    drawText = `${drawText.slice(0, -2)}…`;
+                }
+                const textWidth = ctx.measureText(drawText).width;
+                const bubbleWidth = textWidth + (bubblePaddingX * 2);
+                const bubbleX = anchorX - (bubbleWidth / 2);
+                const bubbleY = anchorY - bubbleHeight;
+                ctx.save();
+                ctx.globalAlpha = alpha;
+                ctx.fillStyle = "rgba(10, 18, 25, 0.9)";
+                ctx.strokeStyle = "rgba(170, 230, 255, 0.95)";
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight);
+                ctx.fill();
+                ctx.stroke();
+                ctx.fillStyle = "#dff7ff";
+                ctx.textAlign = "center";
+                ctx.fillText(drawText, anchorX, bubbleY + 11);
+                ctx.restore();
+            });
+        });
+    };
+    window.removeEventListener(CHAT_BUBBLE_EVENT, handleIncomingChatBubbleEvent);
+    window.addEventListener(CHAT_BUBBLE_EVENT, handleIncomingChatBubbleEvent);
     const playerName = () => state.myName || "Player";
     const hotbarLayout = {
         slotSize: 40,
@@ -2536,6 +2667,7 @@ if (e.button === 2 && !e.shiftKey) {
             ctx.textAlign = "center";
             ctx.fillText(p.name, p.x + TILE_SIZE / 2, p.y - 5);
         });
+        updateAndDrawInWorldChatBubbles(localPlayer);
 
         // Draw bullets
         room.state.bullets.forEach((b) => {
@@ -3310,6 +3442,8 @@ if (inventoryOpen) {
         canvas.removeEventListener("mouseup", handleMouseUp);
 
         clearBuildHoldTimers();
+        inWorldChatBubblesByUser.clear();
+        window.removeEventListener(CHAT_BUBBLE_EVENT, handleIncomingChatBubbleEvent);
         menu.style.display = "block";
         gameArea.style.display = "none";
         btnJoin.textContent = "QUICK JOIN ANY SERVER";

--- a/styles.css
+++ b/styles.css
@@ -645,6 +645,18 @@ body::before {
   flex: 1;
   min-width: 0;
 }
+.chat-msg.chat-msg-continuation {
+  margin-top: -2px;
+}
+.chat-msg.chat-msg-continuation .chat-msg-text {
+  padding-left: 18px;
+}
+.chat-crew-tag {
+  color: #8fb6ff;
+  font-size: 9px;
+  margin-right: 4px;
+  opacity: 0.9;
+}
 .chat-muted-placeholder {
   color: #7f8c9a;
   font-style: italic;


### PR DESCRIPTION
### Motivation

- Render player chat as floating, context-aware bubbles in Builder so nearby/recipient players see in-world messages above characters. 
- Keep in-world and terminal chat consistent by emitting the same message payloads and visibility rules to the Builder renderer. 
- Improve terminal readability by grouping consecutive messages from the same sender so metadata/controls are only shown on the first message in a run. 

### Description

- Added a deduplicated chat event bridge in `core.js` with `emitBuilderChatBubbleMessage` and `renderCrewAffiliationTag`, and extended tab configs with `renderMessageBody` to support continuation rendering. 
- Updated `renderChatTab` in `core.js` to detect sender continuity, toggle a `chat-msg-continuation` flag, omit repeated metadata/controls for continuations, and emit the `gooner:builder-chat-message` event for visible messages. 
- Implemented in-world bubble handling in `games/builder.js` by listening for `gooner:builder-chat-message`, building per-player stacked bubble lists with max stack size, chronological stacking (newest nearest the player), smooth vertical transitions, timed fade/expiry, and visibility filtering for global/crew/dm scopes. 
- Added minimal styling in `styles.css` for continuation rows and a crew-affiliation tag via `.chat-msg-continuation` and `.chat-crew-tag`, and ensured bubble renderer cleans up listeners and state on stop. 

### Testing

- Ran `node --check core.js` and `node --check games/builder.js`, both succeeded with no syntax errors. 
- Attempted `node --check styles.css` as part of a combined check which failed because Node does not support syntax-checking `.css` files (this is an environment limitation, not a CSS syntax regression). 
- No automated UI tests were executed in this environment; the change is client-side and should be validated in-browser for visual/audio smoothing and multi-player visibility behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a7b8af948326b1149881cad3438e)