### PR TITLE
Add Rocket Launcher: low-velocity explosive missiles with large blast radius

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -12,7 +12,7 @@ let muzzleFlashTime = 0;
 let nextFireTime = 0;
 let isReloading = false;
 let reloadEndTime = 0;
-let ammo = [12, 6, 2, 250]; // Current ammo for each weapon
+let ammo = [12, 6, 2, 250, 1]; // Current ammo for each weapon
 let recoilTime = 0;
 let recoilIntensity = 0;
 let bobTime = 0;
@@ -1112,7 +1112,8 @@ const WEAPONS = [
   { name: "PISTOL", color: 0x555555, cooldown: 400, damage: 25, spread: 0, magSize: 12, reloadTime: 1200 },
   { name: "SHOTGUN", color: 0x882222, cooldown: 1000, damage: 20, spread: 0.1, bullets: 5, magSize: 6, reloadTime: 2000 },
   { name: "SNIPER", color: 0x228822, cooldown: 1500, damage: 100, spread: 0, magSize: 2, reloadTime: 2500 },
-  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3600, immobilizesOnFire: true }
+  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3600, immobilizesOnFire: true },
+  { name: "ROCKET LAUNCHER", color: 0xcc5522, cooldown: 1300, damage: 140, spread: 0.01, magSize: 1, reloadTime: 2200, firesProjectile: true }
 ];
 
 function resetGatlingRamp() {
@@ -1279,6 +1280,7 @@ function onKeyDown(event) {
     case 'Digit2': switchWeapon(1); break;
     case 'Digit3': switchWeapon(2); break;
     case 'Digit4': switchWeapon(3); break;
+    case 'Digit5': switchWeapon(4); break;
     case 'KeyR': startReload(); break;
     case 'KeyG': throwGrenade(); break;
   }
@@ -1559,6 +1561,15 @@ function tryFireWeapon() {
   let spread = weapon.spread || 0;
   if (localPlayer.weapon === 3) {
     spread = getGatlingSpread(now, spread);
+  }
+
+  if (weapon.firesProjectile) {
+    room.send("shoot", {
+      origin: { x: origin.x, y: origin.y, z: origin.z },
+      dir: { x: dir.x, y: dir.y, z: dir.z },
+      weaponId: localPlayer.weapon
+    });
+    return;
   }
 
   for (let i = 0; i < bullets; i++) {

--- a/server.js
+++ b/server.js
@@ -2810,8 +2810,8 @@ class FPSRoom extends colyseus.Room {
 
   explodeRocket(ex, ey, ez, ownerId) {
     this.broadcast("rocketExplode", { x: ex, y: ey, z: ez });
-    const radius = 15;
-    const maxDamage = 80;
+    const radius = 28;
+    const maxDamage = 140;
 
     let shooterClient = this.clients.find(c => c.sessionId === ownerId);
     let shooter = this.state.players.get(ownerId);
@@ -2984,6 +2984,24 @@ class FPSRoom extends colyseus.Room {
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
+
+      if (data.weaponId === 4) {
+        const proj = new FPSProjectile();
+        proj.id = Math.random().toString(36).substr(2, 9);
+        proj.ownerId = client.sessionId;
+        proj.type = 0; // Rocket
+        proj.x = data.origin.x;
+        proj.y = data.origin.y;
+        proj.z = data.origin.z;
+        proj.dx = data.dir.x;
+        proj.dy = data.dir.y;
+        proj.dz = data.dir.z;
+        proj.speed = 0.55; // intentionally low velocity
+        proj.life = 3500;
+        this.state.projectiles.set(proj.id, proj);
+        this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
+        return;
+      }
 
       this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
 


### PR DESCRIPTION
### Motivation
- Add a new heavy weapon that launches true projectile rockets (not hitscan) which travel slowly and create a large-area explosion on impact. 
- Provide a gameplay option that trades low projectile speed for high splash damage and radius for FPS mode variety.

### Description
- Added a `ROCKET LAUNCHER` entry to the client `WEAPONS` list and extended the `ammo` array to include the new weapon (`firesProjectile: true`).
- Added keyboard slot `5` (`Digit5`) to select the rocket launcher and updated client firing flow so weapons with `firesProjectile` call `room.send("shoot", ...)` and return early from the hitscan loop. 
- Server-side `shoot` handler now spawns an `FPSProjectile` when `weaponId === 4`, setting `type = 0` (rocket), low `speed` (0.55) and increased `life` so rockets travel slowly. 
- Tuned rocket explosion handling by increasing `explodeRocket` radius and `maxDamage` to make impacts produce a large-area, high-damage blast.

### Testing
- Ran client and server syntax checks with `node --check games/fps.js` which succeeded. 
- Ran `node --check server.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24d9a19588330b38e75702a5ded77)