### PR TITLE
Add Arena Shooter map selection and fix spawn bounds

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -126,9 +126,12 @@ async function fetchServers() {
 
 async function createRoom() {
   const serverName = serverNameInput.value.trim() || `${state.myName}'s Server`;
+  const mapSelect = document.getElementById("fpsMapSelect");
+  const mapId = mapSelect ? Number(mapSelect.value) : 0;
+
   try {
     const client = new Colyseus.Client(getColyseusEndpoint());
-    room = await client.create("fps_room", { serverName, playerName: state.myName });
+    room = await client.create("fps_room", { serverName, playerName: state.myName, mapId });
     setupRoom();
   } catch (err) {
     console.error("Create room failed:", err);

--- a/index.html
+++ b/index.html
@@ -2239,6 +2239,11 @@
           <option value="local">LOCALHOST NETWORK</option>
         </select>
         <button class="menu-btn" id="btnRefreshFpsServers" style="margin-top: 10px;">REFRESH SERVER LIST</button>
+        <select id="fpsMapSelect" class="term-input" style="margin-top: 10px;">
+          <option value="0">MAP: CLASSIC</option>
+          <option value="1">MAP: CITY</option>
+          <option value="2">MAP: PLATFORMS</option>
+        </select>
         <input type="text" id="fpsServerName" class="term-input" placeholder="NEW SERVER NAME" maxlength="24" />
         <button class="term-btn" id="btnCreateFpsServer">CREATE SERVER</button>
         <div id="fpsServerList" style="text-align: left; margin-top: 12px; max-height: 180px; overflow-y: auto;"></div>

--- a/server.js
+++ b/server.js
@@ -2368,6 +2368,10 @@ class FPSRoom extends colyseus.Room {
     this.setMetadata({ serverName: this.serverName });
     this.setState(new FPSState());
 
+    if (options.mapId !== undefined) {
+      this.state.mapId = options.mapId;
+    }
+
     this.mapVotes = { 0: 0, 1: 0, 2: 0 };
     this.playerVotes = new Map();
 
@@ -2467,8 +2471,8 @@ class FPSRoom extends colyseus.Room {
             // Respawn after 3 seconds
             setTimeout(() => {
               if (this.state.players.has(hitClient.id) && !this.state.roundOver) {
-                const respawnX = (Math.random() * 40 - 20) * 4;
-                const respawnZ = (Math.random() * 40 - 20) * 4;
+                const respawnX = (Math.random() * 40 - 20) * 2;
+                const respawnZ = (Math.random() * 40 - 20) * 2;
                 hitClient.player.health = 100;
                 hitClient.player.x = respawnX;
                 hitClient.player.y = 1.5;
@@ -2509,9 +2513,9 @@ class FPSRoom extends colyseus.Room {
     this.state.players.forEach((player, sessionId) => {
       player.kills = 0;
       player.health = 100;
-      player.x = (Math.random() * 40 - 20) * 4;
+      player.x = (Math.random() * 40 - 20) * 2;
       player.y = 1.5;
-      player.z = (Math.random() * 40 - 20) * 4;
+      player.z = (Math.random() * 40 - 20) * 2;
       const client = this.clients.find(c => c.sessionId === sessionId);
       if (client) {
         client.send("respawn", { x: player.x, y: player.y, z: player.z });
@@ -2523,9 +2527,9 @@ class FPSRoom extends colyseus.Room {
   onJoin(client, options) {
     const player = new FPSPlayer();
     player.name = options.playerName || "Unknown";
-    player.x = (Math.random() * 40 - 20) * 4;
+    player.x = (Math.random() * 40 - 20) * 2;
     player.y = 1.5;
-    player.z = (Math.random() * 40 - 20) * 4;
+    player.z = (Math.random() * 40 - 20) * 2;
     this.state.players.set(client.sessionId, player);
 
     // Initial spawn pos


### PR DESCRIPTION
Adds a dropdown to choose between Classic, City, or Platforms maps when creating an Arena Shooter server. 
Fixes a bug where players spawn too far out of bounds by decreasing the random spawn bounds to +/- 40 from +/- 80.

---
*PR created automatically by Jules for task [8273859299755397258](https://jules.google.com/task/8273859299755397258) started by @thefoxssss*