### PR TITLE
Fix builder UI scaling, inventory visibility, furnace/editor bugs

### DIFF
--- a/core.js
+++ b/core.js
@@ -363,11 +363,12 @@ export const state = {
 };
 
 function isValidPixelLogo(logoData) {
+  const size = Array.isArray(logoData?.pixels) ? logoData.pixels.length : 0;
   return Boolean(
     logoData &&
     Array.isArray(logoData.palette) &&
     Array.isArray(logoData.pixels) &&
-    logoData.pixels.length === 32
+    (size === 16 || size === 32)
   );
 }
 
@@ -2786,7 +2787,8 @@ function renderCrewLogo(canvasId, logoData) {
 }
 
 // Global pixel editor state
-let crewLogoEditorPixels = Array(32).fill().map(() => Array(32).fill(-1));
+let editorGridSize = 32;
+let crewLogoEditorPixels = Array(editorGridSize).fill().map(() => Array(editorGridSize).fill(-1));
 let crewLogoEditorPalette = ["transparent"];
 let currentEditorTool = "draw"; // "draw" or "erase"
 let currentEditorColor = "#00ff00";
@@ -2801,16 +2803,19 @@ function charForPaletteIndex(idx) {
 }
 
 function parseLogoToEditor(logoData) {
-  crewLogoEditorPixels = Array(32).fill().map(() => Array(32).fill(-1));
+  const sourcePixels = Array.isArray(logoData?.pixels) ? logoData.pixels : [];
+  const inferredSize = sourcePixels.length === 16 ? 16 : 32;
+  editorGridSize = pixelEditorSession.mode === "builder_character" ? 16 : inferredSize;
+  crewLogoEditorPixels = Array(editorGridSize).fill().map(() => Array(editorGridSize).fill(-1));
   crewLogoEditorPalette = ["transparent"];
 
   if (!logoData || !logoData.palette || !logoData.pixels) return;
 
   crewLogoEditorPalette = [...logoData.palette];
 
-  for (let y = 0; y < 32; y++) {
+  for (let y = 0; y < editorGridSize; y++) {
     const row = logoData.pixels[y] || "";
-    for (let x = 0; x < 32; x++) {
+    for (let x = 0; x < editorGridSize; x++) {
       const char = row[x] || " ";
       if (char !== " ") {
         let colorIdx = -1;
@@ -2828,9 +2833,9 @@ function parseLogoToEditor(logoData) {
 
 function serializeEditorToLogo() {
   const rows = [];
-  for (let y = 0; y < 32; y++) {
+  for (let y = 0; y < editorGridSize; y++) {
     let rowStr = "";
-    for (let x = 0; x < 32; x++) {
+    for (let x = 0; x < editorGridSize; x++) {
       rowStr += charForPaletteIndex(crewLogoEditorPixels[y][x]);
     }
     rows.push(rowStr);
@@ -2849,11 +2854,13 @@ function getPaletteIndex(color) {
 function renderCrewLogoEditor() {
   const canvas = document.getElementById("crewLogoEditorCanvas");
   if (!canvas) return;
+  canvas.width = editorGridSize;
+  canvas.height = editorGridSize;
   const ctx = canvas.getContext("2d");
-  ctx.clearRect(0, 0, 32, 32);
+  ctx.clearRect(0, 0, editorGridSize, editorGridSize);
 
-  for (let y = 0; y < 32; y++) {
-    for (let x = 0; x < 32; x++) {
+  for (let y = 0; y < editorGridSize; y++) {
+    for (let x = 0; x < editorGridSize; x++) {
       const idx = crewLogoEditorPixels[y][x];
       if (idx >= 0 && idx < crewLogoEditorPalette.length && crewLogoEditorPalette[idx] !== "transparent") {
         ctx.fillStyle = crewLogoEditorPalette[idx];
@@ -2874,7 +2881,7 @@ function floodFill(startX, startY, targetColorIndex) {
     const [x, y] = stack.pop();
     const key = `${x},${y}`;
 
-    if (x < 0 || x >= 32 || y < 0 || y >= 32) continue;
+    if (x < 0 || x >= editorGridSize || y < 0 || y >= editorGridSize) continue;
     if (visited.has(key)) continue;
     if (crewLogoEditorPixels[y][x] !== startColorIndex) continue;
 
@@ -2970,7 +2977,7 @@ function initCrewUx() {
 
   if (clearLogoBtn) {
     clearLogoBtn.onclick = () => {
-      crewLogoEditorPixels = Array(32).fill().map(() => Array(32).fill(-1));
+      crewLogoEditorPixels = Array(editorGridSize).fill().map(() => Array(editorGridSize).fill(-1));
       renderCrewLogoEditor();
     };
   }
@@ -3036,8 +3043,8 @@ function initCrewUx() {
         clientX = e.touches[0].clientX;
         clientY = e.touches[0].clientY;
       }
-      const x = Math.floor(((clientX - rect.left) / rect.width) * 32);
-      const y = Math.floor(((clientY - rect.top) / rect.height) * 32);
+      const x = Math.floor(((clientX - rect.left) / rect.width) * editorGridSize);
+      const y = Math.floor(((clientY - rect.top) / rect.height) * editorGridSize);
       return { x, y };
     };
 
@@ -3045,7 +3052,7 @@ function initCrewUx() {
       e.preventDefault();
       isDrawing = true;
       const { x, y } = getPos(e);
-      if (x < 0 || x >= 32 || y < 0 || y >= 32) return;
+      if (x < 0 || x >= editorGridSize || y < 0 || y >= editorGridSize) return;
 
       if (currentEditorTool === "fill") {
         const targetIdx = getPaletteIndex(currentEditorColor);
@@ -3064,7 +3071,7 @@ function initCrewUx() {
       e.preventDefault();
       if (currentEditorTool === "fill") return;
       const { x, y } = getPos(e);
-      if (x < 0 || x >= 32 || y < 0 || y >= 32) return;
+      if (x < 0 || x >= editorGridSize || y < 0 || y >= editorGridSize) return;
 
       const targetIdx = currentEditorTool === "draw" ? getPaletteIndex(currentEditorColor) : -1;
       if (crewLogoEditorPixels[y][x] !== targetIdx) {

--- a/games/builder.js
+++ b/games/builder.js
@@ -24,6 +24,7 @@ export function initBuilder() {
     let room;
     let client;
     let animationFrameId;
+    let inputLoopId = null;
 let selectedRoomId = null;
     let inventoryOpen = false;
     let isCraftingTableOpen = false;
@@ -581,8 +582,8 @@ const blockColors = {
         const rows = inventoryLayout.rows;
         const gridWidth = (inventoryLayout.cols * inventoryLayout.slotSize) + ((inventoryLayout.cols - 1) * inventoryLayout.gap);
         const gridHeight = (rows * inventoryLayout.slotSize) + ((rows - 1) * inventoryLayout.gap);
-        const startX = panel.x + inventoryLayout.padding; // Shift inventory left to make room
-        const startY = panel.y + Math.floor((panel.height - gridHeight) / 2) + 40;
+        const startX = panel.x + inventoryLayout.padding;
+        const startY = panel.y + panel.height - gridHeight - inventoryLayout.padding;
         return { rows, gridWidth, gridHeight, startX, startY };
     }
 
@@ -596,15 +597,18 @@ const blockColors = {
     }
 
     function getInventoryBounds() {
-        const width = Math.floor(canvas.width * inventoryLayout.widthRatio);
-        const height = Math.floor(canvas.height * inventoryLayout.heightRatio);
+        const minWidth = (inventoryLayout.cols * inventoryLayout.slotSize) + ((inventoryLayout.cols - 1) * inventoryLayout.gap) + (inventoryLayout.padding * 2) + 220;
+        const width = Math.min(canvas.width - 12, Math.max(minWidth, Math.floor(canvas.width * inventoryLayout.widthRatio)));
+        const height = Math.min(canvas.height - 12, Math.max(250, Math.floor(canvas.height * inventoryLayout.heightRatio)));
         const x = Math.floor((canvas.width - width) / 2);
         const y = Math.floor((canvas.height - height) / 2);
         return { x, y, width, height };
     }
 
     function getCreativePanelBounds(panel) {
-        return { x: panel.x, y: Math.max(8, panel.y - 170), width: panel.width, height: 154 };
+        const width = Math.min(260, panel.width - 16);
+        const height = Math.max(140, panel.height - 110);
+        return { x: panel.x + panel.width - width - 8, y: panel.y + 28, width, height };
     }
 
     function getItemName(item) {
@@ -2745,9 +2749,7 @@ if (e.button === 2 && !e.shiftKey) {
         }
     }
 
-    document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("keyup", handleKeyUp);
-    canvas.addEventListener("wheel", (e) => {
+    const handleCanvasWheel = (e) => {
         if (!room) return;
         if (inventoryOpen && creativeModeEnabled) {
             const panel = getInventoryBounds();
@@ -2776,7 +2778,12 @@ if (e.button === 2 && !e.shiftKey) {
             e.preventDefault();
             return;
         }
-    }, { passive: false });
+    };
+    const handleCanvasContextMenu = (e) => e.preventDefault();
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+    canvas.addEventListener("wheel", handleCanvasWheel, { passive: false });
 
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("mousedown", handleMouseDown);
@@ -2784,10 +2791,10 @@ if (e.button === 2 && !e.shiftKey) {
 
 
     // Prevent context menu on canvas for right click breaking
-    canvas.addEventListener("contextmenu", e => e.preventDefault());
+    canvas.addEventListener("contextmenu", handleCanvasContextMenu);
 
     // Send input loop
-    setInterval(() => {
+    inputLoopId = setInterval(() => {
         if (room && localPlayerId && room.state.players.has(localPlayerId)) {
             if (!canUseFlight()) {
                 flightToggleEnabled = false;
@@ -3240,9 +3247,9 @@ if (e.button === 2 && !e.shiftKey) {
             if (inventoryOpen) captureHoverItem(item, slotX, slotY, hotbarLayout.slotSize);
         });
 
-if (inventoryOpen) {
+if (inventoryOpen && !showEscapeMenu) {
             const panel = getInventoryBounds();
-            const { rows, startX, startY } = getInventoryMetrics(panel);
+            const { rows, gridWidth, startX, startY } = getInventoryMetrics(panel);
 
             ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
             ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -3665,6 +3672,8 @@ if (inventoryOpen) {
                         captureHoverItem(craftingOutputSlot, outX, outY, inventoryLayout.slotSize, `x${craftingOutputSlot.count}`);
                     }
                 }
+            }
+
             {
                 for (let index = 0; index < totalSlots; index += 1) {
                     const item = inventorySlots[index];
@@ -3717,7 +3726,6 @@ if (inventoryOpen) {
                         ctx.strokeRect(slotX - 1, slotY - 1, inventoryLayout.slotSize + 2, inventoryLayout.slotSize + 2);
                     }
                 }
-            }
             }
 
             if (hoverItemName) {
@@ -3809,6 +3817,12 @@ if (inventoryOpen) {
         canvas.removeEventListener("mousemove", handleMouseMove);
         canvas.removeEventListener("mousedown", handleMouseDown);
         canvas.removeEventListener("mouseup", handleMouseUp);
+        canvas.removeEventListener("wheel", handleCanvasWheel);
+        canvas.removeEventListener("contextmenu", handleCanvasContextMenu);
+        if (inputLoopId) {
+            clearInterval(inputLoopId);
+            inputLoopId = null;
+        }
 
         clearBuildHoldTimers();
         inWorldChatBubblesByUser.clear();


### PR DESCRIPTION
### Motivation
- The Builder room UI had multiple layout regressions causing the player inventory to be hidden or overlap other panels, making the game unplayable in many in-game menus. 
- Furnaces/chests and creative catalog positioning caused runtime layout issues and a chest sizing crash due to missing panel width data. 
- Rejoin/teardown logic left canvas listeners and input loops active which could cause duplicate loops or crashes after leaving and rejoining. 
- The character sprite editor claimed to be 16x16 but was using a 32x32 pipeline which discarded valid 16x16 saves.

### Description
- Adjusted inventory layout: `getInventoryMetrics` now anchors inventory rows to the panel bottom and returns `gridWidth`, and `getInventoryBounds` enforces minimum panel dimensions and clamps to canvas size to prevent overlap. (changes in `games/builder.js`).
- Repositioned the creative catalog to render inside the inventory panel using `getCreativePanelBounds` and used `gridWidth` when rendering chest/furnace backgrounds to avoid sizing crashes. (changes in `games/builder.js`).
- Made input loop and canvas handlers removable by storing the input interval id (`inputLoopId`) and moving wheel/contextmenu handlers into named functions so they are removed in `stopBuilder`, preventing duplicated loops/listeners on rejoin. (changes in `games/builder.js`).
- Fixed inventory rendering so the player inventory grid is visible across container UIs (chest, furnace, crafting, creative) and is suppressed while the ESC pause menu is shown. (changes in `games/builder.js`).
- Updated pixel editor and sprite handling so Builder character editing uses a true 16x16 grid while crew logos remain 32x32, including canvas sizing, pointer math, flood-fill bounds, clear/serialize logic, and validation relaxed to accept 16x16 or 32x32 payloads. (changes in `core.js`).

### Testing
- Ran `node --check core.js` which succeeded. 
- Ran `node --check games/builder.js` which succeeded. 
- Attempted the Playwright CUJ Python tests (`pytest -q test_cuj8.py test_cuj9.py test_cuj10.py test_cuj11.py test_cuj12.py`) but collection failed due to a missing local Playwright Python dependency (`ModuleNotFoundError: No module named 'playwright'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24fa3c28083278838b0c7c8c49b6d)