### PR TITLE
Enable anti-aliasing for FPS renderer

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -884,7 +884,7 @@ function initThreeJs() {
 
   camera = new THREE.PerspectiveCamera(75, 800 / 450, 0.1, 1000);
 
-  renderer = new THREE.WebGLRenderer({ canvas: fpsCanvas, antialias: false });
+  renderer = new THREE.WebGLRenderer({ canvas: fpsCanvas, antialias: true });
   renderer.setSize(800, 450);
   renderer.shadowMap.enabled = true;
 


### PR DESCRIPTION
### Motivation
- Improve visual quality of the FPS game by reducing jagged edges via renderer anti-aliasing.

### Description
- Flip the Three.js WebGLRenderer option from `antialias: false` to `antialias: true` in `initThreeJs()` in `games/fps.js` to enable MSAA-based smoothing.

### Testing
- Ran `node --check games/fps.js` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaac94af8832b9f9dc11420bde458)