### PR TITLE
Fix furnace/chest item-move bugs, add crafting split, and tighten inventory UI

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -597,7 +597,8 @@ const blockColors = {
     }
 
     function getInventoryBounds() {
-        const minWidth = (inventoryLayout.cols * inventoryLayout.slotSize) + ((inventoryLayout.cols - 1) * inventoryLayout.gap) + (inventoryLayout.padding * 2) + 220;
+        const rightPanelExtraWidth = isPlayerInventoryOnlyView() || isCraftingTableOpen ? 220 : 130;
+        const minWidth = (inventoryLayout.cols * inventoryLayout.slotSize) + ((inventoryLayout.cols - 1) * inventoryLayout.gap) + (inventoryLayout.padding * 2) + rightPanelExtraWidth;
         const width = Math.min(canvas.width - 12, Math.max(minWidth, Math.floor(canvas.width * inventoryLayout.widthRatio)));
         const height = Math.min(canvas.height - 12, Math.max(250, Math.floor(canvas.height * inventoryLayout.heightRatio)));
         const x = Math.floor((canvas.width - width) / 2);
@@ -2261,15 +2262,22 @@ function sendBuildOrBreak(e) {
                             mouse.y >= slotY && mouse.y <= slotY + inventoryLayout.slotSize) {
                             const craftingIndex = r * size + c;
                             const grid = isCraftingTableOpen ? craftingGrid3x3 : craftingGrid2x2;
-                            if (grid[craftingIndex] !== undefined) {
-                                draggedItemType = cloneItem(grid[craftingIndex]);
+                            const itemInSlot = grid[craftingIndex];
+                            if (itemInSlot !== undefined) {
+                                if (isRightClick && itemInSlot.count > 1) {
+                                    const splitCount = Math.ceil(itemInSlot.count / 2);
+                                    draggedItemType = { type: itemInSlot.type, count: splitCount };
+                                    grid[craftingIndex] = { type: itemInSlot.type, count: itemInSlot.count - splitCount };
+                                } else {
+                                    draggedItemType = cloneItem(itemInSlot);
+                                    grid[craftingIndex] = undefined;
+                                }
                                 pickedItemOnMouseDown = true;
                                 dragSourceHotbarIndex = null;
                                 dragSourceInventoryIndex = null;
                                 dragSourceCraftingIndex = craftingIndex;
                                 dragSourceOutputSlot = false;
                                 dragSourceArmorSlot = false;
-                                grid[craftingIndex] = undefined;
                                 checkRecipes();
                             }
                             return;

--- a/server.js
+++ b/server.js
@@ -877,23 +877,28 @@ this.onMessage("interact", (client, message) => {
         const containerId = message.containerId; // "x,y"
         const chest = this.state.chests.get(containerId);
         if (!chest) return;
+        if (!message?.item || !Number.isFinite(message.item.type) || !Number.isFinite(message.item.count)) return;
+        if (message.item.count <= 0) return;
+        const slotKey = message.slot?.toString?.();
+        if (slotKey === undefined) return;
+        const maxStack = 99;
 
         if (message.action === "put") {
-            const currentItem = chest.items.get(message.slot.toString());
+            const currentItem = chest.items.get(slotKey);
             if (currentItem && currentItem.type === message.item.type) {
-                currentItem.count += message.item.count;
+                currentItem.count = Math.min(maxStack, currentItem.count + message.item.count);
             } else if (!currentItem) {
                 const newItem = new ChestItem();
                 newItem.type = message.item.type;
-                newItem.count = message.item.count;
-                chest.items.set(message.slot.toString(), newItem);
+                newItem.count = Math.min(maxStack, message.item.count);
+                chest.items.set(slotKey, newItem);
             }
         } else if (message.action === "take") {
-            const currentItem = chest.items.get(message.slot.toString());
+            const currentItem = chest.items.get(slotKey);
             if (currentItem && currentItem.type === message.item.type) {
-                currentItem.count -= message.item.count;
+                currentItem.count -= Math.min(currentItem.count, message.item.count);
                 if (currentItem.count <= 0) {
-                    chest.items.delete(message.slot.toString());
+                    chest.items.delete(slotKey);
                 }
             }
         }
@@ -1871,45 +1876,48 @@ isSolid(x, y) {
 
 
     // Furnace Smelting Logic
-    this.state.furnaces.forEach(furnace => {
-        if (furnace.inputCount > 0 && furnace.fuelCount > 0 && furnace.inputItem >= 13 && furnace.inputItem <= 17) {
-            // Check if fuel is log/coal
-            if (furnace.fuelItem === 12 || furnace.fuelItem === 7 || furnace.fuelItem === 9) {
-                furnace.progress += 1;
-                if (furnace.progress >= 100) {
-                    furnace.progress = 0;
+    const furnaceOutputByInput = new Map([
+        [13, 43],
+        [14, 44],
+        [15, 45],
+        [16, 46],
+        [17, 47],
+    ]);
+    const furnaceFuelTypes = new Set([12, 7, 9]); // coal, log, planks
+    const furnaceProgressPerSmelt = 100;
+    const furnaceOutputMaxStack = 99;
 
-                    // Consume input & fuel
-                    furnace.inputCount--;
-                    if (furnace.inputCount <= 0) furnace.inputItem = 0;
-
-                    // Fuel consumption logic: 1 coal smelts 8 items? Let's just do 1:1 for simplicity right now
-                    furnace.fuelCount--;
-                    if (furnace.fuelCount <= 0) furnace.fuelItem = 0;
-
-                    let outputType = 0;
-                    if (furnace.inputItem === 13) outputType = 43;
-                    if (furnace.inputItem === 14) outputType = 44;
-                    if (furnace.inputItem === 15) outputType = 45;
-                    if (furnace.inputItem === 16) outputType = 46;
-                    if (furnace.inputItem === 17) outputType = 47;
-                    if (furnace.inputItem === 12) outputType = 12; // Coal just cooks coal? Skip.
-
-                    if (outputType !== 0) {
-                        if (furnace.outputItem === 0 || furnace.outputItem === outputType) {
-                            furnace.outputItem = outputType;
-                            furnace.outputCount++;
-                        } else {
-                            // Output full of something else, refund
-                            furnace.inputCount++;
-                            furnace.fuelCount++;
-                        }
-                    }
-                }
-            }
-        } else {
+    this.state.furnaces.forEach((furnace) => {
+        const outputType = furnaceOutputByInput.get(furnace.inputItem) || 0;
+        const canUseFuel = furnaceFuelTypes.has(furnace.fuelItem);
+        const hasWork = furnace.inputCount > 0 && furnace.fuelCount > 0 && outputType > 0 && canUseFuel;
+        const outputCompatible = furnace.outputCount === 0 || furnace.outputItem === outputType;
+        const outputHasSpace = furnace.outputCount < furnaceOutputMaxStack;
+        if (!(hasWork && outputCompatible && outputHasSpace)) {
             furnace.progress = 0;
+            return;
         }
+
+        furnace.progress += 1;
+        if (furnace.progress < furnaceProgressPerSmelt) return;
+        furnace.progress = 0;
+
+        const smeltingInputType = furnace.inputItem;
+        const smeltingOutputType = furnaceOutputByInput.get(smeltingInputType) || 0;
+        if (smeltingOutputType <= 0) return;
+
+        furnace.inputCount = Math.max(0, furnace.inputCount - 1);
+        if (furnace.inputCount === 0) furnace.inputItem = 0;
+
+        furnace.fuelCount = Math.max(0, furnace.fuelCount - 1);
+        if (furnace.fuelCount === 0) furnace.fuelItem = 0;
+
+        if (furnace.outputCount === 0) {
+            furnace.outputItem = smeltingOutputType;
+            furnace.outputCount = 1;
+            return;
+        }
+        furnace.outputCount = Math.min(furnaceOutputMaxStack, furnace.outputCount + 1);
     });
 
     this.state.bullets.forEach((b, id) => {


### PR DESCRIPTION
### Motivation
- Prevent furnaces from entering inconsistent states or appearing to "crash" while items are moved by making smelting logic deterministic and guarding transitions. 
- Stop chest stack-splitting/move races from deleting items by hardening server-side container handling. 
- Make the chest UI less wide on the right side to avoid awkward layout when containers are open. 
- Add right-click splitting in the crafting grid to match normal inventory split behavior.

### Description
- Validate and sanitize `container_move` payloads on the server in `server.js` and clamp stack math to a `maxStack` to avoid over-subtraction and accidental deletion when splitting/moving items. 
- Replace brittle furnace smelt tick code in `server.js` with a clearer flow that maps input→output via `furnaceOutputByInput`, checks fuel/input/output compatibility before progressing, prevents overfilling output stacks, and consumes input/fuel deterministically per smelt. 
- Reduce the right-side inventory minimum width in `games/builder.js` by computing a smaller `rightPanelExtraWidth` when appropriate so chest/furnace UIs are not excessively wide. 
- Implement right-click split pickup for crafting-grid slots in `games/builder.js` so right-click will pick up half the stack (when >1) and leave the remainder in the crafting slot.

### Testing
- Static syntax checks: ran `node --check games/builder.js && node --check server.js`, which succeeded. 
- Functional verification script: attempted `python3 verify_furnace_final.py`, which failed to run in this environment due to a missing `playwright` dependency (test not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2525070a08327b73c46f723e817de)