### PR TITLE
Increase Gatling reload time slightly

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1039,7 +1039,7 @@ const WEAPONS = [
   { name: "PISTOL", color: 0x555555, cooldown: 400, damage: 25, spread: 0, magSize: 12, reloadTime: 1200 },
   { name: "SHOTGUN", color: 0x882222, cooldown: 1000, damage: 20, spread: 0.1, bullets: 5, magSize: 6, reloadTime: 2000 },
   { name: "SNIPER", color: 0x228822, cooldown: 1500, damage: 100, spread: 0, magSize: 2, reloadTime: 2500 },
-  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3000, immobilizesOnFire: true }
+  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3600, immobilizesOnFire: true }
 ];
 
 function resetGatlingRamp() {


### PR DESCRIPTION
### Motivation
- Slow the Gatling weapon's pacing by making its reload take a bit longer for balance/tuning reasons.

### Description
- Updated the `reloadTime` value for the `"GATLING"` entry in `games/fps.js` from `3000` to `3600` (milliseconds), leaving all other weapon fields unchanged.

### Testing
- No automated gameplay tests were run for this tuning change; this is a single-constant update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e6b4fbb0833094c15f21a0b075f8)