### PR TITLE
Retry builder server creation on expired seat reservation and debounce create button

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -987,13 +987,36 @@ const blockColors = {
         }
     };
 
+    const isSeatReservationExpiredError = (error) => {
+        const message = `${error?.message || error || ""}`.toLowerCase();
+        return message.includes("seat reservation expired");
+    };
+
     if (btnCreateServer) {
+        let isCreatingServer = false;
         btnCreateServer.onclick = async () => {
+            if (isCreatingServer) return;
+            isCreatingServer = true;
             try {
                 btnCreateServer.textContent = "CREATING...";
                 const serverName = (serverNameInput?.value || "").trim() || "Public World";
-                client = new window.Colyseus.Client(getServerUrl());
-                room = await client.create("builder_room", { name: playerName(), serverName, sprite: spriteToPayload(localCharacterSprite) });
+                const createPayload = { name: playerName(), serverName, sprite: spriteToPayload(localCharacterSprite) };
+                let lastError = null;
+
+                for (let attempt = 0; attempt < 2; attempt += 1) {
+                    try {
+                        client = new window.Colyseus.Client(getServerUrl());
+                        room = await client.create("builder_room", createPayload);
+                        break;
+                    } catch (e) {
+                        lastError = e;
+                        if (!isSeatReservationExpiredError(e) || attempt > 0) throw e;
+                        console.warn("Create server seat reservation expired; retrying once.", e);
+                    }
+                }
+
+                if (!room) throw lastError || new Error("Failed to create room");
+
                 localPlayerId = room.sessionId;
                 setupRoomListeners();
                 menu.style.display = "none";
@@ -1002,6 +1025,8 @@ const blockColors = {
             } catch (e) {
                 console.error("Create server error", e);
                 btnCreateServer.textContent = "CREATE SERVER";
+            } finally {
+                isCreatingServer = false;
             }
         };
     }


### PR DESCRIPTION
### Motivation
- Creating a builder server sometimes fails with a `seat reservation expired` error which prevents users from creating a room even if a retry would succeed.
- Rapid repeated clicks can trigger overlapping create attempts which exacerbate reservation timing issues.

### Description
- Added explicit detection for `seat reservation expired` errors by inspecting the error message in `games/builder.js` and treating it specially.
- Retry the `client.create("builder_room", ...)` call once with a fresh Colyseus client when the first attempt fails due to an expired seat reservation.
- Added an in-flight guard (`isCreatingServer`) to debounce the create button and prevent duplicate overlapping create attempts.
- Preserved existing UI fallback behavior by resetting the button text on error and ensuring the in-flight flag is cleared in a `finally` block.

### Testing
- Ran `node --check games/builder.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e245a151008327b0b6d4db172cade2)