### PR TITLE
Fix builder inventory behavior, furnace sync validation, accessory persistence, and chest UI scaling

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -377,11 +377,23 @@ const blockColors = {
         inventorySlots = normalizeSlots([], 27);
     }
 
-    let armorSlot = builderArmor ? cloneItem(builderArmor) : undefined;
-    let backSlot = undefined;
+    const resolveArmorState = (rawArmorState) => {
+        if (!rawArmorState) return { armor: undefined, back: undefined };
+        if (rawArmorState.armor !== undefined || rawArmorState.back !== undefined) {
+            return {
+                armor: cloneItem(rawArmorState.armor),
+                back: cloneItem(rawArmorState.back),
+            };
+        }
+        return { armor: cloneItem(rawArmorState), back: undefined };
+    };
+    const initialArmorState = resolveArmorState(builderArmor);
+    let armorSlot = initialArmorState.armor;
+    let backSlot = initialArmorState.back;
+    const ACCESSORY_TYPES = new Set([18, 19, 20, 21, 22, 62, 65]);
 
     const saveInventoryState = () => {
-        updateBuilderInventoryState(hotbarSlots, inventorySlots, armorSlot);
+        updateBuilderInventoryState(hotbarSlots, inventorySlots, { armor: armorSlot, back: backSlot });
         saveStats();
     };
 
@@ -568,8 +580,8 @@ const blockColors = {
         bottom: 6,
     };
     const inventoryLayout = {
-        widthRatio: 0.80,
-        heightRatio: 0.56,
+        widthRatio: 0.72,
+        heightRatio: 0.54,
         padding: 12,
         slotSize: 34,
         gap: 3,
@@ -597,7 +609,9 @@ const blockColors = {
     }
 
     function getInventoryBounds() {
-        const rightPanelExtraWidth = isPlayerInventoryOnlyView() || isCraftingTableOpen ? 220 : 130;
+        const rightPanelExtraWidth = isChestOpen || isFurnaceOpen
+            ? 76
+            : (isPlayerInventoryOnlyView() || isCraftingTableOpen ? 220 : 130);
         const minWidth = (inventoryLayout.cols * inventoryLayout.slotSize) + ((inventoryLayout.cols - 1) * inventoryLayout.gap) + (inventoryLayout.padding * 2) + rightPanelExtraWidth;
         const width = Math.min(canvas.width - 12, Math.max(minWidth, Math.floor(canvas.width * inventoryLayout.widthRatio)));
         const height = Math.min(canvas.height - 12, Math.max(250, Math.floor(canvas.height * inventoryLayout.heightRatio)));
@@ -946,19 +960,23 @@ const blockColors = {
             if (room !== activeRoom) return;
             console.log(`Died to ${message.killer}`);
 
-            // Drop all items
+            // Drop non-accessory items only; keep accessories equipped/in inventory
             const dropItems = [];
-            hotbarSlots.forEach(s => { const item = normalizeItem(s); if (item) dropItems.push(item); });
-            inventorySlots.forEach(s => { const item = normalizeItem(s); if (item) dropItems.push(item); });
+            const keepOrDrop = (slot) => {
+                const item = normalizeItem(slot);
+                if (!item) return slot;
+                if (ACCESSORY_TYPES.has(item.type)) return slot;
+                dropItems.push(item);
+                return undefined;
+            };
+            hotbarSlots = hotbarSlots.map(keepOrDrop);
+            inventorySlots = inventorySlots.map(keepOrDrop);
 
-            room.send("spawn_drops", { items: dropItems });
+            if (dropItems.length > 0) room.send("spawn_drops", { items: dropItems });
             room.send("respawn");
-
-            // Clear inventory
-            hotbarSlots = new Array(9).fill(undefined).map(cloneItem);
-            inventorySlots = new Array(27).fill(undefined).map(cloneItem);
             selectedBlockType = hotbarSlots[selectedHotbarIndex];
             room.send("select_item", { type: 0 });
+            saveInventoryState();
         });
     };
 
