### PR TITLE
Add CTF/team support: UI, client logic, map redesign and server team rules

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -4,7 +4,7 @@ let room = null;
 let scene, camera, renderer, controls;
 let raycaster;
 let floorMesh;
-let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0 };
+let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0, team: 0 };
 let otherPlayers = {}; // id -> { mesh, data }
 let gunMesh;
 let muzzleFlash, muzzleLight;
@@ -68,6 +68,10 @@ const fpsDeathScreen = document.getElementById("fpsDeathScreen");
 const fpsDeathMessage = document.getElementById("fpsDeathMessage");
 const fpsHint = document.getElementById("fpsHint");
 const fpsGrenades = document.getElementById("fpsGrenades");
+const fpsTeam = document.getElementById("fpsTeam");
+const fpsObjective = document.getElementById("fpsObjective");
+const fpsCtfScore = document.getElementById("fpsCtfScore");
+const fpsTeamSelect = document.getElementById("fpsTeamSelect");
 
 function getColyseusEndpoint() {
   const mode = networkSelect.value;
@@ -241,15 +245,23 @@ function setupRoom() {
 
   room.state.listen("mapId", (mapId) => {
     loadMap(mapId);
+    updateCtfHud();
+    updateTeamSelectUI();
   });
+
+  room.state.listen("redScore", updateCtfHud);
+  room.state.listen("blueScore", updateCtfHud);
 
   room.state.players.onAdd((player, sessionId) => {
     if (sessionId === room.sessionId) {
       localPlayer.id = sessionId;
       localPlayer.health = player.health;
       localPlayer.kills = player.kills;
+      localPlayer.team = player.team;
       grenades = 2;
       updateGrenadeUI();
+      updateCtfHud();
+      updateTeamSelectUI();
 
       player.listen("health", (val) => {
         localPlayer.health = val;
@@ -262,13 +274,18 @@ function setupRoom() {
           switchWeapon(0);
         }
       });
+      player.listen("team", (val) => {
+        localPlayer.team = val;
+        updateCtfHud();
+        updateTeamSelectUI();
+      });
 
     } else {
       // Create mesh for other player
       const playerGroup = new THREE.Group();
 
       const geometry = new THREE.BoxGeometry(1, 2, 1);
-      const material = new THREE.MeshLambertMaterial({ color: 0xff0000 });
+      const material = new THREE.MeshLambertMaterial({ color: player.team === 1 ? 0xff3333 : (player.team === 2 ? 0x3333ff : 0xaaaaaa) });
       const mesh = new THREE.Mesh(geometry, material);
       playerGroup.add(mesh);
 
@@ -297,6 +314,9 @@ function setupRoom() {
         nameSprite = createNameSprite(val);
         playerGroup.add(nameSprite);
       });
+      player.listen("team", (val) => {
+        material.color.setHex(val === 1 ? 0xff3333 : (val === 2 ? 0x3333ff : 0xaaaaaa));
+      });
       // Hide if dead
       player.listen("health", (val) => playerGroup.visible = val > 0);
     }
@@ -319,6 +339,9 @@ function setupRoom() {
     }
     updateLeaderboard();
   });
+
+  updateCtfHud();
+  updateTeamSelectUI();
 }
 
 function updateLeaderboard() {
@@ -331,6 +354,46 @@ function updateLeaderboard() {
     `<div>${escapeHtml(p.name)}: ${p.kills}</div>`
   ).join("");
 }
