### PR TITLE
Fix CTF flag base positions in FPS client

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1579,8 +1579,8 @@ function updateFlagPositions() {
   if (!room || room.state.mapId !== 5) return;
   if (!redFlagMesh || !blueFlagMesh) return;
 
-  const RED_FLAG_BASE = new THREE.Vector3(0, 5, -165);
-  const BLUE_FLAG_BASE = new THREE.Vector3(0, 5, 165);
+  const RED_FLAG_BASE = new THREE.Vector3(0, 5, -142);
+  const BLUE_FLAG_BASE = new THREE.Vector3(0, 5, 142);
 
   if (room.state.redFlagStatus === 0 || room.state.redFlagStatus === 2) {
     redFlagMesh.position.copy(RED_FLAG_BASE);


### PR DESCRIPTION
### Motivation
- Flags on the CTF map were appearing in the wrong places because the client-side `updateFlagPositions()` used z coordinates that didn't match the map/server base positions, so base/dropped flags did not render at the castles.

### Description
- Adjusted the `RED_FLAG_BASE` and `BLUE_FLAG_BASE` vectors in `games/fps.js` inside `updateFlagPositions()` from `z = ±165` to `z = ±142` so client-side flag base/dropped positions match the map.

### Testing
- Executed `node --check games/fps.js` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0be7de5008327ad272be6e74f04c6)