### PR TITLE
Limit FPS sniper magazine to 2 shots

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -12,7 +12,7 @@ let muzzleFlashTime = 0;
 let nextFireTime = 0;
 let isReloading = false;
 let reloadEndTime = 0;
-let ammo = [12, 6, 5, 120]; // Current ammo for each weapon
+let ammo = [12, 6, 2, 120]; // Current ammo for each weapon
 let recoilTime = 0;
 let recoilIntensity = 0;
 let bobTime = 0;
@@ -1036,7 +1036,7 @@ window.voteMap = (mapId) => {
 const WEAPONS = [
   { name: "PISTOL", color: 0x555555, cooldown: 400, damage: 25, spread: 0, magSize: 12, reloadTime: 1200 },
   { name: "SHOTGUN", color: 0x882222, cooldown: 1000, damage: 20, spread: 0.1, bullets: 5, magSize: 6, reloadTime: 2000 },
-  { name: "SNIPER", color: 0x228822, cooldown: 1500, damage: 100, spread: 0, magSize: 5, reloadTime: 2500 },
+  { name: "SNIPER", color: 0x228822, cooldown: 1500, damage: 100, spread: 0, magSize: 2, reloadTime: 2500 },
   { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.06, magSize: 120, reloadTime: 3000, immobilizesOnFire: true, unlockKills: 25 }
 ];
 


### PR DESCRIPTION
### Motivation
- Make the sniper rifle have only two shots per reload so its in-game magazine is limited to 2 rounds.

### Description
- Updated `games/fps.js` to set the sniper weapon `magSize` to `2` and adjusted the starting `ammo` array to `let ammo = [12, 6, 2, 120];` to match the new magazine size.

### Testing
- Ran `node --check games/fps.js` to validate there are no syntax errors and the file checks cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c8796af483308424de4c01a8b6f3)