### PR TITLE
Fix live oil quote updates by adding server-side proxy and client fallback

### DIFF
--- a/core.js
+++ b/core.js
@@ -205,7 +205,10 @@ const GLOBAL_MARKET_COLLECTION = "gooner_meta";
 const GLOBAL_MARKET_DOC_ID = "stock_market";
 const STOCK_TICK_MS = 2000;
 const OIL_SYMBOL = "OIL";
-const OIL_QUOTE_URL = "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d";
+const OIL_QUOTE_URLS = [
+  "/api/oil-quote",
+  "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d",
+];
 const OIL_QUOTE_REFRESH_MS = 10_000;
 
 const SHOP_TOGGLE_STORAGE_PREFIX = "goonerItemToggles:";
@@ -1259,11 +1262,19 @@ async function refreshLiveOilPrice(force = false) {
   if (!force && now - oilQuoteState.fetchedAt < OIL_QUOTE_REFRESH_MS) return;
   oilQuoteState.isFetching = true;
   try {
-    const res = await fetch(`${OIL_QUOTE_URL}&_=${now}`, { cache: "no-store" });
-    if (!res.ok) return;
-    const payload = await res.json();
-    const quote = payload?.chart?.result?.[0]?.meta;
-    const rawPrice = Number(quote?.regularMarketPrice ?? quote?.previousClose);
+    let rawPrice = null;
+    for (const baseUrl of OIL_QUOTE_URLS) {
+      const joiner = baseUrl.includes("?") ? "&" : "?";
+      const res = await fetch(`${baseUrl}${joiner}_=${now}`, { cache: "no-store" });
+      if (!res.ok) continue;
+      const payload = await res.json();
+      const quote = payload?.chart?.result?.[0]?.meta || payload?.quote || payload;
+      const candidate = Number(quote?.regularMarketPrice ?? quote?.price ?? quote?.previousClose);
+      if (Number.isFinite(candidate) && candidate > 0) {
+        rawPrice = candidate;
+        break;
+      }
+    }
     if (!Number.isFinite(rawPrice) || rawPrice <= 0) return;
     oilQuoteState.price = rawPrice;
     oilQuoteState.fetchedAt = now;

--- a/server.js
+++ b/server.js
@@ -77,6 +77,7 @@ function layeredNoise(x, y, octaves, persistence, scale) {
 const app = express();
 app.use(cors());
 const port = process.env.PORT || 2567;
+const OIL_QUOTE_UPSTREAM_URL = "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d";
 const builderServerDirectory = new Map();
 const fpsServerDirectory = new Map();
 
@@ -563,6 +564,41 @@ app.get("/fnaf_servers", (req, res) => {
     .sort((a, b) => b.clients - a.clients)
     .slice(0, 50);
   res.json(active);
+});
+
+app.get("/api/oil-quote", async (req, res) => {
+  try {
+    const upstream = await fetch(`${OIL_QUOTE_UPSTREAM_URL}&_=${Date.now()}`, {
+      headers: {
+        "accept": "application/json",
+        "user-agent": "Mozilla/5.0 (compatible; FoxsssMarketBot/1.0)",
+      },
+    });
+    if (!upstream.ok) {
+      res.status(upstream.status).json({ error: "upstream quote unavailable" });
+      return;
+    }
+    const payload = await upstream.json();
+    const quote = payload?.chart?.result?.[0]?.meta || {};
+    const price = Number(quote.regularMarketPrice ?? quote.previousClose);
+    if (!Number.isFinite(price) || price <= 0) {
+      res.status(502).json({ error: "invalid quote payload" });
+      return;
+    }
+    res.set("cache-control", "no-store");
+    res.json({
+      quote: {
+        symbol: "CL=F",
+        price,
+        regularMarketPrice: price,
+        previousClose: Number(quote.previousClose) || price,
+      },
+      source: "yahoo-finance",
+      fetchedAt: Date.now(),
+    });
+  } catch {
+    res.status(502).json({ error: "quote fetch failed" });
+  }
 });
 
 // --------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Oil price quotes could stop updating in the UI when browser requests to Yahoo were blocked, rate-limited, or filtered, resulting in stale or missing live oil pricing.
- Provide a more reliable same-origin path and tolerant parsing so the stock market UI keeps receiving live oil prices.

### Description
- Added a backend endpoint `GET /api/oil-quote` in `server.js` that proxies the Yahoo CL=F feed, validates and normalizes the numeric price, sets `cache-control: no-store`, and returns a simplified quote payload.
- Updated the client in `core.js` to replace the single `OIL_QUOTE_URL` with an `OIL_QUOTE_URLS` array and to attempt each URL in order (server endpoint first, then Yahoo) when running `refreshLiveOilPrice`.
- Made the client quote parsing tolerant of both Yahoo chart payloads and the backend-normalized shape by checking multiple fields (`regularMarketPrice`, `price`, `previousClose`) and only applying finite, positive prices to the market via `applyLiveOilPriceToMarket`.
- The server proxy uses a conservative `User-Agent` and upstream validation to return a stable, same-origin source for the frontend.

### Testing
- Ran `node --check core.js` and the file passed syntax checking successfully.
- Ran `node --check server.js` and the file passed syntax checking successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c9b06ee883279662dced3eeae6c5)