### PR TITLE
Replace Arena Shooter platforms map with maze map

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -435,24 +435,37 @@ function loadMap(mapId) {
     createCar(5, 15, carMat1, 0);
     createCar(-5, -15, carMat2, 0);
 
-  } else if (mapId === 2) { // Platforms / Vertical
-    const mat = new THREE.MeshPhongMaterial({ color: 0x882222 });
+  } else if (mapId === 2) { // Maze
+    const wallMat = new THREE.MeshPhongMaterial({ color: 0x7a2233 });
+    const coverMat = new THREE.MeshPhongMaterial({ color: 0x4f1a24 });
+    const wallHeight = 6;
 
-    // Central tower
-    addBox(15, 2, 15, 0, 1, 0, mat);
-    addBox(10, 2, 10, 0, 8, 0, mat);
-    addBox(5, 2, 5, 0, 15, 0, mat);
+    // Outer boundaries
+    addBox(100, wallHeight, 2, 0, wallHeight / 2, -50, wallMat);
+    addBox(100, wallHeight, 2, 0, wallHeight / 2, 50, wallMat);
+    addBox(2, wallHeight, 100, -50, wallHeight / 2, 0, wallMat);
+    addBox(2, wallHeight, 100, 50, wallHeight / 2, 0, wallMat);
 
-    // Ramps/Stairs (approximated as blocks for now)
-    addBox(4, 2, 4, 10, 3, 0, mat);
-    addBox(4, 2, 4, 15, 5, 0, mat);
-    addBox(4, 2, 4, 20, 7, 0, mat);
+    // Maze walls laid out to create multiple loops and flank routes
+    addBox(48, wallHeight, 2, -18, wallHeight / 2, -32, wallMat);
+    addBox(2, wallHeight, 36, -42, wallHeight / 2, -12, wallMat);
+    addBox(2, wallHeight, 30, -20, wallHeight / 2, -3, wallMat);
+    addBox(26, wallHeight, 2, -6, wallHeight / 2, 14, wallMat);
+    addBox(2, wallHeight, 26, 6, wallHeight / 2, -4, wallMat);
+    addBox(28, wallHeight, 2, 22, wallHeight / 2, -22, wallMat);
+    addBox(2, wallHeight, 42, 34, wallHeight / 2, -2, wallMat);
+    addBox(34, wallHeight, 2, 16, wallHeight / 2, 26, wallMat);
+    addBox(2, wallHeight, 24, -4, wallHeight / 2, 34, wallMat);
+    addBox(22, wallHeight, 2, -30, wallHeight / 2, 30, wallMat);
+    addBox(2, wallHeight, 20, -30, wallHeight / 2, 10, wallMat);
+    addBox(14, wallHeight, 2, -34, wallHeight / 2, -2, wallMat);
 
-    // Outer pillars
-    addBox(4, 20, 4, -30, 10, -30, mat);
-    addBox(4, 20, 4, 30, 10, -30, mat);
-    addBox(4, 20, 4, -30, 10, 30, mat);
-    addBox(4, 20, 4, 30, 10, 30, mat);
+    // Mid-lane cover so firefights are less binary in corridors
+    addBox(4, 3, 4, -10, 1.5, -18, coverMat);
+    addBox(4, 3, 4, 12, 1.5, -6, coverMat);
+    addBox(4, 3, 4, 20, 1.5, 16, coverMat);
+    addBox(4, 3, 4, -18, 1.5, 20, coverMat);
+    addBox(4, 3, 4, 0, 1.5, 30, coverMat);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -2242,7 +2242,7 @@
         <select id="fpsMapSelect" class="term-input" style="margin-top: 10px;">
           <option value="0">MAP: CLASSIC</option>
           <option value="1">MAP: CITY</option>
-          <option value="2">MAP: PLATFORMS</option>
+          <option value="2">MAP: MAZE</option>
         </select>
         <input type="text" id="fpsServerName" class="term-input" placeholder="NEW SERVER NAME" maxlength="24" />
         <button class="term-btn" id="btnCreateFpsServer">CREATE SERVER</button>
@@ -2286,7 +2286,7 @@
             <div style="display: flex; gap: 10px;">
               <button class="term-btn" onclick="window.voteMap(0)">CLASSIC <span id="mapVote0">(0)</span></button>
               <button class="term-btn" onclick="window.voteMap(1)">CITY <span id="mapVote1">(0)</span></button>
-              <button class="term-btn" onclick="window.voteMap(2)">PLATFORMS <span id="mapVote2">(0)</span></button>
+              <button class="term-btn" onclick="window.voteMap(2)">MAZE <span id="mapVote2">(0)</span></button>
             </div>
           </div>
         </div>

--- a/server.js
+++ b/server.js
@@ -2349,7 +2349,7 @@ class FPSState extends schema.Schema {
   constructor() {
     super();
     this.players = new schema.MapSchema();
-    this.mapId = 0; // 0 = Classic, 1 = City, 2 = Platforms
+    this.mapId = 0; // 0 = Classic, 1 = City, 2 = Maze
     this.roundOver = false;
     this.winnerName = "";
   }
@@ -2386,8 +2386,20 @@ class FPSRoom extends colyseus.Room {
       const road = safeRoads[Math.floor(Math.random() * safeRoads.length)];
       x = road.xMin + Math.random() * (road.xMax - road.xMin);
       z = road.zMin + Math.random() * (road.zMax - road.zMin);
-    } else if (mapId === 2) {
-      y = 15; // platforms map spawns you higher up
+    } else if (mapId === 2) { // Maze
+      const mazeSpawns = [
+        { x: -38, z: -38 },
+        { x: 38, z: -38 },
+        { x: -38, z: 38 },
+        { x: 38, z: 38 },
+        { x: -6, z: -30 },
+        { x: 28, z: 22 },
+        { x: -26, z: 18 },
+        { x: 8, z: -10 }
+      ];
+      const spawn = mazeSpawns[Math.floor(Math.random() * mazeSpawns.length)];
+      x = spawn.x + (Math.random() * 4 - 2);
+      z = spawn.z + (Math.random() * 4 - 2);
     }
 
     return { x, y, z };


### PR DESCRIPTION
### Motivation
- Convert the Arena Shooter "Platforms" map into a corridor-style maze to change gameplay flow and create more tactical indoor skirmishes.
- Update server spawn logic so players spawn in grounded maze-safe positions instead of high platform spawns.

### Description
- Renamed the map option and vote label from `PLATFORMS` to `MAZE` in the FPS overlay UI (`index.html`).
- Replaced the `mapId === 2` client geometry in `games/fps.js` with a maze layout that includes outer boundaries, interior corridor walls, and small cover props (new wall/cover materials and sizes).
- Updated server-side map metadata/comment and `getSafeSpawn` for `mapId === 2` in `server.js` to pick from fixed grounded maze spawn points with a small random offset.
- Files modified: `index.html`, `games/fps.js`, and `server.js`.

### Testing
- Ran `node --check games/fps.js` and it completed successfully.
- Ran `node --check server.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4cafc72c8330ae4a9306b40771e1)