### PR TITLE
Fix missing export for playSuccessSound in core.js

### DIFF
--- a/core.js
+++ b/core.js
@@ -1600,7 +1600,7 @@ export function beep(freq = 440, type = "square", len = 0.1) {
 }
 
 // "Success" melody used after achievements or purchases.
-function playSuccessSound() {
+export function playSuccessSound() {
   beep(523.25, "triangle", 0.1);
   setTimeout(() => beep(659.25, "triangle", 0.1), 100);
   setTimeout(() => beep(783.99, "triangle", 0.2), 200);


### PR DESCRIPTION
Fixed missing export for `playSuccessSound` in `core.js` so it can be imported by other files like `games/wordle.js` without throwing a `SyntaxError`.

---
*PR created automatically by Jules for task [12423240086996512634](https://jules.google.com/task/12423240086996512634) started by @thefoxssss*