### PR TITLE
Fix FPS fullscreen render resolution scaling

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -23,6 +23,7 @@ let gatlingMovementLockUntil = 0;
 let isPrimaryFireHeld = false;
 let gameLoopId;
 let initialized = false;
+let handleFpsResize = null;
 
 let moveForward = false;
 let moveBackward = false;
@@ -885,7 +886,19 @@ function initThreeJs() {
   camera = new THREE.PerspectiveCamera(75, 800 / 450, 0.1, 1000);
 
   renderer = new THREE.WebGLRenderer({ canvas: fpsCanvas, antialias: true });
-  renderer.setSize(800, 450);
+  const updateRendererSize = () => {
+    const width = Math.max(1, Math.floor(fpsGame.clientWidth || 800));
+    const height = Math.max(1, Math.floor(fpsGame.clientHeight || 450));
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    renderer.setPixelRatio(pixelRatio);
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  };
+  handleFpsResize = updateRendererSize;
+  updateRendererSize();
+  window.addEventListener("resize", updateRendererSize);
+  document.addEventListener("fullscreenchange", updateRendererSize);
   renderer.shadowMap.enabled = true;
 
   // Lights
@@ -1756,6 +1769,11 @@ window.stopFps = () => {
   document.removeEventListener('keyup', onKeyUp);
   document.removeEventListener('mousedown', onMouseDown);
   document.removeEventListener('mouseup', onMouseUp);
+  if (handleFpsResize) {
+    window.removeEventListener("resize", handleFpsResize);
+    document.removeEventListener("fullscreenchange", handleFpsResize);
+    handleFpsResize = null;
+  }
   isPrimaryFireHeld = false;
 
   if (scene) {


### PR DESCRIPTION
### Motivation
- Fullscreen FPS view was rendering at a fixed 800x450 backbuffer and not honoring device pixel ratio, causing blurry/low-res output on fullscreen and high-DPI displays.

### Description
- Replace the hardcoded `renderer.setSize(800, 450)` with a live `updateRendererSize` function that sizes the renderer from the `#fpsGame` container and updates `camera.aspect` and projection.
- Apply `renderer.setPixelRatio(...)` using `window.devicePixelRatio` capped at `2` to improve clarity on high-DPI screens.
- Hook `window.resize` and `document.fullscreenchange` to call `updateRendererSize` while FPS is active and call `updateRendererSize()` once during initialization.
- Add a module-level `handleFpsResize` reference and remove the resize/fullscreen listeners in `window.stopFps` to ensure proper cleanup.

### Testing
- Verified the modified file parses as an ES module using Acorn with `node -e "const acorn=require('acorn');const fs=require('fs');acorn.parse(fs.readFileSync('games/fps.js','utf8'),{ecmaVersion:'latest',sourceType:'module'});console.log('acorn parse ok');"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efabdeacc4832b8378c3578298ff74)