### PR TITLE
Gatling: arrange barrels in triangular cluster and spin while firing

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1375,19 +1375,16 @@ function createGunModel(id) {
     gatlingBarrelCluster.position.set(0, 0, -0.35);
     gunMesh.add(gatlingBarrelCluster);
 
-    const barrelRadius = 0.06;
-    const barrelAngles = [
-      Math.PI / 2,
-      Math.PI / 2 + (Math.PI * 2 / 3),
-      Math.PI / 2 + (Math.PI * 4 / 3)
-    ];
-    barrelAngles.forEach((angle) => {
+    const barrelCount = 7;
+    const barrelRadius = 0.075;
+    for (let i = 0; i < barrelCount; i++) {
+      const angle = (i / barrelCount) * Math.PI * 2;
       const barrelGeo = new THREE.CylinderGeometry(0.03, 0.03, 1.2, 16);
       const barrel = new THREE.Mesh(barrelGeo, matMain);
       barrel.rotation.x = Math.PI / 2;
       barrel.position.set(0, Math.cos(angle) * barrelRadius, Math.sin(angle) * barrelRadius);
       gatlingBarrelCluster.add(barrel);
-    });
+    }
   } else if (id === 4) { // Rocket Launcher
     const barrelGeo = new THREE.CylinderGeometry(0.2, 0.2, 1.5, 12);
     barrelGeo.rotateX(Math.PI / 2);

--- a/games/fps.js
+++ b/games/fps.js
@@ -7,6 +7,7 @@ let floorMesh;
 let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0, team: 0 };
 let otherPlayers = {}; // id -> { mesh, data, targetPos, targetRotY, lastNetUpdate }
 let gunMesh;
+let gatlingBarrelCluster = null;
 let muzzleFlash, muzzleLight;
 let muzzleFlashTime = 0;
 let nextFireTime = 0;
