### PR TITLE
Add throwable grenades to Arena Shooter

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -15,6 +15,9 @@ let ammo = [12, 6, 5]; // Current ammo for each weapon
 let recoilTime = 0;
 let recoilIntensity = 0;
 let bobTime = 0;
+let grenades = 2;
+let nextGrenadeTime = 0;
+let grenadeEffects = [];
 let gameLoopId;
 let initialized = false;
 
@@ -57,6 +60,7 @@ const fpsLeaderboardList = document.getElementById("fpsLeaderboardList");
 const fpsDeathScreen = document.getElementById("fpsDeathScreen");
 const fpsDeathMessage = document.getElementById("fpsDeathMessage");
 const fpsHint = document.getElementById("fpsHint");
+const fpsGrenades = document.getElementById("fpsGrenades");
 
 function getColyseusEndpoint() {
   const mode = networkSelect.value;
@@ -164,6 +168,8 @@ function setupRoom() {
 
   room.onMessage("respawn", (data) => {
     localPlayer.health = 100;
+    grenades = 2;
+    updateGrenadeUI();
     localPlayer.x = data.x;
     localPlayer.y = data.y;
     localPlayer.z = data.z;
@@ -184,6 +190,10 @@ function setupRoom() {
       new THREE.Vector3(data.origin.x, data.origin.y, data.origin.z),
       new THREE.Vector3(data.dir.x, data.dir.y, data.dir.z)
     );
+  });
+
+  room.onMessage("grenadeExplode", (data) => {
+    createGrenadeEffect(new THREE.Vector3(data.x, data.y, data.z));
   });
 
   room.onMessage("mapVotes", (votes) => {
@@ -211,6 +221,8 @@ function setupRoom() {
       localPlayer.id = sessionId;
       localPlayer.health = player.health;
       localPlayer.kills = player.kills;
+      grenades = 2;
+      updateGrenadeUI();
 
       player.listen("health", (val) => {
         localPlayer.health = val;
@@ -585,6 +597,7 @@ function onKeyDown(event) {
     case 'Digit2': switchWeapon(1); break;
     case 'Digit3': switchWeapon(2); break;
     case 'KeyR': startReload(); break;
+    case 'KeyG': throwGrenade(); break;
   }
 }
 
@@ -804,6 +817,38 @@ function onMouseDown(event) {
   }
 }
 
+function updateGrenadeUI() {
+  if (fpsGrenades) fpsGrenades.textContent = String(grenades);
+}
+
+function throwGrenade() {
+  if (!room || localPlayer.health <= 0) return;
+  const now = performance.now();
+  if (now < nextGrenadeTime) return;
+  if (grenades <= 0) return;
+
+  raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
+  const origin = raycaster.ray.origin.clone();
+  const dir = raycaster.ray.direction.clone();
+
+  grenades -= 1;
+  updateGrenadeUI();
+  nextGrenadeTime = now + 2500;
+  room.send("throwGrenade", {
+    origin: { x: origin.x, y: origin.y, z: origin.z },
+    dir: { x: dir.x, y: dir.y, z: dir.z }
+  });
+}
+
+function createGrenadeEffect(position) {
+  const geometry = new THREE.SphereGeometry(0.3, 10, 10);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff8800, transparent: true, opacity: 0.8 });
+  const sphere = new THREE.Mesh(geometry, material);
+  sphere.position.copy(position);
+  scene.add(sphere);
+  grenadeEffects.push({ mesh: sphere, born: performance.now() });
+}
+
 function createTracer(origin, dir, color = 0xffff00) {
   const material = new THREE.LineBasicMaterial({ color: color });
   const points = [];
@@ -828,6 +873,24 @@ function updateTracers(time) {
   }
 }
 
+function updateGrenadeEffects(time) {
+  for (let i = grenadeEffects.length - 1; i >= 0; i--) {
+    const fx = grenadeEffects[i];
+    const age = time - fx.born;
+    if (age > 400) {
+      scene.remove(fx.mesh);
+      fx.mesh.geometry.dispose();
+      fx.mesh.material.dispose();
+      grenadeEffects.splice(i, 1);
+      continue;
+    }
+    const p = age / 400;
+    const scale = 1 + p * 8;
+    fx.mesh.scale.set(scale, scale, scale);
+    fx.mesh.material.opacity = 0.8 * (1 - p);
+  }
+}
+
 function animate() {
   gameLoopId = requestAnimationFrame(animate);
 
@@ -841,6 +904,7 @@ function animate() {
   }
 
   updateTracers(time);
+  updateGrenadeEffects(time);
 
   if (muzzleFlash && muzzleFlash.visible && time - muzzleFlashTime > 50) {
     muzzleFlash.visible = false;
@@ -1017,6 +1081,9 @@ export function initFps() {
   fpsMenu.style.display = "block";
   fpsGame.style.display = "none";
   fpsDeathScreen.style.display = "none";
+  grenades = 2;
+  nextGrenadeTime = 0;
+  updateGrenadeUI();
 
   if (room) {
     room.leave();
@@ -1054,6 +1121,7 @@ window.stopFps = () => {
         scene.remove(scene.children[0]);
     }
   }
+  grenadeEffects = [];
 
   fpsMenu.style.display = "block";
   fpsGame.style.display = "none";

--- a/index.html
+++ b/index.html
@@ -2257,7 +2257,8 @@
           HP: <span id="fpsHealth" style="color: lime;">100</span><br/>
           KILLS: <span id="fpsKills">0</span><br/>
           WEAPON: <span id="fpsWeapon" style="color: yellow;">PISTOL</span><br/>
-          AMMO: <span id="fpsAmmo" style="color: orange;">12/12</span>
+          AMMO: <span id="fpsAmmo" style="color: orange;">12/12</span><br/>
+          GRENADES: <span id="fpsGrenades" style="color: #ff8800;">2</span>
         </div>
         <div id="fpsLeaderboard" style="position: absolute; top: 10px; right: 10px; background: rgba(0,0,0,0.5); color: white; padding: 10px; font-family: monospace; font-size: 12px; pointer-events: none; text-align: right;">
           <div style="border-bottom: 1px solid #fff; margin-bottom: 5px;">LEADERBOARD</div>
@@ -2268,7 +2269,7 @@
           <div style="position: absolute; top: 0; left: 50%; width: 1px; height: 100%; background: rgba(0,0,0,0.8);"></div>
         </div>
         <div id="fpsHint" style="position: absolute; bottom: 10px; width: 100%; text-align: center; color: rgba(255,255,255,0.7); font-family: monospace; font-size: 12px; pointer-events: none;">
-          CLICK TO LOCK MOUSE | WASD: MOVE | CLICK: SHOOT | RCLICK: SCOPE | SPACE: JUMP | 1-3: WEAPONS
+          CLICK TO LOCK MOUSE | WASD: MOVE | CLICK: SHOOT | RCLICK: SCOPE | G: GRENADE | SPACE: JUMP | 1-3: WEAPONS
         </div>
 
         <div id="fpsDeathScreen" style="display: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,0,0,0.4); flex-direction: column; justify-content: center; align-items: center; z-index: 10;">

--- a/server.js
+++ b/server.js
@@ -2427,6 +2427,35 @@ class FPSRoom extends colyseus.Room {
       player.rotY = data.rotY;
     });
 
+    const handleElimination = (shooter, hitClient) => {
+      if (hitClient.player.health > 0) return;
+      hitClient.player.health = 0;
+      shooter.kills += 1;
+
+      if (shooter.kills >= 50 && !this.state.roundOver) {
+        this.state.roundOver = true;
+        this.state.winnerName = shooter.name;
+        setTimeout(() => this.resetRound(), 10000); // 10 seconds to vote
+      }
+
+      const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
+      if (victimClient) {
+        victimClient.send("killed", { killer: shooter.name });
+
+        // Respawn after 3 seconds
+        setTimeout(() => {
+          if (this.state.players.has(hitClient.id) && !this.state.roundOver) {
+            const spawnPos = this.getSafeSpawn(this.state.mapId);
+            hitClient.player.health = 100;
+            hitClient.player.x = spawnPos.x;
+            hitClient.player.y = spawnPos.y;
+            hitClient.player.z = spawnPos.z;
+            victimClient.send("respawn", spawnPos);
+          }
+        }, 3000);
+      }
+    };
+
     this.onMessage("shoot", (client, data) => {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
@@ -2484,35 +2513,48 @@ class FPSRoom extends colyseus.Room {
         if (data.weaponId === 2) damage = 100; // Sniper
 
         hitClient.player.health -= damage;
-        if (hitClient.player.health <= 0) {
-          hitClient.player.health = 0;
-          shooter.kills += 1;
-
-          if (shooter.kills >= 50 && !this.state.roundOver) {
-            this.state.roundOver = true;
-            this.state.winnerName = shooter.name;
-            setTimeout(() => this.resetRound(), 10000); // 10 seconds to vote
-          }
-
-          // Notify the dead client
-          const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
-          if (victimClient) {
-            victimClient.send("killed", { killer: shooter.name });
-
-            // Respawn after 3 seconds
-            setTimeout(() => {
-              if (this.state.players.has(hitClient.id) && !this.state.roundOver) {
-                const spawnPos = this.getSafeSpawn(this.state.mapId);
-                hitClient.player.health = 100;
-                hitClient.player.x = spawnPos.x;
-                hitClient.player.y = spawnPos.y;
-                hitClient.player.z = spawnPos.z;
-                victimClient.send("respawn", spawnPos);
-              }
-            }, 3000);
-          }
-        }
+        handleElimination(shooter, hitClient);
       }
+    });
+
+    this.onMessage("throwGrenade", (client, data) => {
+      if (this.state.roundOver) return;
+      const shooter = this.state.players.get(client.sessionId);
+      if (!shooter || shooter.health <= 0) return;
+
+      const ox = data.origin?.x ?? shooter.x;
+      const oy = data.origin?.y ?? shooter.y + 1;
+      const oz = data.origin?.z ?? shooter.z;
+      const dx = data.dir?.x ?? 0;
+      const dy = data.dir?.y ?? 0;
+      const dz = data.dir?.z ?? -1;
+
+      const throwDistance = 18;
+      const ex = ox + dx * throwDistance;
+      const ey = Math.max(1, oy + dy * throwDistance);
+      const ez = oz + dz * throwDistance;
+
+      this.broadcast("grenadeExplode", {
+        x: ex,
+        y: ey,
+        z: ez,
+        ownerId: client.sessionId
+      });
+
+      const radius = 12;
+      this.state.players.forEach((target, targetId) => {
+        if (target.health <= 0 || targetId === client.sessionId) return;
+        const tx = target.x - ex;
+        const ty = (target.y + 1) - ey;
+        const tz = target.z - ez;
+        const dist = Math.sqrt(tx * tx + ty * ty + tz * tz);
+        if (dist > radius) return;
+
+        const t = 1 - (dist / radius);
+        const damage = Math.max(10, Math.round(90 * t));
+        target.health -= damage;
+        handleElimination(shooter, { id: targetId, player: target });
+      });
     });
 
     fpsServerDirectory.set(this.roomId, {


### PR DESCRIPTION
### Motivation
- Introduce a throwable explosive to diversify combat in the Arena Shooter and provide an area-of-effect damage mechanic for more tactical play.  

### Description
- Implemented server-side grenade handling in `FPSRoom` with a new `throwGrenade` message that computes an explosion point, broadcasts `grenadeExplode`, applies AoE falloff damage, and reuses a new `handleElimination` helper for kill/respawn logic in `server.js`.  
- Added client-side grenade state and controls in `games/fps.js`, including `grenades`, cooldown (`nextGrenadeTime`), `throwGrenade()` to send throws, `createGrenadeEffect()` for visuals, and runtime management of grenade effects.  
- Updated HUD and help text in `index.html` to show grenade count (`fpsGrenades`) and the `G: GRENADE` control hint.  
- Ensured grenade inventory is reset on spawn/respawn and integrated grenade explosion visuals via `grenadeExplode` message handling on the client.  

### Testing
- Ran static checks with `node --check games/fps.js` which succeeded.  
- Ran static checks with `node --check server.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2bce4ecc832ba4cad6bd075b6efe)