### PR TITLE
Fix Arena Shooter CTF wiring and client flag updates

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -46,6 +46,10 @@ let tracers = [];
 
 let obstaclesGroup;
 let obstacleBoxes = [];
+let smokeParticles = [];
+let redFlagMesh = null;
+let blueFlagMesh = null;
+let currentGrenadeType = 0;
 
 const networkSelect = document.getElementById("fpsNetwork");
 const btnRefresh = document.getElementById("btnRefreshFpsServers");
@@ -172,6 +176,7 @@ function setupRoom() {
   room.onMessage("respawn", (data) => {
     localPlayer.health = 100;
     grenades = 2;
+    currentGrenadeType = 0;
     updateGrenadeUI();
     localPlayer.x = data.x;
     localPlayer.y = data.y;
@@ -221,6 +226,7 @@ function setupRoom() {
     document.getElementById("mapVote2").textContent = `(${votes[2]})`;
     if (document.getElementById("mapVote3")) document.getElementById("mapVote3").textContent = `(${votes[3] || 0})`;
     if (document.getElementById("mapVote4")) document.getElementById("mapVote4").textContent = `(${votes[4] || 0})`;
+    if (document.getElementById("mapVote5")) document.getElementById("mapVote5").textContent = `(${votes[5] || 0})`;
   });
 
   room.state.listen("roundOver", (isOver) => {
@@ -482,6 +488,18 @@ function loadMap(mapId) {
     if (mesh.material) mesh.material.dispose();
   }
   obstacleBoxes = [];
+  if (redFlagMesh) {
+    scene.remove(redFlagMesh);
+    if (redFlagMesh.geometry) redFlagMesh.geometry.dispose();
+    if (redFlagMesh.material) redFlagMesh.material.dispose();
+    redFlagMesh = null;
+  }
+  if (blueFlagMesh) {
+    scene.remove(blueFlagMesh);
+    if (blueFlagMesh.geometry) blueFlagMesh.geometry.dispose();
+    if (blueFlagMesh.material) blueFlagMesh.material.dispose();
+    blueFlagMesh = null;
+  }
 
   const addBox = (w, h, d, x, y, z, mat, userData = {}) => {
     const geo = new THREE.BoxGeometry(w, h, d);
@@ -1489,6 +1507,7 @@ function animate() {
 
   updateTracers(time);
   updateGrenadeEffects(time);
+  updateFlagPositions();
 
   if (muzzleFlash && muzzleFlash.visible && time - muzzleFlashTime > 50) {
     muzzleFlash.visible = false;

--- a/index.html
+++ b/index.html
@@ -2245,6 +2245,7 @@
           <option value="2">MAP: MAZE</option>
           <option value="3">MAP: SPACE STATION</option>
           <option value="4">MAP: SNIPER TOWER</option>
+          <option value="5">MAP: CTF TWO FORTS</option>
         </select>
         <input type="text" id="fpsServerName" class="term-input" placeholder="NEW SERVER NAME" maxlength="24" />
         <button class="term-btn" id="btnCreateFpsServer">CREATE SERVER</button>
@@ -2291,6 +2292,7 @@
               <button class="term-btn" onclick="window.voteMap(2)">MAZE <span id="mapVote2">(0)</span></button>
               <button class="term-btn" onclick="window.voteMap(3)">SPACE <span id="mapVote3">(0)</span></button>
               <button class="term-btn" onclick="window.voteMap(4)">SNIPER <span id="mapVote4">(0)</span></button>
+              <button class="term-btn" onclick="window.voteMap(5)">CTF <span id="mapVote5">(0)</span></button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- The CTF (map ID `5`) frontend was only partially wired which caused missing UI options, stale or undefined client state (flag meshes / grenade type), and flag visuals not updating during gameplay.

### Description
- Added client-side declarations for `smokeParticles`, `redFlagMesh`, `blueFlagMesh`, and `currentGrenadeType` in `games/fps.js` to prevent runtime reference errors.
- Reset `currentGrenadeType` on respawn and added cleanup code to remove/dispose flag meshes when a map is reloaded in `loadMap` to avoid stale objects.
- Wired `updateFlagPositions()` into the render loop (`animate()`) so flag visuals follow server state changes in real time and updated the `mapVotes` handler to render `mapVote5` counts.
- Exposed the CTF map in the UI by adding `MAP: CTF TWO FORTS` to the `fpsMapSelect` and adding a round-end vote button for map ID `5` in `index.html`.

### Testing
- Ran `node --check games/fps.js` which succeeded.
- Ran `node --check server.js` which succeeded.
- Ran `python verify_cuj.py` which failed in this environment with `ModuleNotFoundError: No module named 'playwright'` so end-to-end browser verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa91841d48327b61037e1af1964cf)