+
+function teamLabel(teamId) {
+  if (teamId === 1) return "RED";
+  if (teamId === 2) return "BLUE";
+  return "FFA";
+}
+
+function updateCtfHud() {
+  if (!fpsTeam || !fpsObjective || !fpsCtfScore) return;
+  const mapId = room?.state?.mapId ?? 0;
+  fpsTeam.textContent = teamLabel(localPlayer.team);
+  fpsTeam.style.color = localPlayer.team === 1 ? "#ff6666" : (localPlayer.team === 2 ? "#6666ff" : "#bbbbbb");
+
+  if (mapId === 5) {
+    fpsObjective.textContent = "CAPTURE THE FLAG";
+    fpsObjective.style.color = "#ffff66";
+    fpsCtfScore.style.display = "inline";
+    fpsCtfScore.textContent = `RED ${room.state.redScore} - ${room.state.blueScore} BLUE`;
+    fpsCtfScore.style.color = "#ffffff";
+  } else {
+    fpsObjective.textContent = "DEATHMATCH";
+    fpsObjective.style.color = "#bbbbbb";
+    fpsCtfScore.style.display = "none";
+  }
+}
+
+function updateTeamSelectUI() {
+  if (!fpsTeamSelect) return;
+  const shouldShow = !!room && room.state.mapId === 5 && localPlayer.team === 0;
+  fpsTeamSelect.style.display = shouldShow ? "flex" : "none";
+  if (shouldShow && controls?.isLocked) {
+    controls.unlock();
+  }
+}
+
+window.fpsChooseTeam = (teamId) => {
+  if (!room || room.state.mapId !== 5) return;
+  if (teamId !== 1 && teamId !== 2) return;
+  room.send("joinTeam", teamId);
+};
 
 // Procedural textures
 
