### PR TITLE
Allow admins to bypass Gatling kill unlock

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1,4 +1,4 @@
-import { state, isInputFocused, escapeHtml } from "../core.js";
+import { state, isInputFocused, escapeHtml, isGodUser } from "../core.js";
 
 let room = null;
 let scene, camera, renderer, controls;
@@ -1346,6 +1346,9 @@ function createGunModel(id) {
 }
 
 function isWeaponUnlocked(id) {
+  if (id === 3 && isGodUser()) {
+    return true;
+  }
   const w = WEAPONS[id];
   if (w && w.unlockKills) {
     return localPlayer.kills >= w.unlockKills;


### PR DESCRIPTION
### Motivation
- Admins/god users should be able to access the Gatling gun regardless of their in-game kill count.

### Description
- Import `isGodUser` from `core.js` into `games/fps.js` to enable privilege checks.
- Update `isWeaponUnlocked(id)` so that weapon id `3` (Gatling) returns unlocked when `isGodUser()` is true, preserving existing kill-based unlock behavior for all other players and weapons.

### Testing
- Ran `node --check games/fps.js` to validate the modified file and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cad49fa48330a7480b3f369bc108)