### PR TITLE
Fix CTF flag spawn positions to match bases

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1573,8 +1573,8 @@ function updateFlagPositions() {
   if (!room || room.state.mapId !== 5) return;
   if (!redFlagMesh || !blueFlagMesh) return;
 
-  const RED_FLAG_BASE = new THREE.Vector3(-40, 1.5, 0);
-  const BLUE_FLAG_BASE = new THREE.Vector3(40, 1.5, 0);
+  const RED_FLAG_BASE = new THREE.Vector3(0, 5, -165);
+  const BLUE_FLAG_BASE = new THREE.Vector3(0, 5, 165);
 
   if (room.state.redFlagStatus === 0 || room.state.redFlagStatus === 2) {
     redFlagMesh.position.copy(RED_FLAG_BASE);


### PR DESCRIPTION
This commit fixes an issue where the flags in the Capture the Flag game mode were spawning incorrectly instead of in their respective bases.

Changes:
- Modified the RED_FLAG_BASE and BLUE_FLAG_BASE variables in games/fps.js to point to `(0, 5, -165)` and `(0, 5, 165)` respectively, aligning them with the base spawn locations handled in `server.js`.

---
*PR created automatically by Jules for task [2013385869220590489](https://jules.google.com/task/2013385869220590489) started by @thefoxssss*