### PR TITLE
Run FPSRoom simulation and patches at 60Hz to smooth player movement

### DIFF
--- a/server.js
+++ b/server.js
@@ -2797,7 +2797,11 @@ class FPSRoom extends colyseus.Room {
   }
 
   onCreate(options) {
-    this.setSimulationInterval(() => this.simulateTick(), 50);
+    // Run FPS room at higher simulation + patch rates so remote player movement
+    // appears near-instant instead of stepping at ~20hz.
+    const FPS_NET_TICK_MS = 1000 / 60;
+    this.setSimulationInterval(() => this.simulateTick(), FPS_NET_TICK_MS);
+    this.setPatchRate(FPS_NET_TICK_MS);
 
     this.maxClients = 1000;
     this.serverName = options.serverName || "Arena Server";


### PR DESCRIPTION
### Motivation
- Improve perceived remote player movement by increasing the simulation and network patch rate from ~20Hz to 60Hz so updates appear near-instant.

### Description
- Change `onCreate` to use `FPS_NET_TICK_MS = 1000 / 60` and call `setSimulationInterval(..., FPS_NET_TICK_MS)` and `setPatchRate(FPS_NET_TICK_MS)` to run the room simulation and patching at 60Hz.

### Testing
- Ran the existing unit test suite and a server smoke test validating tick/patch timing and basic player movement behavior, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaf3414148327a0d1b931190de08c)