### PR TITLE
Fix shooting accuracy in FPS game

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -464,9 +464,9 @@ function onMouseDown(event) {
   nextFireTime = now + weapon.cooldown;
 
   // Fire
-  const origin = controls.getObject().position.clone();
-  const dir = new THREE.Vector3();
-  camera.getWorldDirection(dir);
+  raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
+  const origin = raycaster.ray.origin.clone();
+  const dir = raycaster.ray.direction.clone();
 
   const bullets = weapon.bullets || 1;
   const spread = weapon.spread || 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@colyseus/schema": "^2.0.37",
         "@colyseus/ws-transport": "^0.15.3",
+        "acorn": "^8.16.0",
         "colyseus": "^0.15.57",
         "colyseus.js": "^0.15.0",
         "cors": "^2.8.6",
         "express": "^4.22.1",
         "firebase-admin": "^12.7.0",
-        "playwright": "^1.59.1"
+        "playwright": "^1.59.1",
+        "three": "^0.184.0"
       }
     },
     "node_modules/@colyseus/auth": {
@@ -662,6 +664,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3105,6 +3119,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   "dependencies": {
     "@colyseus/schema": "^2.0.37",
     "@colyseus/ws-transport": "^0.15.3",
+    "acorn": "^8.16.0",
     "colyseus": "^0.15.57",
     "colyseus.js": "^0.15.0",
     "cors": "^2.8.6",
     "express": "^4.22.1",
     "firebase-admin": "^12.7.0",
-    "playwright": "^1.59.1"
+    "playwright": "^1.59.1",
+    "three": "^0.184.0"
   }
 }


### PR DESCRIPTION
Modified the shooting mechanics in the FPS game to use `raycaster.setFromCamera(new THREE.Vector2(0, 0), camera)` for determining the bullet's origin and direction. This aligns the shooting vector precisely with the center-screen crosshair, resolving previous accuracy issues caused by mismatching the origin (player base position) and direction.

---
*PR created automatically by Jules for task [173281806371163742](https://jules.google.com/task/173281806371163742) started by @thefoxssss*