### PR TITLE
Fix builder.js EOF syntax error

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -4004,3 +4004,4 @@ if (inventoryOpen) {
         window.gameStops = [stopBuilder];
     }
 }
+}


### PR DESCRIPTION
### Motivation
- The `games/builder.js` module was failing to parse with a runtime/loader error `Unexpected end of input` caused by an unclosed block at end-of-file, preventing the builder game from loading.

### Description
- Add the missing closing brace at the end of `games/builder.js` to correct the module syntax and close the previously unclosed block.

### Testing
- Validated the fix with `node --experimental-default-type=module --check games/builder.js` and `node --check games/builder.js`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e240afc8c0832ba3202ab3a4e67e8d)