### PR TITLE
Fix Builder graphics settings so in-game HUD controls work and stay synced

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -53,9 +53,18 @@ let selectedRoomId = null;
     const uiX = document.getElementById("builderX");
     const uiY = document.getElementById("builderY");
     const uiBlockType = document.getElementById("builderBlockType");
-    const graphicsPresetSelect = document.getElementById("builderGraphicsPreset");
-    const graphicsShadowsToggle = document.getElementById("builderGraphicsShadows");
-    const graphicsTrailsToggle = document.getElementById("builderGraphicsTrails");
+    const graphicsPresetControls = [
+        document.getElementById("builderGraphicsPreset"),
+        document.getElementById("builderGraphicsPresetHud"),
+    ].filter(Boolean);
+    const graphicsShadowsControls = [
+        document.getElementById("builderGraphicsShadows"),
+        document.getElementById("builderGraphicsShadowsHud"),
+    ].filter(Boolean);
+    const graphicsTrailsControls = [
+        document.getElementById("builderGraphicsTrails"),
+        document.getElementById("builderGraphicsTrailsHud"),
+    ].filter(Boolean);
 
     const TILE_SIZE = 32;
     const CHUNK_SIZE = 16;
@@ -96,21 +105,35 @@ let selectedRoomId = null;
         }
     };
     const syncGraphicsControls = () => {
-        if (graphicsPresetSelect) graphicsPresetSelect.value = graphicsSettings.preset;
-        if (graphicsShadowsToggle) graphicsShadowsToggle.checked = graphicsSettings.shadows;
-        if (graphicsTrailsToggle) graphicsTrailsToggle.checked = graphicsSettings.trails;
+        graphicsPresetControls.forEach((control) => {
+            control.value = graphicsSettings.preset;
+        });
+        graphicsShadowsControls.forEach((control) => {
+            control.checked = graphicsSettings.shadows;
+        });
+        graphicsTrailsControls.forEach((control) => {
+            control.checked = graphicsSettings.trails;
+        });
     };
-    const handleGraphicsControlChange = () => {
-        graphicsSettings.preset = clampPreset(graphicsPresetSelect?.value);
-        graphicsSettings.shadows = graphicsShadowsToggle ? graphicsShadowsToggle.checked : true;
-        graphicsSettings.trails = graphicsTrailsToggle ? graphicsTrailsToggle.checked : true;
+    const handleGraphicsControlChange = (event) => {
+        const control = event?.currentTarget;
+        if (control?.matches('select[id^="builderGraphicsPreset"]')) {
+            graphicsSettings.preset = clampPreset(control.value);
+        }
+        if (control?.matches('input[id^="builderGraphicsShadows"]')) {
+            graphicsSettings.shadows = Boolean(control.checked);
+        }
+        if (control?.matches('input[id^="builderGraphicsTrails"]')) {
+            graphicsSettings.trails = Boolean(control.checked);
+        }
+        syncGraphicsControls();
         saveGraphicsSettings();
     };
     readGraphicsSettings();
     syncGraphicsControls();
-    if (graphicsPresetSelect) graphicsPresetSelect.addEventListener("change", handleGraphicsControlChange);
-    if (graphicsShadowsToggle) graphicsShadowsToggle.addEventListener("change", handleGraphicsControlChange);
-    if (graphicsTrailsToggle) graphicsTrailsToggle.addEventListener("change", handleGraphicsControlChange);
+    graphicsPresetControls.forEach((control) => control.addEventListener("change", handleGraphicsControlChange));
+    graphicsShadowsControls.forEach((control) => control.addEventListener("change", handleGraphicsControlChange));
+    graphicsTrailsControls.forEach((control) => control.addEventListener("change", handleGraphicsControlChange));
 
 const blockColors = {
         1: "#3c9e3c", // Grass
@@ -3901,9 +3924,9 @@ if (inventoryOpen && !showEscapeMenu) {
         canvas.removeEventListener("mouseup", handleMouseUp);
         canvas.removeEventListener("wheel", handleCanvasWheel);
         canvas.removeEventListener("contextmenu", handleCanvasContextMenu);
-        if (graphicsPresetSelect) graphicsPresetSelect.removeEventListener("change", handleGraphicsControlChange);
-        if (graphicsShadowsToggle) graphicsShadowsToggle.removeEventListener("change", handleGraphicsControlChange);
-        if (graphicsTrailsToggle) graphicsTrailsToggle.removeEventListener("change", handleGraphicsControlChange);
+        graphicsPresetControls.forEach((control) => control.removeEventListener("change", handleGraphicsControlChange));
+        graphicsShadowsControls.forEach((control) => control.removeEventListener("change", handleGraphicsControlChange));
+        graphicsTrailsControls.forEach((control) => control.removeEventListener("change", handleGraphicsControlChange));
         if (inputLoopId) {
             clearInterval(inputLoopId);
             inputLoopId = null;

--- a/index.html
+++ b/index.html
@@ -2350,19 +2350,19 @@
           <span>X: <span id="builderX">0</span> Y: <span id="builderY">0</span></span>
           <span style="margin-left: 20px;">BLOCK: <span id="builderBlockType">GRASS</span></span>
           <div style="margin-left: auto; display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end;">
-            <label for="builderGraphicsPreset" style="font-size: 10px;">GRAPHICS</label>
-            <select id="builderGraphicsPreset" class="term-input" style="width: auto; min-width: 130px; height: 28px; padding: 2px 8px;">
+            <label for="builderGraphicsPresetHud" style="font-size: 10px;">GRAPHICS</label>
+            <select id="builderGraphicsPresetHud" class="term-input" style="width: auto; min-width: 130px; height: 28px; padding: 2px 8px;">
               <option value="low">LOW (PERFORMANCE)</option>
               <option value="medium">MEDIUM</option>
               <option value="high">HIGH (RECOMMENDED)</option>
               <option value="ultra">ULTRA</option>
             </select>
             <label style="display: inline-flex; align-items: center; gap: 4px; font-size: 10px;">
-              <input id="builderGraphicsShadows" type="checkbox" checked />
+              <input id="builderGraphicsShadowsHud" type="checkbox" checked />
               SHADOWS
             </label>
             <label style="display: inline-flex; align-items: center; gap: 4px; font-size: 10px;">
-              <input id="builderGraphicsTrails" type="checkbox" checked />
+              <input id="builderGraphicsTrailsHud" type="checkbox" checked />
               TRAILS
             </label>
           </div>


### PR DESCRIPTION
### Motivation
- The Builder UI had duplicated control IDs between the main menu and the in-game HUD which prevented the HUD controls from working independently and caused control state desynchronization.
- Users expect graphics preset, shadows, and trails to work both from the menu and the in-game HUD and for changes to immediately persist and mirror across both places.

### Description
- Renamed the in-game HUD controls in `index.html` to unique IDs (`builderGraphicsPresetHud`, `builderGraphicsShadowsHud`, `builderGraphicsTrailsHud`) so they no longer conflict with the menu controls.
- Reworked graphics wiring in `games/builder.js` to treat menu and HUD controls as sets (`graphicsPresetControls`, `graphicsShadowsControls`, `graphicsTrailsControls`) and to synchronize values across all matched DOM controls.
- Replaced single-control change handling with a unified `handleGraphicsControlChange(event)` that updates `graphicsSettings`, calls `syncGraphicsControls()` and persists to localStorage via `saveGraphicsSettings()`.
- Ensured teardown removes listeners from all control instances by iterating the control sets when cleaning up event handlers.

### Testing
- Ran `node --check games/builder.js` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb2a0f2c0832b8a6cdbd2acd7d38d)