### PR TITLE
Map 'voice' game to chat overlay (globalChat) in launcher

### DIFF
--- a/script.js
+++ b/script.js
@@ -236,6 +236,7 @@ function renderInGameShopPanel(game, overlayId) {
 
 function getOverlayIdForGame(gameId) {
   if (!gameId) return "";
+  if (gameId === "voice") return "globalChat";
   return `overlay${gameId === "ttt" ? gameId.toUpperCase() : gameId.charAt(0).toUpperCase() + gameId.slice(1)}`;
 }
 


### PR DESCRIPTION
### Motivation
- The `voice` game entry in the catalog launches into a non-existent `overlayVoice` ID, but its UI lives inside the existing chat overlay (`globalChat`), so the launcher must resolve `voice` to `globalChat` to open the Voice Lounge correctly.

### Description
- Added a special-case in `getOverlayIdForGame` to return `"globalChat"` when `gameId === "voice"`, ensuring the launcher activates the chat overlay containing the Voice UI.

### Testing
- Ran `node --check script.js` which completed successfully.
- Ran a verification script that checks every `GAME_DIRECTORY_ENTRIES` id resolves to an existing DOM overlay and confirmed the mapping (`ALL_GAME_OVERLAYS_RESOLVE`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb17ec25c832b8d14af6192494a4f)