### PR TITLE
Fix server list and display connected players for arena shooter

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -63,9 +63,9 @@ async function fetchServers() {
   serverList.innerHTML = "<div>SCANNING...</div>";
   try {
     const endpoint = getColyseusEndpoint().replace("ws", "http");
-    const res = await fetch(`${endpoint}/colyseus/api`);
-    const rooms = await res.json();
-    const fpsRooms = rooms.filter(r => r.name === "fps_room");
+    const res = await fetch(`${endpoint}/fps-servers`);
+    const payload = await res.json();
+    const fpsRooms = payload.servers || [];
 
     serverList.innerHTML = "";
     if (fpsRooms.length === 0) {
@@ -74,15 +74,18 @@ async function fetchServers() {
     }
 
     fpsRooms.forEach(r => {
-      const metadata = r.metadata || {};
       const row = document.createElement("div");
       row.style.display = "flex";
-      row.style.justifyContent = "space-between";
+      row.style.flexDirection = "column";
       row.style.padding = "5px";
       row.style.borderBottom = "1px solid #333";
 
+      const topRow = document.createElement("div");
+      topRow.style.display = "flex";
+      topRow.style.justifyContent = "space-between";
+
       const info = document.createElement("span");
-      info.textContent = `${metadata.serverName || r.roomId} (${r.clients}/${r.maxClients})`;
+      info.textContent = `${r.serverName || r.roomId} (${r.clients}/${r.maxClients})`;
 
       const btn = document.createElement("button");
       btn.className = "term-btn";
@@ -90,8 +93,19 @@ async function fetchServers() {
       btn.style.padding = "2px 8px";
       btn.onclick = () => joinRoom(r.roomId);
 
-      row.appendChild(info);
-      row.appendChild(btn);
+      topRow.appendChild(info);
+      topRow.appendChild(btn);
+      row.appendChild(topRow);
+
+      if (r.players && r.players.length > 0) {
+          const playersDiv = document.createElement("div");
+          playersDiv.style.fontSize = "12px";
+          playersDiv.style.color = "#aaa";
+          playersDiv.style.marginTop = "4px";
+          playersDiv.textContent = "Players: " + r.players.map(p => p.name).join(", ");
+          row.appendChild(playersDiv);
+      }
+
       serverList.appendChild(row);
     });
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -78,6 +78,7 @@ const app = express();
 app.use(cors());
 const port = process.env.PORT || 2567;
 const builderServerDirectory = new Map();
+const fpsServerDirectory = new Map();
 
 const gameServer = new colyseus.Server({
   transport: new WebSocketTransport({
@@ -2363,7 +2364,8 @@ schema.defineTypes(FPSState, {
 class FPSRoom extends colyseus.Room {
   onCreate(options) {
     this.maxClients = 1000;
-    this.setMetadata({ serverName: options.serverName || "Arena Server" });
+    this.serverName = options.serverName || "Arena Server";
+    this.setMetadata({ serverName: this.serverName });
     this.setState(new FPSState());
 
     this.mapVotes = { 0: 0, 1: 0, 2: 0 };
@@ -2478,6 +2480,13 @@ class FPSRoom extends colyseus.Room {
         }
       }
     });
+
+    fpsServerDirectory.set(this.roomId, {
+      roomId: this.roomId,
+      serverName: this.serverName,
+      clients: this.clients.length,
+      maxClients: this.maxClients
+    });
   }
 
   resetRound() {
@@ -2521,10 +2530,28 @@ class FPSRoom extends colyseus.Room {
 
     // Initial spawn pos
     client.send("respawn", { x: player.x, y: player.y, z: player.z });
+    this.updateMetadata();
   }
 
   onLeave(client) {
     this.state.players.delete(client.sessionId);
+    this.updateMetadata();
+  }
+
+  updateMetadata() {
+    const d = fpsServerDirectory.get(this.roomId);
+    if (d) {
+      d.clients = this.clients.length;
+      d.players = [];
+      this.state.players.forEach((player) => {
+        d.players.push({ name: player.name });
+      });
+      fpsServerDirectory.set(this.roomId, d);
+    }
+  }
+
+  onDispose() {
+    fpsServerDirectory.delete(this.roomId);
   }
 }
 
@@ -2844,6 +2871,14 @@ app.get("/agar-servers", (req, res) => {
 
 app.get("/builder-servers", (req, res) => {
   const servers = Array.from(builderServerDirectory.values()).sort((a, b) => {
+    if (b.clients !== a.clients) return b.clients - a.clients;
+    return a.serverName.localeCompare(b.serverName);
+  });
+  res.json({ servers });
+});
+
+app.get("/fps-servers", (req, res) => {
+  const servers = Array.from(fpsServerDirectory.values()).sort((a, b) => {
     if (b.clients !== a.clients) return b.clients - a.clients;
     return a.serverName.localeCompare(b.serverName);
   });


### PR DESCRIPTION
Implemented a custom `/fps-servers` endpoint on the node server, similar to how `/builder-servers` and `/agar-servers` operate. Track the active FPS servers in an `fpsServerDirectory` Map and expose the client metadata, including the list of players connected to the server. Update `games/fps.js` to correctly query the newly introduced endpoint and display the updated UI with player names.

---
*PR created automatically by Jules for task [895070519835624748](https://jules.google.com/task/895070519835624748) started by @thefoxssss*