### PR TITLE
Fix Arena Shooter fullscreen UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -803,6 +803,7 @@ function initGameScroller() {
 
 
 function getFullscreenTarget(overlay) {
+  if (overlay.id === "overlayFps") return overlay.querySelector("#fpsGame");
   return overlay.querySelector("canvas, iframe") || overlay;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -4556,3 +4556,7 @@ body.reduce-motion *::after {
 .admin-tab-content.active {
   display: block;
 }
+
+/* Added for FPS fullscreen */
+#fpsGame:fullscreen { width: 100vw !important; height: 100vh !important; background: black; }
+#fpsGame:fullscreen canvas { width: 100vw !important; height: 100vh !important; max-width: none !important; max-height: none !important; margin: 0 !important; object-fit: contain; }


### PR DESCRIPTION
Fixes an issue in the Arena Shooter game where going full screen hid the UI elements (leaderboard, kills, crosshair, HP). The fix adjusts the fullscreen target to the game's wrapper div and adds CSS to scale the canvas properly.

---
*PR created automatically by Jules for task [9991323980135250778](https://jules.google.com/task/9991323980135250778) started by @thefoxssss*