### PR TITLE
Fix Hexfall players falling through platforms

### DIFF
--- a/games/hexfall.js
+++ b/games/hexfall.js
@@ -272,23 +272,31 @@ function animate() {
 
     const pos = controls.getObject().position;
 
-    // Custom raycast down for floor
-    raycaster.set(pos, new THREE.Vector3(0, -1, 0));
+    // Cast from above the camera position so we can still detect floors
+    // even if a low frame rate lets us dip slightly into a platform.
+    const rayOrigin = new THREE.Vector3(pos.x, pos.y + 3, pos.z);
+    raycaster.set(rayOrigin, new THREE.Vector3(0, -1, 0));
     const floorMeshes = Object.values(hexMeshes).map(h => h.mesh);
     const intersects = raycaster.intersectObjects(floorMeshes, false);
 
     let onFloor = false;
-    if (intersects.length > 0 && intersects[0].distance < 2.0) {
-      velocity.y = Math.max(0, velocity.y);
-      pos.y = intersects[0].point.y + 1.5; // snap to floor + eye height
-      onFloor = true;
+    if (intersects.length > 0) {
+      const floorY = intersects[0].point.y + 1.5; // floor + eye height
+      const grounded = velocity.y <= 0 && pos.y <= floorY + 1.2;
+      if (grounded) {
+        velocity.y = Math.max(0, velocity.y);
+        pos.y = floorY;
+        onFloor = true;
+      }
 
       // We are standing on this hex. Find its ID and tell server.
-      const hitMesh = intersects[0].object;
-      for (const [key, data] of Object.entries(hexMeshes)) {
-        if (data.mesh === hitMesh && !data.hexObj.stepped) {
-           room.send("stepHex", { id: key });
-           break;
+      if (onFloor) {
+        const hitMesh = intersects[0].object;
+        for (const [key, data] of Object.entries(hexMeshes)) {
+          if (data.mesh === hitMesh && !data.hexObj.stepped) {
+             room.send("stepHex", { id: key });
+             break;
+          }
         }
       }
     }


### PR DESCRIPTION
### Motivation

- Players could slip through hex platforms during low frame-rate or when dipping slightly into a tile because the downward raycast originated at the camera position and used a strict short-distance check.
- The goal is to make floor detection more robust and only mark tiles as stepped when the player is truly grounded.

### Description

- Updated `games/hexfall.js` to cast the downward ray from above the camera by creating `rayOrigin = new THREE.Vector3(pos.x, pos.y + 3, pos.z)` and using that as the ray origin.
- Replaced the old `intersects[0].distance < 2.0` check with grounded logic that computes `floorY = intersects[0].point.y + 1.5` and considers the player grounded only when `velocity.y <= 0 && pos.y <= floorY + 1.2`.
- Snap the player `pos.y` to `floorY` and zero upward velocity when grounded, and only send the `stepHex` message when the grounded check is true.

### Testing

- Ran `node --check games/hexfall.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bb775c288327b8f049d6cd4b77c9)