@@ -1420,7 +1438,7 @@ function sendBuildOrBreak(e) {
         if (!room || !room.state) return false;
 
         // Cannot place tools/weapons as blocks
-        if (selectedBlockType !== undefined && [11, 23, 24, 25, 26, 27, 28, 36, 61, 63].includes(itemType(selectedBlockType))) return false;
+        if (selectedBlockType !== undefined && [11, 23, 24, 25, 26, 27, 28, 30, 36, 61, 63].includes(itemType(selectedBlockType))) return false;
 
         const localPlayer = room.state.players.get(localPlayerId);
         if (!localPlayer || localPlayer.hp <= 0) return false;
@@ -1842,6 +1860,7 @@ function sendBuildOrBreak(e) {
                                     draggedItemType = cloneItem(currentItem);
                                     room.send("container_move", { action: "take", containerId: currentChestId, slot: indexStr, item: cloneItem(currentItem) });
                                 }
+                                pickedItemOnMouseDown = true;
                             }
                         } else {
                             if (isRightClick) {
@@ -1931,6 +1950,7 @@ function sendBuildOrBreak(e) {
                                 draggedItemType = cloneItem(currentItem);
                                 setSlot(undefined);
                             }
+                            pickedItemOnMouseDown = true;
                         }
                         return;
                     }
@@ -1952,9 +1972,11 @@ function sendBuildOrBreak(e) {
                                     draggedItemType = cloneItem(currentItem);
                                     setSlot(undefined);
                                 }
+                                pickedItemOnMouseDown = true;
                             } else {
                                 draggedItemType = cloneItem(currentItem);
                                 setSlot(undefined);
+                                pickedItemOnMouseDown = true;
                             }
                         }
                     } else {
@@ -2218,7 +2240,7 @@ function sendBuildOrBreak(e) {
                             backSlot = cloneItem(draggedItemType);
                             draggedItemType = currentItem;
                         }
-                        room.send("equip_armor", { type: backSlot ? backSlot.type : (armorSlot ? armorSlot.type : 0) });
+                        room.send("equip_armor", { type: armorSlot ? armorSlot.type : 0 });
                     }
                     saveInventoryState();
                     return;
@@ -2710,7 +2732,7 @@ if (e.button === 2 && !e.shiftKey) {
                         if (dragSourceHotbarIndex !== null) { hotbarSlots[dragSourceHotbarIndex] = undefined; saveInventoryState(); }
                         else if (dragSourceInventoryIndex !== null) { inventorySlots[dragSourceInventoryIndex] = undefined; saveInventoryState(); }
                         else if (dragSourceArmorSlot) { armorSlot = undefined; room.send("equip_armor", { type: 0 }); }
-                        else if (dragSourceCraftingIndex !== null && dragSourceCraftingIndex !== targetCraftingIndex) grid[dragSourceCraftingIndex] = undefined;
+                        // dragSourceCraftingIndex is already updated during pickup/split; do not clear here.
                     }
                 }
 

