### PR TITLE
Add TNT/Nuke chain reactions and prevent explosive blocks from being destroyed

### DIFF
--- a/server.js
+++ b/server.js
@@ -2093,6 +2093,7 @@ if (onLadder) {
             const isNuke = exp.type === 34;
             const radius = isNuke ? (TILE_SIZE * 1000) : (TILE_SIZE * 5);
             const damage = isNuke ? 100 : 20;
+            const chainFuse = isNuke ? 30 : 10;
 
             // Damage players
             this.state.players.forEach(p => {
@@ -2105,6 +2106,17 @@ if (onLadder) {
                     const knockback = (radius - dist) / radius * (isNuke ? 30 : 15);
                     p.vx += (dx / dist) * knockback;
                     p.vy += (dy / dist) * knockback - 5;
+                }
+            });
+
+            // Chain-react with nearby live explosives instead of deleting them.
+            this.state.explosives.forEach((otherExp, otherId) => {
+                if (otherId === id) return;
+                const dx = otherExp.x - exp.x;
+                const dy = otherExp.y - exp.y;
+                if (dx * dx + dy * dy > radius * radius) return;
+                if (otherExp.timer > chainFuse) {
+                    otherExp.timer = chainFuse;
                 }
             });
 
@@ -2125,6 +2137,17 @@ if (onLadder) {
                             const b = chunk.blocks.get(`${tx},${ty}`);
                             if (b) {
                                 if (b.type === 48) continue; // Bedrock is blast-proof
+                                if (b.type === 33 || b.type === 34) {
+                                    // TNT / Nuke chain reaction: ignite instead of destroying.
+                                    const explosive = new Explosive();
+                                    explosive.x = tx * TILE_SIZE + TILE_SIZE / 2;
+                                    explosive.y = ty * TILE_SIZE + TILE_SIZE / 2;
+                                    explosive.type = b.type;
+                                    explosive.timer = chainFuse;
+                                    this.state.explosives.set(`exp-${Date.now()}-${Math.random()}`, explosive);
+                                    chunk.blocks.delete(`${tx},${ty}`);
+                                    continue;
+                                }
                                 // Destroy and maybe drop item
                                 if (Math.random() < (isNuke ? 0.2 : 0.5)) {
                                     const drop = new ItemDrop();


### PR DESCRIPTION
### Motivation
- Make explosions trigger nearby TNT/Nuke entities so blasts can chain-react rather than simply destroying other explosives.
- Ensure TNT and Nuke block tiles are not destroyed by nearby explosions but instead ignite (become active explosives) when hit by a blast.
- Preserve existing blast immunity for bedrock and existing block drop/destroy behavior for non-explosive blocks.

### Description
- Add a `chainFuse` (short fuse) value and, when an explosive detonates, shorten the timer of any other live explosives within the blast radius so they ignite in sequence (`server.js`).
- When an explosion would destroy blocks, detect TNT (type `33`) and Nuke (type `34`) block tiles and convert them into active `Explosive` instances with `chainFuse` instead of treating them as normal destroyed blocks (`server.js`).
- Keep bedrock (type `48`) blast immunity and existing drop/destroy logic unchanged for non-explosive blocks.
- Changes made in `server.js` and committed.

### Testing
- Ran a syntax check with `node --check server.js`, which succeeded.
- No existing automated unit tests were modified or available for explosive behavior; manual/interactive validation expected in runtime scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ae401fe88326a8cebf7728917f14)