### PR TITLE
Fix live oil price fetch origin

### DIFF
--- a/core.js
+++ b/core.js
@@ -206,7 +206,7 @@ const GLOBAL_MARKET_DOC_ID = "stock_market";
 const STOCK_TICK_MS = 2000;
 const OIL_SYMBOL = "OIL";
 const OIL_QUOTE_URLS = [
-  "/api/oil-quote",
+  "https://seahorse-app-mv4sg.ondigitalocean.app/api/oil-quote",
 ];
 const OIL_QUOTE_REFRESH_MS = 10_000;
 


### PR DESCRIPTION
Fixes a bug where the live oil price feature failed to fetch the price due to a missing backend route on the frontend origin. Updated `core.js` to point directly to the full deployed backend URL.

---
*PR created automatically by Jules for task [8061558097152986625](https://jules.google.com/task/8061558097152986625) started by @thefoxssss*