### PR TITLE
Add hold-to-fire support for FPS gatling gun

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -19,6 +19,7 @@ let grenades = 2;
 let nextGrenadeTime = 0;
 let grenadeEffects = [];
 let gatlingMovementLockUntil = 0;
+let isPrimaryFireHeld = false;
 let gameLoopId;
 let initialized = false;
 
@@ -779,6 +780,9 @@ function onKeyUp(event) {
 }
 
 function onMouseUp(event) {
+  if (event.button === 0) {
+    isPrimaryFireHeld = false;
+  }
   if (event.button === 2) {
     if (WEAPONS[localPlayer.weapon].name === "SNIPER") {
       unzoomSniper();
@@ -786,29 +790,14 @@ function onMouseUp(event) {
   }
 }
 
-function onMouseDown(event) {
+function tryFireWeapon() {
   if (!controls.isLocked) return;
   if (localPlayer.health <= 0) return;
-
-  if (event.button === 2) {
-    if (WEAPONS[localPlayer.weapon].name === "SNIPER") {
-      isSniperZoomed = true;
-      camera.fov = 20;
-      camera.updateProjectionMatrix();
-      if (gunMesh) gunMesh.visible = false;
-      document.getElementById("fpsScopeOverlay").style.display = "block";
-    }
-    return;
-  }
-
-  if (event.button !== 0) return; // Left click only
-
   if (isReloading) return; // Cannot fire while reloading
 
+  const weapon = WEAPONS[localPlayer.weapon];
   const now = performance.now();
   if (now < nextFireTime) return;
-
-  const weapon = WEAPONS[localPlayer.weapon];
 
   // Check Ammo
   if (ammo[localPlayer.weapon] <= 0) {
@@ -862,6 +851,27 @@ function onMouseDown(event) {
       weaponId: localPlayer.weapon
     });
   }
+}
+
+function onMouseDown(event) {
+  if (!controls.isLocked) return;
+  if (localPlayer.health <= 0) return;
+
+  if (event.button === 2) {
+    if (WEAPONS[localPlayer.weapon].name === "SNIPER") {
+      isSniperZoomed = true;
+      camera.fov = 20;
+      camera.updateProjectionMatrix();
+      if (gunMesh) gunMesh.visible = false;
+      document.getElementById("fpsScopeOverlay").style.display = "block";
+    }
+    return;
+  }
+
+  if (event.button !== 0) return; // Left click only
+
+  isPrimaryFireHeld = true;
+  tryFireWeapon();
 }
 
 function updateGrenadeUI() {
@@ -1121,6 +1131,10 @@ function animate() {
     gunMesh.rotation.x += (targetRotX - gunMesh.rotation.x) * dampFactor;
   }
 
+  if (isPrimaryFireHeld && localPlayer.weapon === 3) {
+    tryFireWeapon();
+  }
+
   renderer.render(scene, camera);
   prevTime = time;
 }
@@ -1132,6 +1146,7 @@ export function initFps() {
   grenades = 2;
   nextGrenadeTime = 0;
   gatlingMovementLockUntil = 0;
+  isPrimaryFireHeld = false;
   updateGrenadeUI();
 
   if (room) {
@@ -1164,6 +1179,7 @@ window.stopFps = () => {
   document.removeEventListener('keyup', onKeyUp);
   document.removeEventListener('mousedown', onMouseDown);
   document.removeEventListener('mouseup', onMouseUp);
+  isPrimaryFireHeld = false;
 
   if (scene) {
      while(scene.children.length > 0){


### PR DESCRIPTION
### Motivation

- Enable continuous firing for the Gatling weapon when the player holds the primary fire button instead of requiring repeated clicks.

### Description

- Added a held-fire flag `isPrimaryFireHeld` and refactored firing logic into a reusable `tryFireWeapon()` helper in `games/fps.js`.
- Updated input handlers so left mouse down sets `isPrimaryFireHeld` and triggers `tryFireWeapon()`, and left mouse up clears `isPrimaryFireHeld`, while preserving right-click sniper zoom behavior.
- Call `tryFireWeapon()` from the main loop when the fire button is held and the Gatling weapon (`weapon id 3`) is equipped to allow continuous fire, and reset the held state in `initFps()` and `stopFps()` to avoid sticky input.
- All changes are contained in `games/fps.js`.

### Testing

- Ran `node --check games/fps.js` to validate the modified file has no syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea737a78dc8330ac682af165c9417f)