--- a/server.js
+++ b/server.js
@@ -765,6 +765,9 @@ class BuilderRoom extends colyseus.Room {
     this.onMessage("build", (client, message) => {
       const p = this.state.players.get(client.sessionId);
       if (!p || p.hp <= 0) return;
+      const requestedType = Number.parseInt(message?.type, 10);
+      const nonPlaceableTypes = new Set([11, 23, 24, 25, 26, 27, 28, 30, 36, 61, 63]);
+      if (!Number.isFinite(requestedType) || nonPlaceableTypes.has(requestedType)) return;
 
       const playerCenterX = p.x + TILE_SIZE / 2;
       const playerCenterY = p.y + TILE_SIZE / 2;
@@ -801,7 +804,7 @@ class BuilderRoom extends colyseus.Room {
               const b = new Block();
               b.x = x;
               b.y = y;
-              b.type = message.type || 3;
+              b.type = requestedType;
               chunk.blocks.set(key, b);
           }
       }
@@ -908,7 +911,9 @@ this.onMessage("interact", (client, message) => {
         const p = this.state.players.get(client.sessionId);
         if (!p || p.hp <= 0) return;
 
+        if (!message || typeof message !== "object") return;
         const containerId = message.containerId;
+        if (typeof containerId !== "string" || !containerId.includes(",")) return;
         let furnace = this.state.furnaces.get(containerId);
         if (!furnace) {
             const [xStr, yStr] = (containerId || "").split(",");
@@ -924,12 +929,26 @@ this.onMessage("interact", (client, message) => {
             this.state.furnaces.set(containerId, furnace);
         }
 
-        furnace.inputItem = message.inputItem || 0;
-        furnace.inputCount = message.inputCount || 0;
-        furnace.fuelItem = message.fuelItem || 0;
-        furnace.fuelCount = message.fuelCount || 0;
-        furnace.outputItem = message.outputItem || 0;
-        furnace.outputCount = message.outputCount || 0;
+        const toSafeInt = (value, fallback = 0) => {
+            const num = Number.parseInt(value, 10);
+            return Number.isFinite(num) ? num : fallback;
+        };
+        const sanitizeSlot = (itemVal, countVal) => {
+            const item = Math.max(0, toSafeInt(itemVal, 0));
+            const count = Math.max(0, Math.min(99, toSafeInt(countVal, 0)));
+            if (item <= 0 || count <= 0) return { item: 0, count: 0 };
+            return { item, count };
+        };
+        const input = sanitizeSlot(message.inputItem, message.inputCount);
+        const fuel = sanitizeSlot(message.fuelItem, message.fuelCount);
+        const output = sanitizeSlot(message.outputItem, message.outputCount);
+
+        furnace.inputItem = input.item;
+        furnace.inputCount = input.count;
+        furnace.fuelItem = fuel.item;
+        furnace.fuelCount = fuel.count;
+        furnace.outputItem = output.item;
+        furnace.outputCount = output.count;
     });
 
 this.onMessage("hammer", (client, message) => {


### PR DESCRIPTION
### Motivation
- Correct several gameplay/UX regressions in the builder: stack-split/item pickup edge-cases, broken armor/back persistence, accessories being lost on death, apples being placeable, and an oversized chest/furnace UI panel.
- Prevent server crashes and invalid furnace state updates caused by malformed or unvalidated `furnace_sync` payloads.

### Description
- Client (`games/builder.js`): store/restore builder equipment as a backward-compatible `{ armor, back }` structure and persist both slots via `updateBuilderInventoryState` so armor/back save correctly.
- Client: treat armor/back accessory types specially (Set of accessory IDs), keep accessories equipped or in inventory on death while only spawning non-accessory drops, and avoid accidentally clearing crafting/crafting-source slots after split pickups.
- Client: mark `pickedItemOnMouseDown` for chest/furnace/container pickups to prevent immediate mouse-up reprocessing that caused stack-splitting losses, stop sending the back-slot as the equipped armor type during back-slot interactions, and add apples to the client-side non-placeable list so apples cannot be placed.
- Client: tighten inventory UI sizing and right-panel width when chest/furnace is open to prevent a huge right-side chest UI and better scale the inventory/crafting area.
- Server (`server.js`): validate `build` requests to block placement of non-placeable item types (including apples) and require a sane numeric type, and harden `furnace_sync` handling by validating the message shape, container id, and sanitizing item/count integers before mutating furnace state to avoid crashes.

### Testing
- `node --check games/builder.js` completed successfully.
- `node --check server.js` completed successfully.
- Attempted to run the automated Playwright verification script (`verify_furnace_final.py`) but it failed in this environment due to the missing Python Playwright module (`ModuleNotFoundError: No module named 'playwright'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2543143688327b92124fb11e81bfb)