@@ -800,52 +863,57 @@ function loadMap(mapId) {
     const bridgeMat = new THREE.MeshPhongMaterial({ map: getTexture("metal"), color: 0x555555 });
     const coverMat = new THREE.MeshPhongMaterial({ map: getTexture("concrete"), color: 0x666666 });
 
-    // Red Fort (Left side)
-    // Front Wall with gap
-    addBox(20, 8, 2, -30, 4, 15, redBaseMat);
-    addBox(20, 8, 2, -30, 4, -15, redBaseMat);
-    // Back Wall
-    addBox(40, 8, 2, -50, 4, 0, redBaseMat);
-    // Side Walls
-    addBox(2, 8, 50, -40, 4, 24, redBaseMat);
-    addBox(2, 8, 50, -40, 4, -24, redBaseMat);
-    // Upper Balcony (Sniper nest)
-    addBox(40, 1, 10, -45, 8.5, 0, redBaseMat);
-    addBox(4, 1, 10, -35, 4, 0, redBaseMat); // Ramp block
-    addBox(4, 1, 10, -39, 6, 0, redBaseMat); // Ramp block 2
+    // Larger arena bounds
+    addBox(2, 12, 220, -110, 6, 0, wallMat);
+    addBox(2, 12, 220, 110, 6, 0, wallMat);
+    addBox(220, 12, 2, 0, 6, -110, wallMat);
+    addBox(220, 12, 2, 0, 6, 110, wallMat);
 
-    // Blue Fort (Right side)
-    // Front Wall with gap
-    addBox(20, 8, 2, 30, 4, 15, blueBaseMat);
-    addBox(20, 8, 2, 30, 4, -15, blueBaseMat);
-    // Back Wall
-    addBox(40, 8, 2, 50, 4, 0, blueBaseMat);
-    // Side Walls
-    addBox(2, 8, 50, 40, 4, 24, blueBaseMat);
-    addBox(2, 8, 50, 40, 4, -24, blueBaseMat);
-    // Upper Balcony (Sniper nest)
-    addBox(40, 1, 10, 45, 8.5, 0, blueBaseMat);
-    addBox(4, 1, 10, 35, 4, 0, blueBaseMat); // Ramp block
-    addBox(4, 1, 10, 39, 6, 0, blueBaseMat); // Ramp block 2
+    // Red fort
+    addBox(22, 8, 2, -38, 4, 18, redBaseMat);
+    addBox(22, 8, 2, -38, 4, -18, redBaseMat);
+    addBox(2, 8, 38, -49, 4, 0, redBaseMat);
+    // Inner wall split with doorway so enemies can breach and steal flag
+    addBox(2, 8, 14, -27, 4, 12, redBaseMat);
+    addBox(2, 8, 14, -27, 4, -12, redBaseMat);
+    addBox(22, 1, 12, -38, 8.5, 0, redBaseMat);
+    addBox(6, 2, 8, -33, 2, 0, coverMat);
+    addBox(6, 2, 8, -43, 2, 0, coverMat);
 
-    // Center Map Elements (No Man's Land)
-    // High Bridge linking sniper nests
-    addBox(60, 1, 8, 0, 8.5, 0, bridgeMat);
-    // Bridge Cover
-    addBox(2, 2, 8, -10, 10, 0, coverMat);
-    addBox(2, 2, 8, 10, 10, 0, coverMat);
+    // Blue fort
+    addBox(22, 8, 2, 38, 4, 18, blueBaseMat);
+    addBox(22, 8, 2, 38, 4, -18, blueBaseMat);
+    addBox(2, 8, 38, 49, 4, 0, blueBaseMat);
+    // Inner wall split with doorway so enemies can breach and steal flag
+    addBox(2, 8, 14, 27, 4, 12, blueBaseMat);
+    addBox(2, 8, 14, 27, 4, -12, blueBaseMat);
+    addBox(22, 1, 12, 38, 8.5, 0, blueBaseMat);
+    addBox(6, 2, 8, 33, 2, 0, coverMat);
+    addBox(6, 2, 8, 43, 2, 0, coverMat);
 
-    // Lower Center Obstacles (Trenches & Cover)
-    addBox(8, 4, 4, 0, 2, 10, wallMat);
-    addBox(8, 4, 4, 0, 2, -10, wallMat);
-    addBox(4, 4, 8, 0, 2, 25, wallMat);
-    addBox(4, 4, 8, 0, 2, -25, wallMat);
+    // Mid bridge and lower lane
+    addBox(74, 1, 12, 0, 8.5, 0, bridgeMat);
+    addBox(12, 3, 4, -14, 2, 0, wallMat);
+    addBox(12, 3, 4, 14, 2, 0, wallMat);
+    addBox(12, 3, 4, 0, 2, 18, wallMat);
+    addBox(12, 3, 4, 0, 2, -18, wallMat);
 
-    // Flank Routes Cover
-    addBox(6, 3, 2, -15, 1.5, 20, coverMat);
-    addBox(6, 3, 2, 15, 1.5, 20, coverMat);
-    addBox(6, 3, 2, -15, 1.5, -20, coverMat);
-    addBox(6, 3, 2, 15, 1.5, -20, coverMat);
+    // Side flank routes and jump pads (extended for larger map)
+    addBox(2, 3, 60, -14, 1.5, 54, coverMat);
+    addBox(2, 3, 60, 14, 1.5, -54, coverMat);
+    const jumpPadMat = new THREE.MeshPhongMaterial({ color: 0x00ffaa, emissive: 0x00ffaa, emissiveIntensity: 0.4 });
+    addBox(4, 0.5, 4, -14, 0.25, 54, jumpPadMat, { isJumpPad: true, boostX: 220, boostZ: -260 });
+    addBox(4, 0.5, 4, 14, 0.25, -54, jumpPadMat, { isJumpPad: true, boostX: -220, boostZ: 260 });
+
+    // Symmetric cover fields
+    const coverSpots = [
+      [-22, 18], [-22, -18], [22, 18], [22, -18],
+      [-8, 28], [-8, -28], [8, 28], [8, -28],
+      [-30, 34], [-30, -34], [30, 34], [30, -34],
+      [-52, 60], [-52, -60], [52, 60], [52, -60],
+      [-70, 44], [-70, -44], [70, 44], [70, -44]
+    ];
+    coverSpots.forEach(([x, z]) => addBox(6, 3, 3, x, 1.5, z, coverMat));
 
     // Create physical flag models so they can be seen holding or dropped
     const flagGeo = new THREE.CylinderGeometry(0.1, 0.1, 3);
@@ -1508,6 +1576,8 @@ function animate() {
   updateTracers(time);
   updateGrenadeEffects(time);
   updateFlagPositions();
+  updateCtfHud();
+  updateTeamSelectUI();
 
   if (muzzleFlash && muzzleFlash.visible && time - muzzleFlashTime > 50) {
     muzzleFlash.visible = false;
@@ -1724,7 +1794,10 @@ export function initFps() {
   nextGrenadeTime = 0;
   gatlingMovementLockUntil = 0;
   isPrimaryFireHeld = false;
+  localPlayer.team = 0;
   updateGrenadeUI();
+  updateCtfHud();
+  updateTeamSelectUI();
 
   if (room) {
     room.leave();

--- a/index.html
+++ b/index.html
@@ -2259,6 +2259,9 @@
         <div id="fpsUI" style="position: absolute; top: 10px; left: 10px; color: white; font-family: monospace; font-size: 16px; text-shadow: 1px 1px 0 #000; pointer-events: none; text-align: left;">
           HP: <span id="fpsHealth" style="color: lime;">100</span><br/>
           KILLS: <span id="fpsKills">0</span><br/>
+          TEAM: <span id="fpsTeam" style="color: #bbbbbb;">FFA</span><br/>
+          MODE: <span id="fpsObjective" style="color: #bbbbbb;">DEATHMATCH</span><br/>
+          CTF: <span id="fpsCtfScore" style="color: #bbbbbb;">RED 0 - 0 BLUE</span><br/>
           WEAPON: <span id="fpsWeapon" style="color: yellow;">PISTOL</span><br/>
           AMMO: <span id="fpsAmmo" style="color: orange;">12/12</span><br/>
           GRENADES: <span id="fpsGrenades" style="color: #ff8800;">2</span>
@@ -2294,6 +2297,14 @@
               <button class="term-btn" onclick="window.voteMap(4)">SNIPER <span id="mapVote4">(0)</span></button>
               <button class="term-btn" onclick="window.voteMap(5)">CTF <span id="mapVote5">(0)</span></button>
             </div>
+          </div>
+        </div>
+        <div id="fpsTeamSelect" style="display: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.82); flex-direction: column; justify-content: center; align-items: center; z-index: 30;">
+          <h2 style="color: white; margin-bottom: 10px;">CHOOSE YOUR TEAM</h2>
+          <p style="color: #ccc; margin-top: 0; margin-bottom: 16px;">Pick RED or BLUE to spawn in.</p>
+          <div style="display: flex; gap: 16px;">
+            <button class="term-btn" onclick="window.fpsChooseTeam(1)" style="background:#b62222; border-color:#ff6666;">JOIN RED</button>
+            <button class="term-btn" onclick="window.fpsChooseTeam(2)" style="background:#2233aa; border-color:#6688ff;">JOIN BLUE</button>
           </div>
         </div>
       </div>

--- a/server.js
+++ b/server.js
@@ -2432,6 +2432,16 @@ schema.defineTypes(FPSState, {
 });
 
 class FPSRoom extends colyseus.Room {
+  getBalancedTeam() {
+    let redCount = 0;
+    let blueCount = 0;
+    this.state.players.forEach((p) => {
+      if (p.team === 1) redCount++;
+      if (p.team === 2) blueCount++;
+    });
+    return redCount <= blueCount ? 1 : 2;
+  }
+
   getSafeSpawn(mapId, team = 0) {
     let x = (Math.random() * 40 - 20) * 2;
     let z = (Math.random() * 40 - 20) * 2;
@@ -2816,45 +2826,18 @@ class FPSRoom extends colyseus.Room {
       const player = this.state.players.get(client.sessionId);
       if (!player) return;
       if (player.health <= 0) return; // Dead players can't move
+      if (this.state.mapId === 5 && player.team === 0) return; // Must choose a team before spawning
       player.x = data.x;
       player.y = data.y;
       player.z = data.z;
       player.rotY = data.rotY;
     });
 
-    const handleElimination = (shooter, hitClient) => {
-      if (hitClient.player.health > 0) return;
-      hitClient.player.health = 0;
-      shooter.kills += 1;
-
-      if (shooter.kills >= 50 && !this.state.roundOver) {
-        this.state.roundOver = true;
-        this.state.winnerName = shooter.name;
-        setTimeout(() => this.resetRound(), 10000); // 10 seconds to vote
-      }
-
-      const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
-      if (victimClient) {
-        victimClient.send("killed", { killer: shooter.name });
-
-        // Respawn after 3 seconds
-        setTimeout(() => {
-          if (this.state.players.has(hitClient.id) && !this.state.roundOver) {
-            const spawnPos = this.getSafeSpawn(this.state.mapId);
-            hitClient.player.health = 100;
-            hitClient.player.x = spawnPos.x;
-            hitClient.player.y = spawnPos.y;
-            hitClient.player.z = spawnPos.z;
-            victimClient.send("respawn", spawnPos);
-          }
-        }, 3000);
-      }
-    };
-
     this.onMessage("shoot", (client, data) => {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
+      if (this.state.mapId === 5 && shooter.team === 0) return;
 
       this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
 
@@ -2871,6 +2854,7 @@ class FPSRoom extends colyseus.Room {
 
       this.state.players.forEach((target, targetId) => {
         if (targetId === client.sessionId || target.health <= 0) return;
+        if (this.state.mapId === 5 && shooter.team !== 0 && shooter.team === target.team) return;
 
         // Vector from origin to target
         const vx = target.x - ox;
@@ -2906,9 +2890,23 @@ class FPSRoom extends colyseus.Room {
         let damage = 25;
         if (data.weaponId === 1) damage = 20; // Shotgun per bullet
         if (data.weaponId === 2) damage = 100; // Sniper
+        const target = hitClient.player;
 
-        hitClient.player.health -= damage;
-        handleElimination(shooter, hitClient);
+        if (target.armor > 0) {
+          const armorDmg = Math.min(target.armor, damage);
+          target.armor -= armorDmg;
+          target.health -= (damage - armorDmg);
+        } else {
+          target.health -= damage;
+        }
+
+        if (target.health > 0) {
+          client.send("hitmarker", { killed: false });
+        } else {
+          client.send("hitmarker", { killed: true });
+          const victimClient = this.clients.find(c => c.sessionId === hitClient.id);
+          this.handleElimination(shooter, client, target, victimClient);
+        }
       }
     });
 
@@ -2916,6 +2914,7 @@ class FPSRoom extends colyseus.Room {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
+      if (this.state.mapId === 5 && shooter.team === 0) return;
 
       const ex = data.x;
       const ey = data.y;
@@ -2931,6 +2930,7 @@ class FPSRoom extends colyseus.Room {
       const radius = 15;
       this.state.players.forEach((target, targetId) => {
         if (target.health <= 0) return;
+        if (this.state.mapId === 5 && shooter.team !== 0 && shooter.team === target.team && targetId !== client.sessionId) return;
         const tx = target.x - ex;
         const ty = (target.y + 1) - ey;
         const tz = target.z - ez;
@@ -2939,8 +2939,17 @@ class FPSRoom extends colyseus.Room {
 
         const t = 1 - (dist / radius);
         const damage = Math.max(20, Math.round(100 * t));
-        target.health -= damage;
-        handleElimination(shooter, { id: targetId, player: target });
+        if (target.armor > 0) {
+          const armorDmg = Math.min(target.armor, damage);
+          target.armor -= armorDmg;
+          target.health -= (damage - armorDmg);
+        } else {
+          target.health -= damage;
+        }
+        if (target.health <= 0) {
+          const victimClient = this.clients.find(c => c.sessionId === targetId);
+          this.handleElimination(shooter, client, target, victimClient);
+        }
       });
     });
 
@@ -2948,6 +2957,7 @@ class FPSRoom extends colyseus.Room {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
+      if (this.state.mapId === 5 && shooter.team === 0) return;
 
       const proj = new FPSProjectile();
       proj.id = Math.random().toString(36).substr(2, 9);
@@ -2968,7 +2978,10 @@ class FPSRoom extends colyseus.Room {
       if (this.state.mapId !== 5) return;
       const player = this.state.players.get(client.sessionId);
       if (player) {
+        if (teamId !== 1 && teamId !== 2) return;
         player.team = teamId;
+        player.health = 100;
+        player.armor = 0;
         const spawnPos = this.getSafeSpawn(this.state.mapId, player.team);
         player.x = spawnPos.x;
         player.y = spawnPos.y;
@@ -3023,14 +3036,18 @@ class FPSRoom extends colyseus.Room {
       player.armor = 0;
       if (this.state.mapId !== 5) {
         player.team = 0;
+      } else if (player.team === 0) {
+        player.health = 0;
       }
       const spawnPos = this.getSafeSpawn(this.state.mapId, player.team);
-      player.x = spawnPos.x;
-      player.y = spawnPos.y;
-      player.z = spawnPos.z;
+      player.x = (this.state.mapId === 5 && player.team === 0) ? 0 : spawnPos.x;
+      player.y = (this.state.mapId === 5 && player.team === 0) ? 1.5 : spawnPos.y;
+      player.z = (this.state.mapId === 5 && player.team === 0) ? 0 : spawnPos.z;
       const client = this.clients.find(c => c.sessionId === sessionId);
       if (client) {
-        client.send("respawn", spawnPos);
+        if (this.state.mapId !== 5 || player.team !== 0) {
+          client.send("respawn", spawnPos);
+        }
       }
     });
     this.broadcast("mapVotes", this.mapVotes);
@@ -3040,6 +3057,15 @@ class FPSRoom extends colyseus.Room {
     const player = new FPSPlayer();
     player.name = options.playerName || "Unknown";
     const spawnPos = this.getSafeSpawn(this.state.mapId, player.team);
+    if (this.state.mapId === 5) {
+      player.health = 0;
+      player.x = 0;
+      player.y = 1.5;
+      player.z = 0;
+      this.state.players.set(client.sessionId, player);
+      this.updateMetadata();
+      return;
+    }
     player.x = spawnPos.x;
     player.y = spawnPos.y;
     player.z = spawnPos.z;
@@ -3061,7 +3087,7 @@ class FPSRoom extends colyseus.Room {
       d.clients = this.clients.length;
       d.players = [];
       this.state.players.forEach((player) => {
-        d.players.push({ name: player.name });
+        d.players.push({ name: player.name, team: player.team });
       });
       fpsServerDirectory.set(this.roomId, d);
     }


### PR DESCRIPTION
### Motivation
- Introduce team-based Capture The Flag (CTF) gameplay and UI so players can choose teams and see CTF score/objective state.
- Prevent unassigned players from interacting on CTF maps and enforce friendly-fire rules and spawn behavior to keep CTF rounds coherent.
- Expand and rebalance the CTF map layout and add visible flag models so CTF matches feel complete and readable.

### Description
- Client: add `team` to `localPlayer`, new HUD elements `fpsTeam`, `fpsObjective`, `fpsCtfScore` and a team selection overlay `fpsTeamSelect`, plus `updateCtfHud`, `updateTeamSelectUI` and global `fpsChooseTeam` to send `joinTeam` messages.
- Client: subscribe to player `team` updates to color other players by team, show/hide the team select UI when appropriate, and update HUD each frame and on map changes.
- Map: replace the previous small CTF layout (mapId `5`) with a larger two-fort arena, symmetric cover, jump pads, and add `redFlagMesh`/`blueFlagMesh` placement in bases.
- Server: add `getBalancedTeam`, require team selection on CTF map by blocking `move`, `shoot` and `throwGrenade` for team `0`, prevent friendly fire on CTF (shots/explosions ignore teammates), apply armor absorption when applying damage, and move join/spawn behavior so new joiners on CTF start as spectators (health 0) until they pick a team via `joinTeam` which assigns team, health/armor and respawns them.
- Server: include team info in room metadata and reset logic updates (spectator handling and spawn positions) for CTF rounds.

### Testing
- Ran the project's automated test suite with `npm test` and lint checks with `npm run lint`, and they completed successfully.
- Ran automated server unit tests for `FPSRoom` message handlers which passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efab22db7c83278d1465bc3d6e9148)