### PR TITLE
Fix crude oil live quote with multi-source backend and transport fallback

### DIFF
--- a/core.js
+++ b/core.js
@@ -207,7 +207,6 @@ const STOCK_TICK_MS = 2000;
 const OIL_SYMBOL = "OIL";
 const OIL_QUOTE_URLS = [
   "/api/oil-quote",
-  "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d",
 ];
 const OIL_QUOTE_REFRESH_MS = 10_000;
 

--- a/server.js
+++ b/server.js
@@ -8,6 +8,9 @@ const cors = require("cors");
 const admin = require("firebase-admin"); // <-- Firebase is here!
 const fs = require("fs");
 const path = require("path");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const execFileAsync = promisify(execFile);
 
 // Simple Perlin-like noise
 const permutation = new Uint8Array(512);
@@ -77,7 +80,74 @@ function layeredNoise(x, y, octaves, persistence, scale) {
 const app = express();
 app.use(cors());
 const port = process.env.PORT || 2567;
-const OIL_QUOTE_UPSTREAM_URL = "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d";
+const OIL_QUOTE_SOURCES = [
+  {
+    name: "yahoo-finance",
+    url: "https://query1.finance.yahoo.com/v8/finance/chart/CL=F?interval=1m&range=1d",
+    parser: async (bodyText) => {
+      const payload = JSON.parse(bodyText);
+      const quote = payload?.chart?.result?.[0]?.meta || {};
+      const price = Number(quote.regularMarketPrice ?? quote.previousClose);
+      if (!Number.isFinite(price) || price <= 0) return null;
+      return {
+        symbol: "CL=F",
+        price,
+        regularMarketPrice: price,
+        previousClose: Number(quote.previousClose) || price,
+      };
+    },
+  },
+  {
+    name: "stooq",
+    url: "https://stooq.com/q/l/?s=cl.f&i=d",
+    parser: async (bodyText) => {
+      const line = String(bodyText || "").trim().split(/\r?\n/).find(Boolean);
+      if (!line) return null;
+      const parts = line.split(",");
+      if (parts.length < 7) return null;
+      const close = Number(parts[6]);
+      const previousClose = Number(parts[3]);
+      if (!Number.isFinite(close) || close <= 0) return null;
+      return {
+        symbol: "CL=F",
+        price: close,
+        regularMarketPrice: close,
+        previousClose: Number.isFinite(previousClose) && previousClose > 0 ? previousClose : close,
+      };
+    },
+  },
+];
+
+async function requestOilQuoteBody(url) {
+  const fullUrl = `${url}${url.includes("?") ? "&" : "?"}_=${Date.now()}`;
+  try {
+    const response = await fetch(fullUrl, {
+      headers: {
+        "accept": "application/json,text/plain,*/*",
+        "user-agent": "Mozilla/5.0 (compatible; FoxsssMarketBot/1.0)",
+      },
+    });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    try {
+      const { stdout } = await execFileAsync("curl", [
+        "-L",
+        "--max-time",
+        "12",
+        "-A",
+        "Mozilla/5.0 (compatible; FoxsssMarketBot/1.0)",
+        "-H",
+        "accept: application/json,text/plain,*/*",
+        "-sS",
+        fullUrl,
+      ], { maxBuffer: 512 * 1024 });
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+}
 const builderServerDirectory = new Map();
 const fpsServerDirectory = new Map();
 
@@ -568,34 +638,20 @@ app.get("/fnaf_servers", (req, res) => {
 
 app.get("/api/oil-quote", async (req, res) => {
   try {
-    const upstream = await fetch(`${OIL_QUOTE_UPSTREAM_URL}&_=${Date.now()}`, {
-      headers: {
-        "accept": "application/json",
-        "user-agent": "Mozilla/5.0 (compatible; FoxsssMarketBot/1.0)",
-      },
-    });
-    if (!upstream.ok) {
-      res.status(upstream.status).json({ error: "upstream quote unavailable" });
+    for (const source of OIL_QUOTE_SOURCES) {
+      const body = await requestOilQuoteBody(source.url);
+      if (!body) continue;
+      const quote = await source.parser(body);
+      if (!quote) continue;
+      res.set("cache-control", "no-store");
+      res.json({
+        quote,
+        source: source.name,
+        fetchedAt: Date.now(),
+      });
       return;
     }
-    const payload = await upstream.json();
-    const quote = payload?.chart?.result?.[0]?.meta || {};
-    const price = Number(quote.regularMarketPrice ?? quote.previousClose);
-    if (!Number.isFinite(price) || price <= 0) {
-      res.status(502).json({ error: "invalid quote payload" });
-      return;
-    }
-    res.set("cache-control", "no-store");
-    res.json({
-      quote: {
-        symbol: "CL=F",
-        price,
-        regularMarketPrice: price,
-        previousClose: Number(quote.previousClose) || price,
-      },
-      source: "yahoo-finance",
-      fetchedAt: Date.now(),
-    });
+    res.status(502).json({ error: "all quote sources unavailable" });
   } catch {
     res.status(502).json({ error: "quote fetch failed" });
   }


### PR DESCRIPTION
### Motivation
- The live crude oil price feed was failing due to reliance on a single upstream and client-side provider quirks, so the server needs a more resilient way to obtain quotes and avoid browser CORS/provider failures.
- Provide a backend-first solution that tries multiple providers and a different transport if `fetch` is blocked in the environment.

### Description
- Replaced the single `OIL_QUOTE_UPSTREAM_URL` with a `OIL_QUOTE_SOURCES` array in `server.js` that includes named sources (`yahoo-finance`, `stooq`) and per-source parsers for their response formats.
- Added `requestOilQuoteBody(url)` in `server.js` which first tries Node `fetch` and falls back to invoking `curl` via `child_process.execFile` when `fetch` fails, returning raw response text for parsing.
- Reworked the `/api/oil-quote` handler to iterate `OIL_QUOTE_SOURCES`, parse each response with the source parser, and return the first valid quote or a 502 if all sources fail.
- Updated `core.js` to remove the direct Yahoo URL from the client-side `OIL_QUOTE_URLS` so clients use the local `/api/oil-quote` endpoint instead of querying providers directly.

### Testing
- Ran `node --check server.js` which succeeded. 
- Ran `node --check core.js` which succeeded. 
- Launched the server and queried `http://127.0.0.1:2567/api/oil-quote` which returned a valid live quote JSON from an upstream provider (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cad6e7e48327a685dd538cb88959)