@@ -1286,6 +1287,7 @@ function onKeyDown(event) {
 
 function createGunModel(id) {
   if (!gunMesh) return;
+  gatlingBarrelCluster = null;
 
   // Clear existing parts (except muzzle flash and light)
   for (let i = gunMesh.children.length - 1; i >= 0; i--) {
@@ -1369,13 +1371,22 @@ function createGunModel(id) {
     handle.rotation.x = -Math.PI / 12;
     gunMesh.add(handle);
 
-    const barrelOffsets = [-0.06, 0, 0.06];
-    barrelOffsets.forEach((yOffset) => {
+    gatlingBarrelCluster = new THREE.Group();
+    gatlingBarrelCluster.position.set(0, 0, -0.35);
+    gunMesh.add(gatlingBarrelCluster);
+
+    const barrelRadius = 0.06;
+    const barrelAngles = [
+      Math.PI / 2,
+      Math.PI / 2 + (Math.PI * 2 / 3),
+      Math.PI / 2 + (Math.PI * 4 / 3)
+    ];
+    barrelAngles.forEach((angle) => {
       const barrelGeo = new THREE.CylinderGeometry(0.03, 0.03, 1.2, 16);
       const barrel = new THREE.Mesh(barrelGeo, matMain);
       barrel.rotation.x = Math.PI / 2;
-      barrel.position.set(0, yOffset, -0.35);
-      gunMesh.add(barrel);
+      barrel.position.set(0, Math.cos(angle) * barrelRadius, Math.sin(angle) * barrelRadius);
+      gatlingBarrelCluster.add(barrel);
     });
   } else if (id === 4) { // Rocket Launcher
     const barrelGeo = new THREE.CylinderGeometry(0.2, 0.2, 1.5, 12);
@@ -2046,6 +2057,13 @@ function animate() {
     gunMesh.position.y += (targetY - gunMesh.position.y) * dampFactor;
     gunMesh.position.z += (targetZ - gunMesh.position.z) * dampFactor;
     gunMesh.rotation.x += (targetRotX - gunMesh.rotation.x) * dampFactor;
+  }
+
+  if (gatlingBarrelCluster) {
+    const isGatlingFiring = isPrimaryFireHeld && localPlayer.weapon === 3 && !isReloading && ammo[3] > 0 && localPlayer.health > 0;
+    if (isGatlingFiring) {
+      gatlingBarrelCluster.rotation.z += delta * 25;
+    }
   }
 
   if (isPrimaryFireHeld && localPlayer.weapon === 3) {

--- a/games/fps.js
+++ b/games/fps.js
@@ -1375,7 +1375,7 @@ function createGunModel(id) {
     gatlingBarrelCluster.position.set(0, 0, -0.35);
     gunMesh.add(gatlingBarrelCluster);
 
-    const barrelCount = 7;
+    const barrelCount = 6;
     const radialDistanceFromCenter = 0.075;
     const angleStep = (Math.PI * 2) / barrelCount;
     const startAngle = -Math.PI / 2;
@@ -1387,6 +1387,18 @@ function createGunModel(id) {
       barrel.position.set(0, Math.cos(angle) * radialDistanceFromCenter, Math.sin(angle) * radialDistanceFromCenter);
       gatlingBarrelCluster.add(barrel);
     }
+
+    const hubGeo = new THREE.CylinderGeometry(0.028, 0.028, 1.2, 16);
+    const hub = new THREE.Mesh(hubGeo, matDark);
+    hub.rotation.x = Math.PI / 2;
+    hub.position.set(0, 0, 0);
+    gatlingBarrelCluster.add(hub);
+
+    const muzzleRingGeo = new THREE.CylinderGeometry(0.13, 0.13, 0.1, 20, 1, true);
+    const muzzleRing = new THREE.Mesh(muzzleRingGeo, matDark);
+    muzzleRing.rotation.x = Math.PI / 2;
+    muzzleRing.position.set(0, 0, -0.58);
+    gatlingBarrelCluster.add(muzzleRing);
   } else if (id === 4) { // Rocket Launcher
     const barrelGeo = new THREE.CylinderGeometry(0.2, 0.2, 1.5, 12);
     barrelGeo.rotateX(Math.PI / 2);

--- a/games/fps.js
+++ b/games/fps.js
@@ -1376,13 +1376,15 @@ function createGunModel(id) {
     gunMesh.add(gatlingBarrelCluster);
 
     const barrelCount = 7;
-    const barrelRadius = 0.075;
+    const radialDistanceFromCenter = 0.075;
+    const angleStep = (Math.PI * 2) / barrelCount;
+    const startAngle = -Math.PI / 2;
     for (let i = 0; i < barrelCount; i++) {
-      const angle = (i / barrelCount) * Math.PI * 2;
+      const angle = startAngle + i * angleStep;
       const barrelGeo = new THREE.CylinderGeometry(0.03, 0.03, 1.2, 16);
       const barrel = new THREE.Mesh(barrelGeo, matMain);
       barrel.rotation.x = Math.PI / 2;
-      barrel.position.set(0, Math.cos(angle) * barrelRadius, Math.sin(angle) * barrelRadius);
+      barrel.position.set(0, Math.cos(angle) * radialDistanceFromCenter, Math.sin(angle) * radialDistanceFromCenter);
       gatlingBarrelCluster.add(barrel);
     }
   } else if (id === 4) { // Rocket Launcher


### PR DESCRIPTION
### Motivation
- Implement the requested visual/animation change so the Gatling gun's three barrels are arranged in a triangle and visibly rotate when the weapon is fired.

### Description
- Added a `gatlingBarrelCluster` `THREE.Group` and a top-level reference in `games/fps.js` to hold the Gatling barrels. 
- Replaced the previous vertical-barrel layout in `createGunModel` with three barrels positioned around a circle using trigonometric offsets for 120° spacing. 
- Reset `gatlingBarrelCluster` whenever the gun model is rebuilt via `createGunModel` so it only exists for the Gatling weapon. 
- Added runtime animation in the main `animate` loop to spin `gatlingBarrelCluster` while primary fire is held and the player is alive, has ammo, and is not reloading (conditions mirror firing checks).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36e1acc508330b8ae00978c67b9ba)