### PR TITLE
Shrink FPS CTF map footprint

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -980,15 +980,15 @@ function loadMap(mapId) {
     // Main Ground (Y=0 top surface, thick block) - Split to leave a hole for the tunnel
     // Red Side Ground (Z: -170 to -35)
     // The tunnel goes down at Z=-110 to -70, width 40 (X: -20 to 20).
-    addBox(160, 20, 30, 0, -10, -155, grassMat); // Back section behind tunnel entrance
-    addBox(60, 20, 105, -50, -10, -87.5, grassMat); // Left side
-    addBox(60, 20, 105, 50, -10, -87.5, grassMat);  // Right side
+    addBox(120, 20, 20, 0, -10, -120, grassMat); // Back section behind tunnel entrance
+    addBox(60, 20, 85, -50, -10, -75, grassMat); // Left side
+    addBox(60, 20, 85, 50, -10, -75, grassMat);  // Right side
     // No ground directly under the courtyard center where the ramp is
 
     // Blue Side Ground (Z: 35 to 170)
-    addBox(160, 20, 30, 0, -10, 155, grassMat); // Back section behind tunnel entrance
-    addBox(60, 20, 105, -50, -10, 87.5, grassMat); // Left side
-    addBox(60, 20, 105, 50, -10, 87.5, grassMat);  // Right side
+    addBox(120, 20, 20, 0, -10, 120, grassMat); // Back section behind tunnel entrance
+    addBox(60, 20, 85, -50, -10, 75, grassMat); // Left side
+    addBox(60, 20, 85, 50, -10, 75, grassMat);  // Right side
 
     // The Moat (Z: -40 to 40)
     // Lava at Y=-15
@@ -1007,10 +1007,10 @@ function loadMap(mapId) {
 
         // Courtyard Floor - split to leave hole for tunnel ramp
         // Ramp is in center: X: -10 to 10. Z goes towards moat.
-        addBox(120, 1, 28, 0, 0.5, sign * 142, floorMat); // Back of courtyard
+        addBox(120, 1, 28, 0, 0.5, sign * 112, floorMat); // Back of courtyard
         addBox(50, 1, 45, -35, 0.5, sign * 107.5, floorMat); // Left of courtyard
         addBox(50, 1, 45, 35, 0.5, sign * 107.5, floorMat);  // Right of courtyard
-        addBox(20, 1, 20, 0, 0.5, sign * 120, floorMat); // Small piece right behind ramp
+        addBox(20, 1, 20, 0, 0.5, sign * 102, floorMat); // Small piece right behind ramp
 
         // Front Wall (Facing Moat) at Z = +/-80
         addBox(40, 20, 4, -40, 10, sign * 60, mat); // Left
@@ -1043,13 +1043,13 @@ function loadMap(mapId) {
         addBox(16, 30, 16, 60, 15, sign * 120, mat);
 
         // Flag Room / Keep (Inner protected structure)
-        addBox(10, 10, 26, -15, 5, sign * 142, mat); // left wall
-        addBox(10, 10, 26, 15, 5, sign * 142, mat);  // right wall
-        addBox(40, 10, 4, 0, 5, sign * 153, mat);    // back wall
-        addBox(40, 2, 26, 0, 11, sign * 142, mat);   // Roof
-        addBox(40, 4, 4, 0, 8, sign * 131, mat);     // Front arch top
-        addBox(10, 10, 4, -15, 5, sign * 131, mat);  // Front left
-        addBox(10, 10, 4, 15, 5, sign * 131, mat);   // Front right
+        addBox(10, 10, 26, -15, 5, sign * 112, mat); // left wall
+        addBox(10, 10, 26, 15, 5, sign * 112, mat);  // right wall
+        addBox(40, 10, 4, 0, 5, sign * 123, mat);    // back wall
+        addBox(40, 2, 26, 0, 11, sign * 112, mat);   // Roof
+        addBox(40, 4, 4, 0, 8, sign * 101, mat);     // Front arch top
+        addBox(10, 10, 4, -15, 5, sign * 101, mat);  // Front left
+        addBox(10, 10, 4, 15, 5, sign * 101, mat);   // Front right
 
         // Underground Entrance Ramp (Visible ramp going down in courtyard)
         const rampMat = new THREE.MeshPhongMaterial({ map: getTexture("concrete"), color: 0x444444 });
@@ -1093,11 +1093,11 @@ function loadMap(mapId) {
     const flagMatBlue = new THREE.MeshBasicMaterial({ color: 0x0000ff });
 
     redFlagMesh = new THREE.Mesh(flagGeo, flagMatRed);
-    redFlagMesh.position.set(0, 5, -142); // In Red Keep
+    redFlagMesh.position.set(0, 5, -112); // In Red Keep
     scene.add(redFlagMesh);
 
     blueFlagMesh = new THREE.Mesh(flagGeo, flagMatBlue);
-    blueFlagMesh.position.set(0, 5, 142); // In Blue Keep
+    blueFlagMesh.position.set(0, 5, 112); // In Blue Keep
     scene.add(blueFlagMesh);
   }
 }

--- a/games/fps.js
+++ b/games/fps.js
@@ -969,13 +969,13 @@ function loadMap(mapId) {
     // Moat and Lava
     const lavaMat = new THREE.MeshBasicMaterial({ color: 0xff3300 });
 
-    // Overall Bounds: X from -80 to 80, Z from -170 to 170 (smaller than old CTF map, still large)
+    // Overall Bounds: X from -60 to 60, Z from -130 to 130 (further reduced CTF footprint)
     // Back walls
-    addBox(160, 40, 2, 0, 20, -170, wallMat);
-    addBox(160, 40, 2, 0, 20, 170, wallMat);
+    addBox(120, 40, 2, 0, 20, -130, wallMat);
+    addBox(120, 40, 2, 0, 20, 130, wallMat);
     // Side walls
-    addBox(2, 40, 400, -80, 20, 0, wallMat);
-    addBox(2, 40, 400, 80, 20, 0, wallMat);
+    addBox(2, 40, 300, -60, 20, 0, wallMat);
+    addBox(2, 40, 300, 60, 20, 0, wallMat);
 
     // Main Ground (Y=0 top surface, thick block) - Split to leave a hole for the tunnel
     // Red Side Ground (Z: -170 to -35)
@@ -1003,7 +1003,7 @@ function loadMap(mapId) {
     const buildCastle = (isRed) => {
         const sign = isRed ? -1 : 1;
         const mat = isRed ? redBaseMat : blueBaseMat;
-        const baseZ = sign * 120; // Center of castle moved inward for smaller map
+        const baseZ = sign * 90; // Castle centers moved inward again to tighten CTF pacing
 
         // Courtyard Floor - split to leave hole for tunnel ramp
         // Ramp is in center: X: -10 to 10. Z goes towards moat.
@@ -1013,12 +1013,12 @@ function loadMap(mapId) {
         addBox(20, 1, 20, 0, 0.5, sign * 120, floorMat); // Small piece right behind ramp
 
         // Front Wall (Facing Moat) at Z = +/-80
-        addBox(40, 20, 4, -40, 10, sign * 80, mat); // Left
-        addBox(40, 20, 4, 40, 10, sign * 80, mat);  // Right
-        addBox(40, 10, 4, 0, 15, sign * 80, mat);   // Archway top
+        addBox(40, 20, 4, -40, 10, sign * 60, mat); // Left
+        addBox(40, 20, 4, 40, 10, sign * 60, mat);  // Right
+        addBox(40, 10, 4, 0, 15, sign * 60, mat);   // Archway top
 
         // Back Wall at Z = +/-160
-        addBox(120, 20, 4, 0, 10, sign * 160, mat);
+        addBox(120, 20, 4, 0, 10, sign * 120, mat);
 
         // Side Walls of Castle
         addBox(4, 20, 80, -60, 10, baseZ, mat);
@@ -1031,16 +1031,16 @@ function loadMap(mapId) {
         addBox(10, 1, 15, 50, 5, baseZ, woodMat);
         addBox(10, 1, 15, 40, 10, baseZ, woodMat);
         // Walkways
-        addBox(120, 1, 10, 0, 20.5, sign * 80, mat); // Front
-        addBox(120, 1, 10, 0, 20.5, sign * 160, mat); // Back
+        addBox(120, 1, 10, 0, 20.5, sign * 60, mat); // Front
+        addBox(120, 1, 10, 0, 20.5, sign * 120, mat); // Back
         addBox(10, 1, 80, -60, 20.5, baseZ, mat);     // Left
         addBox(10, 1, 80, 60, 20.5, baseZ, mat);      // Right
 
         // Towers at corners
-        addBox(16, 30, 16, -60, 15, sign * 80, mat);
-        addBox(16, 30, 16, 60, 15, sign * 80, mat);
-        addBox(16, 30, 16, -60, 15, sign * 160, mat);
-        addBox(16, 30, 16, 60, 15, sign * 160, mat);
+        addBox(16, 30, 16, -60, 15, sign * 60, mat);
+        addBox(16, 30, 16, 60, 15, sign * 60, mat);
+        addBox(16, 30, 16, -60, 15, sign * 120, mat);
+        addBox(16, 30, 16, 60, 15, sign * 120, mat);
 
         // Flag Room / Keep (Inner protected structure)
         addBox(10, 10, 26, -15, 5, sign * 142, mat); // left wall


### PR DESCRIPTION
### Motivation
- Reduce the playable CTF arena to shorten travel times and speed up rounds. 
- Tighten castle placement so objectives (flags, keeps, bridges) are closer together and pacing improves. 
- Keep overall architecture and gameplay features intact while scaling down geometry.

### Description
- Reduced the CTF outer bounds and enclosing walls by changing the arena extents from `X: ±80, Z: ±170` to `X: ±60, Z: ±130` in `games/fps.js`.
- Shortened side wall lengths from `400` to `300` and reduced back-wall lengths to match the smaller Z extent by adjusting the `addBox(...)` calls in `games/fps.js`.
- Moved castle centers inward by changing `baseZ` from `±120` to `±90`, and pulled front/back walls, walkways, and corner towers inward to align with the new scale.

### Testing
- No automated tests were executed for this geometry/layout change.
- The change is limited to `games/fps.js` and is a layout-only modification (visual/level geometry only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2462ed2008330b83dd6b26af997e3)