### PR TITLE
Fix builder room join startup ReferenceError

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -950,6 +950,11 @@ const blockColors = {
         });
     };
 
+    const restartRenderLoop = () => {
+        if (animationFrameId) cancelAnimationFrame(animationFrameId);
+        render();
+    };
+
     const joinRoomById = async (roomId) => {
         try {
             btnJoin.textContent = "CONNECTING...";
@@ -959,7 +964,7 @@ const blockColors = {
             setupRoomListeners();
             menu.style.display = "none";
             gameArea.style.display = "block";
-            startGameLoop();
+            restartRenderLoop();
         } catch (e) {
             console.error("Join by id error", e);
             btnJoin.textContent = "QUICK JOIN ANY SERVER";
@@ -975,7 +980,7 @@ const blockColors = {
             setupRoomListeners();
             menu.style.display = "none";
             gameArea.style.display = "block";
-            startGameLoop();
+            restartRenderLoop();
         } catch (e) {
             console.error("Quick join error", e);
             btnJoin.textContent = "QUICK JOIN ANY SERVER";
@@ -993,7 +998,7 @@ const blockColors = {
                 setupRoomListeners();
                 menu.style.display = "none";
                 gameArea.style.display = "block";
-                startGameLoop();
+                restartRenderLoop();
             } catch (e) {
                 console.error("Create server error", e);
                 btnCreateServer.textContent = "CREATE SERVER";
@@ -3955,11 +3960,6 @@ if (inventoryOpen) {
             ctx.fillStyle = blockColors[type] || "#fff";
             ctx.fillRect(x, y, size, size);
         }
-    }
-
-    function startGameLoop() {
-        if (animationFrameId) cancelAnimationFrame(animationFrameId);
-        render();
     }
 
     // Cleanup hook


### PR DESCRIPTION
### Motivation
- Fix a runtime crash where connection flows called an undefined `startGameLoop`, causing `ReferenceError` when joining or creating rooms; ensure the render loop is reliably restarted after connecting.

### Description
- Added a local `restartRenderLoop` helper that cancels any pending frame and calls `render()` in `games/builder.js`.
- Replaced calls to `startGameLoop()` in the `joinRoomById`, quick-join (`btnJoin.onclick`), and `btnCreateServer.onclick` flows with `restartRenderLoop()`.
- Removed the trailing `startGameLoop` function to eliminate the undefined reference and centralize render-loop startup logic in the new helper.

### Testing
- Ran `node --check games/builder.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2444f086c8327a30cab556da26866)