### PR TITLE
Fix Wordle keyboard state reset and block invalid guesses

### DIFF
--- a/games/wordle.js
+++ b/games/wordle.js
@@ -126,8 +126,7 @@ function submitGuess() {
 
     if (!WORDS.includes(currentGuess)) {
         showToast("NOT IN WORD LIST", "⚠️");
-        // We still allow it in some versions, but let's be strict
-        // return;
+        return;
     }
 
     guesses.push(currentGuess);
@@ -245,9 +244,8 @@ function updateKeyboard() {
     const keys = document.querySelectorAll('.wordle-key');
     keys.forEach(key => {
         const letter = key.dataset.key;
-        if (keyStates[letter]) {
-            key.className = `wordle-key ${keyStates[letter]}`;
-        }
+        const stateClass = keyStates[letter];
+        key.className = stateClass ? `wordle-key ${stateClass}` : 'wordle-key';
     });
 }
 


### PR DESCRIPTION
### Motivation
- Prevent invalid/non-dictionary guesses from being recorded or consuming an attempt by returning immediately after showing the "NOT IN WORD LIST" toast.
- Ensure keyboard visual state does not leak between rounds by clearing key classes when there is no state for a letter.

### Description
- In `games/wordle.js` updated `submitGuess()` to `return` immediately after showing the "NOT IN WORD LIST" toast so invalid guesses are not pushed to `guesses`.
- In `games/wordle.js` updated `updateKeyboard()` to always set each key's `className` to `'wordle-key'` when there is no corresponding entry in `keyStates`, which clears stale `correct`/`present`/`absent` classes.

### Testing
- Ran `node --check games/wordle.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f65b73e88327abf76b493068cc24)