### PR TITLE
Add CTF teams, HUD, friendly-fire rules and improved CTF map

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -4,7 +4,7 @@ let room = null;
 let scene, camera, renderer, controls;
 let raycaster;
 let floorMesh;
-let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0 };
+let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0, team: 0 };
 let otherPlayers = {}; // id -> { mesh, data }
 let gunMesh;
 let muzzleFlash, muzzleLight;
@@ -68,6 +68,9 @@ const fpsDeathScreen = document.getElementById("fpsDeathScreen");
 const fpsDeathMessage = document.getElementById("fpsDeathMessage");
 const fpsHint = document.getElementById("fpsHint");
 const fpsGrenades = document.getElementById("fpsGrenades");
+const fpsTeam = document.getElementById("fpsTeam");
+const fpsObjective = document.getElementById("fpsObjective");
+const fpsCtfScore = document.getElementById("fpsCtfScore");
 
 function getColyseusEndpoint() {
   const mode = networkSelect.value;
@@ -241,15 +244,21 @@ function setupRoom() {
 
   room.state.listen("mapId", (mapId) => {
     loadMap(mapId);
+    updateCtfHud();
   });
+
+  room.state.listen("redScore", updateCtfHud);
+  room.state.listen("blueScore", updateCtfHud);
 
   room.state.players.onAdd((player, sessionId) => {
     if (sessionId === room.sessionId) {
       localPlayer.id = sessionId;
       localPlayer.health = player.health;
       localPlayer.kills = player.kills;
+      localPlayer.team = player.team;
       grenades = 2;
       updateGrenadeUI();
+      updateCtfHud();
 
       player.listen("health", (val) => {
         localPlayer.health = val;
@@ -262,13 +271,17 @@ function setupRoom() {
           switchWeapon(0);
         }
       });
+      player.listen("team", (val) => {
+        localPlayer.team = val;
+        updateCtfHud();
+      });
 
     } else {
       // Create mesh for other player
       const playerGroup = new THREE.Group();
 
       const geometry = new THREE.BoxGeometry(1, 2, 1);
-      const material = new THREE.MeshLambertMaterial({ color: 0xff0000 });
+      const material = new THREE.MeshLambertMaterial({ color: player.team === 1 ? 0xff3333 : (player.team === 2 ? 0x3333ff : 0xaaaaaa) });
       const mesh = new THREE.Mesh(geometry, material);
       playerGroup.add(mesh);
 
@@ -297,6 +310,9 @@ function setupRoom() {
         nameSprite = createNameSprite(val);
         playerGroup.add(nameSprite);
       });
+      player.listen("team", (val) => {
+        material.color.setHex(val === 1 ? 0xff3333 : (val === 2 ? 0x3333ff : 0xaaaaaa));
+      });
       // Hide if dead
       player.listen("health", (val) => playerGroup.visible = val > 0);
     }
@@ -319,6 +335,8 @@ function setupRoom() {
     }
     updateLeaderboard();
   });
+
+  updateCtfHud();
 }
 
 function updateLeaderboard() {
@@ -330,6 +348,31 @@ function updateLeaderboard() {
   fpsLeaderboardList.innerHTML = players.map(p =>
     `<div>${escapeHtml(p.name)}: ${p.kills}</div>`
   ).join("");
+}
+
+function teamLabel(teamId) {
+  if (teamId === 1) return "RED";
+  if (teamId === 2) return "BLUE";
+  return "FFA";
+}
+
+function updateCtfHud() {
+  if (!fpsTeam || !fpsObjective || !fpsCtfScore) return;
+  const mapId = room?.state?.mapId ?? 0;
+  fpsTeam.textContent = teamLabel(localPlayer.team);
+  fpsTeam.style.color = localPlayer.team === 1 ? "#ff6666" : (localPlayer.team === 2 ? "#6666ff" : "#bbbbbb");
+
+  if (mapId === 5) {
+    fpsObjective.textContent = "CAPTURE THE FLAG";
+    fpsObjective.style.color = "#ffff66";
+    fpsCtfScore.style.display = "inline";
+    fpsCtfScore.textContent = `RED ${room.state.redScore} - ${room.state.blueScore} BLUE`;
+    fpsCtfScore.style.color = "#ffffff";
+  } else {
+    fpsObjective.textContent = "DEATHMATCH";
+    fpsObjective.style.color = "#bbbbbb";
+    fpsCtfScore.style.display = "none";
+  }
 }
 
 // Procedural textures
@@ -800,52 +843,51 @@ function loadMap(mapId) {
     const bridgeMat = new THREE.MeshPhongMaterial({ map: getTexture("metal"), color: 0x555555 });
     const coverMat = new THREE.MeshPhongMaterial({ map: getTexture("concrete"), color: 0x666666 });
 
-    // Red Fort (Left side)
-    // Front Wall with gap
-    addBox(20, 8, 2, -30, 4, 15, redBaseMat);
-    addBox(20, 8, 2, -30, 4, -15, redBaseMat);
-    // Back Wall
-    addBox(40, 8, 2, -50, 4, 0, redBaseMat);
-    // Side Walls
-    addBox(2, 8, 50, -40, 4, 24, redBaseMat);
-    addBox(2, 8, 50, -40, 4, -24, redBaseMat);
-    // Upper Balcony (Sniper nest)
-    addBox(40, 1, 10, -45, 8.5, 0, redBaseMat);
-    addBox(4, 1, 10, -35, 4, 0, redBaseMat); // Ramp block
-    addBox(4, 1, 10, -39, 6, 0, redBaseMat); // Ramp block 2
+    // Arena bounds
+    addBox(2, 10, 140, -70, 5, 0, wallMat);
+    addBox(2, 10, 140, 70, 5, 0, wallMat);
+    addBox(140, 10, 2, 0, 5, -70, wallMat);
+    addBox(140, 10, 2, 0, 5, 70, wallMat);
 
-    // Blue Fort (Right side)
-    // Front Wall with gap
-    addBox(20, 8, 2, 30, 4, 15, blueBaseMat);
-    addBox(20, 8, 2, 30, 4, -15, blueBaseMat);
-    // Back Wall
-    addBox(40, 8, 2, 50, 4, 0, blueBaseMat);
-    // Side Walls
-    addBox(2, 8, 50, 40, 4, 24, blueBaseMat);
-    addBox(2, 8, 50, 40, 4, -24, blueBaseMat);
-    // Upper Balcony (Sniper nest)
-    addBox(40, 1, 10, 45, 8.5, 0, blueBaseMat);
-    addBox(4, 1, 10, 35, 4, 0, blueBaseMat); // Ramp block
-    addBox(4, 1, 10, 39, 6, 0, blueBaseMat); // Ramp block 2
+    // Red fort
+    addBox(22, 8, 2, -38, 4, 18, redBaseMat);
+    addBox(22, 8, 2, -38, 4, -18, redBaseMat);
+    addBox(2, 8, 38, -49, 4, 0, redBaseMat);
+    addBox(2, 8, 38, -27, 4, 0, redBaseMat);
+    addBox(22, 1, 12, -38, 8.5, 0, redBaseMat);
+    addBox(6, 2, 8, -33, 2, 0, coverMat);
+    addBox(6, 2, 8, -43, 2, 0, coverMat);
 
-    // Center Map Elements (No Man's Land)
-    // High Bridge linking sniper nests
-    addBox(60, 1, 8, 0, 8.5, 0, bridgeMat);
-    // Bridge Cover
-    addBox(2, 2, 8, -10, 10, 0, coverMat);
-    addBox(2, 2, 8, 10, 10, 0, coverMat);
+    // Blue fort
+    addBox(22, 8, 2, 38, 4, 18, blueBaseMat);
+    addBox(22, 8, 2, 38, 4, -18, blueBaseMat);
+    addBox(2, 8, 38, 49, 4, 0, blueBaseMat);
+    addBox(2, 8, 38, 27, 4, 0, blueBaseMat);
+    addBox(22, 1, 12, 38, 8.5, 0, blueBaseMat);
+    addBox(6, 2, 8, 33, 2, 0, coverMat);
+    addBox(6, 2, 8, 43, 2, 0, coverMat);
 
-    // Lower Center Obstacles (Trenches & Cover)
-    addBox(8, 4, 4, 0, 2, 10, wallMat);
-    addBox(8, 4, 4, 0, 2, -10, wallMat);
-    addBox(4, 4, 8, 0, 2, 25, wallMat);
-    addBox(4, 4, 8, 0, 2, -25, wallMat);
+    // Mid bridge and lower lane
+    addBox(52, 1, 10, 0, 8.5, 0, bridgeMat);
+    addBox(10, 3, 3, -10, 2, 0, wallMat);
+    addBox(10, 3, 3, 10, 2, 0, wallMat);
+    addBox(10, 3, 3, 0, 2, 14, wallMat);
+    addBox(10, 3, 3, 0, 2, -14, wallMat);
 
-    // Flank Routes Cover
-    addBox(6, 3, 2, -15, 1.5, 20, coverMat);
-    addBox(6, 3, 2, 15, 1.5, 20, coverMat);
-    addBox(6, 3, 2, -15, 1.5, -20, coverMat);
-    addBox(6, 3, 2, 15, 1.5, -20, coverMat);
+    // Side flank routes and jump pads
+    addBox(2, 3, 40, -12, 1.5, 38, coverMat);
+    addBox(2, 3, 40, 12, 1.5, -38, coverMat);
+    const jumpPadMat = new THREE.MeshPhongMaterial({ color: 0x00ffaa, emissive: 0x00ffaa, emissiveIntensity: 0.4 });
+    addBox(4, 0.5, 4, -12, 0.25, 38, jumpPadMat, { isJumpPad: true, boostX: 200, boostZ: -220 });
+    addBox(4, 0.5, 4, 12, 0.25, -38, jumpPadMat, { isJumpPad: true, boostX: -200, boostZ: 220 });
+
+    // Symmetric cover fields
+    const coverSpots = [
+      [-22, 18], [-22, -18], [22, 18], [22, -18],
+      [-8, 28], [-8, -28], [8, 28], [8, -28],
+      [-30, 34], [-30, -34], [30, 34], [30, -34]
+    ];
+    coverSpots.forEach(([x, z]) => addBox(6, 3, 3, x, 1.5, z, coverMat));
 
     // Create physical flag models so they can be seen holding or dropped
     const flagGeo = new THREE.CylinderGeometry(0.1, 0.1, 3);
@@ -1508,6 +1550,7 @@ function animate() {
   updateTracers(time);
   updateGrenadeEffects(time);
   updateFlagPositions();
+  updateCtfHud();
 
   if (muzzleFlash && muzzleFlash.visible && time - muzzleFlashTime > 50) {
     muzzleFlash.visible = false;
@@ -1724,7 +1767,9 @@ export function initFps() {
   nextGrenadeTime = 0;
   gatlingMovementLockUntil = 0;
   isPrimaryFireHeld = false;
+  localPlayer.team = 0;
   updateGrenadeUI();
+  updateCtfHud();
 
   if (room) {
     room.leave();

--- a/index.html
+++ b/index.html
@@ -2259,6 +2259,9 @@
         <div id="fpsUI" style="position: absolute; top: 10px; left: 10px; color: white; font-family: monospace; font-size: 16px; text-shadow: 1px 1px 0 #000; pointer-events: none; text-align: left;">
           HP: <span id="fpsHealth" style="color: lime;">100</span><br/>
           KILLS: <span id="fpsKills">0</span><br/>
+          TEAM: <span id="fpsTeam" style="color: #bbbbbb;">FFA</span><br/>
+          MODE: <span id="fpsObjective" style="color: #bbbbbb;">DEATHMATCH</span><br/>
+          CTF: <span id="fpsCtfScore" style="color: #bbbbbb;">RED 0 - 0 BLUE</span><br/>
           WEAPON: <span id="fpsWeapon" style="color: yellow;">PISTOL</span><br/>
           AMMO: <span id="fpsAmmo" style="color: orange;">12/12</span><br/>
           GRENADES: <span id="fpsGrenades" style="color: #ff8800;">2</span>

--- a/server.js
+++ b/server.js
@@ -2432,6 +2432,16 @@ schema.defineTypes(FPSState, {
 });
 
 class FPSRoom extends colyseus.Room {
+  getBalancedTeam() {
+    let redCount = 0;
+    let blueCount = 0;
+    this.state.players.forEach((p) => {
+      if (p.team === 1) redCount++;
+      if (p.team === 2) blueCount++;
+    });
+    return redCount <= blueCount ? 1 : 2;
+  }
+
   getSafeSpawn(mapId, team = 0) {
     let x = (Math.random() * 40 - 20) * 2;
     let z = (Math.random() * 40 - 20) * 2;
@@ -2822,35 +2832,6 @@ class FPSRoom extends colyseus.Room {
       player.rotY = data.rotY;
     });
 
-    const handleElimination = (shooter, hitClient) => {
-      if (hitClient.player.health > 0) return;
-      hitClient.player.health = 0;
-      shooter.kills += 1;
-
-      if (shooter.kills >= 50 && !this.state.roundOver) {
-        this.state.roundOver = true;
-        this.state.winnerName = shooter.name;
-        setTimeout(() => this.resetRound(), 10000); // 10 seconds to vote
-      }
-
-      const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
-      if (victimClient) {
-        victimClient.send("killed", { killer: shooter.name });
-
-        // Respawn after 3 seconds
-        setTimeout(() => {
-          if (this.state.players.has(hitClient.id) && !this.state.roundOver) {
-            const spawnPos = this.getSafeSpawn(this.state.mapId);
-            hitClient.player.health = 100;
-            hitClient.player.x = spawnPos.x;
-            hitClient.player.y = spawnPos.y;
-            hitClient.player.z = spawnPos.z;
-            victimClient.send("respawn", spawnPos);
-          }
-        }, 3000);
-      }
-    };
-
     this.onMessage("shoot", (client, data) => {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
@@ -2871,6 +2852,7 @@ class FPSRoom extends colyseus.Room {
 
       this.state.players.forEach((target, targetId) => {
         if (targetId === client.sessionId || target.health <= 0) return;
+        if (this.state.mapId === 5 && shooter.team !== 0 && shooter.team === target.team) return;
 
         // Vector from origin to target
         const vx = target.x - ox;
@@ -2906,9 +2888,23 @@ class FPSRoom extends colyseus.Room {
         let damage = 25;
         if (data.weaponId === 1) damage = 20; // Shotgun per bullet
         if (data.weaponId === 2) damage = 100; // Sniper
+        const target = hitClient.player;
 
-        hitClient.player.health -= damage;
-        handleElimination(shooter, hitClient);
+        if (target.armor > 0) {
+          const armorDmg = Math.min(target.armor, damage);
+          target.armor -= armorDmg;
+          target.health -= (damage - armorDmg);
+        } else {
+          target.health -= damage;
+        }
+
+        if (target.health > 0) {
+          client.send("hitmarker", { killed: false });
+        } else {
+          client.send("hitmarker", { killed: true });
+          const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
+          this.handleElimination(shooter, client, target, victimClient);
+        }
       }
     });
 
@@ -2931,6 +2927,7 @@ class FPSRoom extends colyseus.Room {
       const radius = 15;
       this.state.players.forEach((target, targetId) => {
         if (target.health <= 0) return;
+        if (this.state.mapId === 5 && shooter.team !== 0 && shooter.team === target.team && targetId !== client.sessionId) return;
         const tx = target.x - ex;
         const ty = (target.y + 1) - ey;
         const tz = target.z - ez;
@@ -2939,8 +2936,17 @@ class FPSRoom extends colyseus.Room {
 
         const t = 1 - (dist / radius);
         const damage = Math.max(20, Math.round(100 * t));
-        target.health -= damage;
-        handleElimination(shooter, { id: targetId, player: target });
+        if (target.armor > 0) {
+          const armorDmg = Math.min(target.armor, damage);
+          target.armor -= armorDmg;
+          target.health -= (damage - armorDmg);
+        } else {
+          target.health -= damage;
+        }
+        if (target.health <= 0) {
+          const victimClient = this.clients.find(c => c.sessionId === targetId);
+          this.handleElimination(shooter, client, target, victimClient);
+        }
       });
     });
 
@@ -3023,6 +3029,8 @@ class FPSRoom extends colyseus.Room {
       player.armor = 0;
       if (this.state.mapId !== 5) {
         player.team = 0;
+      } else if (player.team === 0) {
+        player.team = this.getBalancedTeam();
       }
       const spawnPos = this.getSafeSpawn(this.state.mapId, player.team);
       player.x = spawnPos.x;
@@ -3039,6 +3047,9 @@ class FPSRoom extends colyseus.Room {
   onJoin(client, options) {
     const player = new FPSPlayer();
     player.name = options.playerName || "Unknown";
+    if (this.state.mapId === 5) {
+      player.team = this.getBalancedTeam();
+    }
     const spawnPos = this.getSafeSpawn(this.state.mapId, player.team);
     player.x = spawnPos.x;
     player.y = spawnPos.y;
@@ -3061,7 +3072,7 @@ class FPSRoom extends colyseus.Room {
       d.clients = this.clients.length;
       d.players = [];
       this.state.players.forEach((player) => {
-        d.players.push({ name: player.name });
+        d.players.push({ name: player.name, team: player.team });
       });
       fpsServerDirectory.set(this.roomId, d);
     }


### PR DESCRIPTION
### Motivation
- Restore a proper RED vs BLUE CTF mode with visible flags, team assignment and no-friendly-fire so CTF plays like a real capture-the-flag mode.
- Make the client HUD and player rendering reflect team/objective state so players can see team, objective and score in-game.
- Improve the CTF map layout to create clearer lanes, flanks and bridge control for better gameplay.

### Description
- Add HUD elements in `index.html` (`#fpsTeam`, `#fpsObjective`, `#fpsCtfScore`) and wire them up in `games/fps.js` via `updateCtfHud()` to display team, mode and CTF score from room state.
- Track team on the client by adding `team` to `localPlayer`, color-code other player meshes by team, and listen for `team`, `mapId`, `redScore` and `blueScore` changes to update visuals and HUD in `games/fps.js`.
- Replace the old CTF map geometry for `mapId === 5` with a redesigned two-fort arena (bounds, symmetric forts, mid-bridge, flank routes, jump pads and symmetric cover) while preserving visible flag meshes in `games/fps.js`.
- Server-side changes in `server.js` include `getBalancedTeam()` and auto-assigning balanced teams on join/reset, including `team` in FPS server metadata, enforcing no-friendly-fire checks for hitscan and barrel/explosion splash on the CTF map, and routing kills through the authoritative elimination handling that also drops flags and respawns correctly.

### Testing
- Ran `node --check games/fps.js` and it completed without syntax errors (success).
- Ran `node --check server.js` and it completed without syntax errors (success).
- Attempted `node --check index.html` but this is not applicable because `node --check` does not support `.html` files (not runable with Node).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efab22db7c83278d1465bc3d6e9148)