### PR TITLE
Add hidden admin-only FPS map maker with JSON export

### DIFF
--- a/core.js
+++ b/core.js
@@ -22,7 +22,7 @@ import {
   deleteDoc,
   getDocs,
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
-import { GAME_DIRECTORY_ENTRIES, LEADERBOARD_GAME_COLUMNS } from "./gameCatalog.js";
+import { GAME_DIRECTORY_ENTRIES, LEADERBOARD_GAME_COLUMNS, canAccessGameEntry } from "./gameCatalog.js";
 
 // Firebase project configuration.
 const defaultFirebaseConfig = {
@@ -2328,7 +2328,7 @@ function initRandomGameButton() {
   button.addEventListener("click", () => {
     if (typeof window.launchGame !== "function") return;
     const availableGames = GAME_DIRECTORY_ENTRIES
-      .filter((entry) => !entry.hidden)
+      .filter((entry) => canAccessGameEntry(entry, { isAdmin: isGodUser() }))
       .map((entry) => String(entry.id || "").trim())
       .filter((gameId) => Boolean(gameId));
     if (!availableGames.length) return;

--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -42,6 +42,7 @@ export const GAME_DIRECTORY_ENTRIES = Object.freeze([
   { id: "flappy", title: "FLAPPY GOON", description: "Secret bonus mode: tap to survive.", icon: "🐤", tags: ["arcade", "skill"], hidden: true, shopItems: ["item_flappy", "item_shield"] },
   { id: "fnaf", title: "FNAF 3D", description: "Multiplayer horror survival.", icon: "🐻", tags: ["arcade", "multiplayer", "survival"] },
   { id: "fps", title: "ARENA SHOOTER", description: "Fast-paced 3D multiplayer arena shooter.", icon: "🔫", tags: ["arcade", "multiplayer", "pvp", "fps"] },
+  { id: "fpsmapmaker", title: "FPS MAP MAKER", description: "Admin-only map editor for the FPS game with JSON export.", icon: "🗺️", tags: ["admin", "tools", "fps"], hidden: true, adminOnly: true },
   { id: "hexfall", title: "HEXFALL", description: "3D multiplayer hex survival arena.", icon: "⬢", tags: ["arcade", "skill", "puzzle", "multiplayer", "3d", "pvp"], shopItems: ["item_dodge_stabilizer", "item_shield"] },
 ]);
 

--- a/gameCatalog.js
+++ b/gameCatalog.js
@@ -57,6 +57,13 @@ export const LEADERBOARD_GAME_COLUMNS = Object.freeze(
   }))
 );
 
+export function canAccessGameEntry(entry, { isAdmin = false } = {}) {
+  if (!entry) return false;
+  if (entry.adminOnly && !isAdmin) return false;
+  if (entry.hidden && !(entry.adminOnly && isAdmin)) return false;
+  return true;
+}
+
 export const GAME_TAG_EMOJI = Object.freeze({
   arcade: "🕹️",
   skill: "🎯",

--- a/games/fpsmapmaker.js
+++ b/games/fpsmapmaker.js
@@ -1,0 +1,180 @@
+const TILE_SIZE = 24;
+const GRID_W = 30;
+const GRID_H = 18;
+
+const TOOL_DEFS = [
+  { id: "wall", label: "WALL" },
+  { id: "spawn", label: "SPAWN" },
+  { id: "health", label: "HEALTH" },
+  { id: "ammo", label: "AMMO" },
+  { id: "cover", label: "COVER" },
+  { id: "light", label: "LIGHT" },
+  { id: "erase", label: "ERASE" },
+  { id: "fill", label: "FILL" },
+  { id: "rect", label: "RECT" },
+  { id: "select", label: "SELECT" },
+];
+
+const COLORS = {
+  empty: "#151515",
+  wall: "#9a9a9a",
+  spawn: "#3ddf6d",
+  health: "#e84545",
+  ammo: "#4da3ff",
+  cover: "#e0ad42",
+  light: "#d997ff",
+};
+
+const state = {
+  mapName: "fps_custom_map",
+  grid: Array.from({ length: GRID_H }, () => Array.from({ length: GRID_W }, () => "empty")),
+  tool: "wall",
+  selected: null,
+  dragStart: null,
+  isDown: false,
+};
+
+function getEl(id) { return document.getElementById(id); }
+
+function toolValue(tool) { return tool === "erase" ? "empty" : tool; }
+
+function drawGrid() {
+  const canvas = getEl("fpsMapMakerCanvas");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "#111";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  for (let y = 0; y < GRID_H; y += 1) {
+    for (let x = 0; x < GRID_W; x += 1) {
+      const v = state.grid[y][x];
+      ctx.fillStyle = COLORS[v] || COLORS.empty;
+      ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE - 1, TILE_SIZE - 1);
+    }
+  }
+  if (state.selected) {
+    ctx.strokeStyle = "#fff";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(state.selected.x * TILE_SIZE + 1, state.selected.y * TILE_SIZE + 1, TILE_SIZE - 2, TILE_SIZE - 2);
+  }
+}
+
+function posToCell(e) {
+  const canvas = getEl("fpsMapMakerCanvas");
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.floor((e.clientX - rect.left) / TILE_SIZE);
+  const y = Math.floor((e.clientY - rect.top) / TILE_SIZE);
+  if (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H) return null;
+  return { x, y };
+}
+
+function paintCell(cell) {
+  if (!cell) return;
+  if (state.tool === "select") {
+    state.selected = cell;
+  } else if (state.tool !== "rect" && state.tool !== "fill") {
+    state.grid[cell.y][cell.x] = toolValue(state.tool);
+  }
+  drawGrid();
+}
+
+function fillAll() {
+  const value = toolValue(state.tool);
+  for (let y = 0; y < GRID_H; y += 1) {
+    for (let x = 0; x < GRID_W; x += 1) state.grid[y][x] = value;
+  }
+}
+
+function applyRect(from, to) {
+  if (!from || !to) return;
+  const minX = Math.min(from.x, to.x);
+  const maxX = Math.max(from.x, to.x);
+  const minY = Math.min(from.y, to.y);
+  const maxY = Math.max(from.y, to.y);
+  const value = toolValue(state.tool);
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) state.grid[y][x] = value;
+  }
+}
+
+function refreshToolUi() {
+  const panel = getEl("fpsMapMakerTools");
+  if (!panel) return;
+  panel.innerHTML = "";
+  TOOL_DEFS.forEach((tool) => {
+    const btn = document.createElement("button");
+    btn.className = `menu-btn${state.tool === tool.id ? " active" : ""}`;
+    btn.textContent = tool.label;
+    btn.onclick = () => { state.tool = tool.id; refreshToolUi(); };
+    panel.appendChild(btn);
+  });
+}
+
+function objectList() {
+  const objects = [];
+  for (let y = 0; y < GRID_H; y += 1) {
+    for (let x = 0; x < GRID_W; x += 1) {
+      const type = state.grid[y][x];
+      if (type !== "empty") objects.push({ type, x, y });
+    }
+  }
+  return objects;
+}
+
+function exportMap() {
+  state.mapName = String(getEl("fpsMapMakerName")?.value || "fps_custom_map").trim() || "fps_custom_map";
+  const payload = {
+    version: 1,
+    game: "fps",
+    name: state.mapName,
+    width: GRID_W,
+    height: GRID_H,
+    tileSize: TILE_SIZE,
+    objects: objectList(),
+  };
+  const pretty = JSON.stringify(payload, null, 2);
+  const blob = new Blob([pretty], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `${state.mapName.replace(/[^a-z0-9_-]+/gi, "_")}.json`;
+  a.click();
+  URL.revokeObjectURL(a.href);
+  const output = getEl("fpsMapMakerOutput");
+  if (output) output.value = pretty;
+}
+
+export function initFpsMapMaker() {
+  const canvas = getEl("fpsMapMakerCanvas");
+  if (!canvas) return;
+  refreshToolUi();
+  drawGrid();
+
+  canvas.onmousedown = (e) => {
+    state.isDown = true;
+    const cell = posToCell(e);
+    state.dragStart = cell;
+    if (state.tool === "fill") {
+      fillAll();
+      drawGrid();
+      return;
+    }
+    if (state.tool !== "rect") paintCell(cell);
+  };
+  canvas.onmousemove = (e) => {
+    if (!state.isDown) return;
+    if (state.tool === "rect" || state.tool === "select") return;
+    paintCell(posToCell(e));
+  };
+  canvas.onmouseup = (e) => {
+    if (!state.isDown) return;
+    state.isDown = false;
+    if (state.tool === "rect") {
+      applyRect(state.dragStart, posToCell(e));
+      drawGrid();
+    }
+  };
+  getEl("fpsMapMakerClear").onclick = () => {
+    state.grid = Array.from({ length: GRID_H }, () => Array.from({ length: GRID_W }, () => "empty"));
+    drawGrid();
+  };
+  getEl("fpsMapMakerExport").onclick = exportMap;
+}

--- a/index.html
+++ b/index.html
@@ -2792,6 +2792,21 @@
       <button class="exit-btn-fixed" onclick="window.closeOverlays()">EXIT SYSTEM</button>
     </div>
 
+    <div class="overlay" id="overlayFpsmapmaker">
+      <div id="fpsMapMakerMenu" class="menu-box" style="width:min(95vw,1040px);">
+        <h2 style="color:#8be9fd; margin-top:0;">FPS MAP MAKER (ADMIN)</h2>
+        <p style="font-size:12px; color:#aaa;">Design FPS maps and export JSON files for your repo's <code>maps/</code> folder.</p>
+        <input id="fpsMapMakerName" class="term-input" placeholder="MAP NAME" value="fps_custom_map" style="margin-bottom:8px;"/>
+        <div id="fpsMapMakerTools" style="display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px;"></div>
+        <canvas id="fpsMapMakerCanvas" width="720" height="432" style="border:1px solid #3d3d3d; background:#111; width:100%; max-width:720px;"></canvas>
+        <div style="display:flex; gap:8px; justify-content:center; margin-top:10px;">
+          <button id="fpsMapMakerClear" class="menu-btn" type="button">CLEAR</button>
+          <button id="fpsMapMakerExport" class="menu-btn" type="button">EXPORT JSON</button>
+        </div>
+        <textarea id="fpsMapMakerOutput" class="term-input" style="margin-top:10px; height:140px; font-family:monospace;" placeholder="Exported JSON preview appears here..."></textarea>
+      </div>
+    </div>
+
     <!-- Game-over modal shared across mini-games. -->
     <div id="modalGameOver" class="game-over-modal">
       <h1>SYSTEM FAILURE</h1>

--- a/script.js
+++ b/script.js
@@ -101,7 +101,7 @@ import { initMines } from "./games/mines.js";
 import "./games/fnaf.js";
 import { initFps } from "./games/fps.js";
 import { initFpsMapMaker } from "./games/fpsmapmaker.js";
-import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
+import { GAME_DIRECTORY_ENTRIES, canAccessGameEntry } from "./gameCatalog.js";
 
 // Expose select helpers globally for inline HTML event handlers.
 window.openGame = openGame;
@@ -901,7 +901,7 @@ function initMainSiteSearch() {
 
   function findBestGameMatch(query) {
     return GAME_DIRECTORY_ENTRIES
-      .filter((entry) => ((!entry.hidden) || (entry.adminOnly && isGodUser())) && (!entry.adminOnly || isGodUser()))
+      .filter((entry) => canAccessGameEntry(entry, { isAdmin: isGodUser() }))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {
@@ -938,7 +938,7 @@ function initMainSiteSearch() {
     if (!query) return [];
 
     const gameSuggestions = GAME_DIRECTORY_ENTRIES
-      .filter((entry) => ((!entry.hidden) || (entry.adminOnly && isGodUser())) && (!entry.adminOnly || isGodUser()))
+      .filter((entry) => canAccessGameEntry(entry, { isAdmin: isGodUser() }))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {

--- a/script.js
+++ b/script.js
@@ -55,6 +55,7 @@ import {
   claimAprilFoolsSecretItem,
   openGameLeaderboard,
   escapeHtml,
+  isGodUser,
 } from "./core.js";
 import { initGeometry } from "./games/geo.js";
 import { initFlappy } from "./games/flappy.js";
@@ -99,6 +100,7 @@ import { initBaccarat } from "./games/baccarat.js";
 import { initMines } from "./games/mines.js";
 import "./games/fnaf.js";
 import { initFps } from "./games/fps.js";
+import { initFpsMapMaker } from "./games/fpsmapmaker.js";
 import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
 
 // Expose select helpers globally for inline HTML event handlers.
@@ -292,6 +294,8 @@ function initSharedGamebox() {
 
 // Launch a game by name, activate its overlay, and kick off its init routine.
 window.launchGame = (game, source = "direct") => {
+  const entry = GAME_DIRECTORY_ENTRIES.find((candidate) => candidate.id === game);
+  if (entry?.adminOnly && !isGodUser()) return;
   window.__goonerLastGameLaunchSource = source;
   window.closeOverlays();
 
@@ -350,6 +354,7 @@ window.launchGame = (game, source = "direct") => {
   if (game === "mines") initMines();
   if (game === "fnaf") window.initFnaf();
   if (game === "fps") initFps();
+  if (game === "fpsmapmaker") initFpsMapMaker();
   if (game === "hexfall") initHexfall();
   if (typeof window.__updateGameSwitcherState === "function") window.__updateGameSwitcherState(game);
 
@@ -551,7 +556,11 @@ function initGameScroller() {
       overlayId: getOverlayIdForGame(entry.id),
       searchText: `${entry.id} ${entry.title} ${entry.description || ""} ${(entry.tags || []).join(" ")}`.toUpperCase(),
     }))
-    .filter((entry) => document.getElementById(entry.overlayId));
+    .filter((entry) => document.getElementById(entry.overlayId))
+    .filter((entry) => {
+      const meta = GAME_DIRECTORY_ENTRIES.find((candidate) => candidate.id === entry.id);
+      return !(meta?.adminOnly) || isGodUser();
+    });
   if (!orderedGames.length) return;
 
   const strip = document.getElementById("gameboxGameStrip");
@@ -892,7 +901,7 @@ function initMainSiteSearch() {
 
   function findBestGameMatch(query) {
     return GAME_DIRECTORY_ENTRIES
-      .filter((entry) => !entry.hidden)
+      .filter((entry) => !entry.hidden && (!entry.adminOnly || isGodUser()))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {
@@ -929,7 +938,7 @@ function initMainSiteSearch() {
     if (!query) return [];
 
     const gameSuggestions = GAME_DIRECTORY_ENTRIES
-      .filter((entry) => !entry.hidden)
+      .filter((entry) => !entry.hidden && (!entry.adminOnly || isGodUser()))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {

--- a/script.js
+++ b/script.js
@@ -901,7 +901,7 @@ function initMainSiteSearch() {
 
   function findBestGameMatch(query) {
     return GAME_DIRECTORY_ENTRIES
-      .filter((entry) => !entry.hidden && (!entry.adminOnly || isGodUser()))
+      .filter((entry) => ((!entry.hidden) || (entry.adminOnly && isGodUser())) && (!entry.adminOnly || isGodUser()))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {
@@ -938,7 +938,7 @@ function initMainSiteSearch() {
     if (!query) return [];
 
     const gameSuggestions = GAME_DIRECTORY_ENTRIES
-      .filter((entry) => !entry.hidden && (!entry.adminOnly || isGodUser()))
+      .filter((entry) => ((!entry.hidden) || (entry.adminOnly && isGodUser())) && (!entry.adminOnly || isGodUser()))
       .map((entry) => ({ entry, score: scoreGameSuggestion(entry, query) }))
       .filter((item) => item.score < 99)
       .sort((a, b) => {


### PR DESCRIPTION
### Motivation
- Provide administrators with an in-browser map editor for the FPS game to design maps and export them as JSON for repository `maps/` uploads.
- Keep the tool hidden from regular users and prevent non-admin launches by default to avoid accidental exposure.

### Description
- Added a new game module `games/fpsmapmaker.js` that implements a grid-based map editor with tools: `wall`, `spawn`, `health`, `ammo`, `cover`, `light`, `erase`, `fill`, `rect`, and `select` and an export routine that produces JSON containing `version`, `game`, `name`, `width`, `height`, `tileSize`, and an `objects` array of `{type,x,y}`.
- Registered the new entry in `gameCatalog.js` as `{ id: "fpsmapmaker", ..., hidden: true, adminOnly: true }` so it does not appear publicly.
- Added a dedicated overlay UI in `index.html` (`#overlayFpsmapmaker`) with name input, tool bar, editor canvas, clear/export controls, and JSON preview.
- Wired the editor into the launcher in `script.js` by importing `initFpsMapMaker`, invoking it when `fpsmapmaker` is launched, and adding guard/filter logic that blocks launching or listing `adminOnly` entries for non-admin users via `isGodUser` checks.

### Testing
- Ran `node --check script.js` and it completed without syntax errors.
- Ran `node --check games/fpsmapmaker.js` and it completed without syntax errors.
- Verified the new files were staged/committed (no automated unit tests were added or run beyond JS syntax checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f249a523d4832ba2ffcb73d0da73ff)