### PR TITLE
fix: resolve schema is not defined error in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const colyseus = require("colyseus");
 const { WebSocketTransport } = require("@colyseus/ws-transport");
-const { Schema, type, MapSchema } = require("@colyseus/schema");
+const schema = require("@colyseus/schema");
+const { Schema, type, MapSchema } = schema;
 const http = require("http");
 const express = require("express");
 const cors = require("cors");


### PR DESCRIPTION
The server startup failed with a `schema is not defined` error because `server.js` was trying to use `schema.Schema` and `schema.defineTypes` but only destructured `Schema, type, MapSchema` from `@colyseus/schema` on import.

This commit updates the import to explicitly require `@colyseus/schema` as `schema`, resolving the reference error, and then destructures it afterwards for backward compatibility.

---
*PR created automatically by Jules for task [5788276486732424204](https://jules.google.com/task/5788276486732424204) started by @thefoxssss*