### PR TITLE
Hexfall: spawn all players on top platform at round start

### DIFF
--- a/server.js
+++ b/server.js
@@ -3485,6 +3485,10 @@ schema.defineTypes(HexfallState, {
 const hexfallServerDirectory = new Map();
 
 class HexfallRoom extends colyseus.Room {
+  getTopPlatformSpawn() {
+    return { x: 0, y: 31.5, z: 0 };
+  }
+
   onCreate(options) {
     this.maxClients = 20;
     this.serverName = (options && typeof options.serverName === "string" && options.serverName.trim())
@@ -3564,12 +3568,13 @@ class HexfallRoom extends colyseus.Room {
     this.state.status = "playing";
     this.state.winnerName = "";
     this.generateMap();
+    const spawn = this.getTopPlatformSpawn();
 
     this.state.players.forEach((p) => {
       p.isAlive = true;
-      p.x = (Math.random() - 0.5) * 10;
-      p.y = 35;
-      p.z = (Math.random() - 0.5) * 10;
+      p.x = spawn.x;
+      p.y = spawn.y;
+      p.z = spawn.z;
     });
 
     this.broadcast("matchStart", {});


### PR DESCRIPTION
### Motivation
- Ensure every player begins each round on the top platform instead of being randomly placed so round starts are consistent.

### Description
- Added `getTopPlatformSpawn()` to `HexfallRoom` returning `{ x: 0, y: 31.5, z: 0 }` and updated `startGame()` to set every player's `x`, `y`, and `z` to that spawn and mark them alive, replacing the previous randomized spawn behavior.

### Testing
- Ran `node --check server.js` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c4bdf5848330858360bbe81f3d72)