### PR TITLE
Remove dead enemies after abilities execute

### DIFF
--- a/games/shadow-assassin-safe-rooms.html
+++ b/games/shadow-assassin-safe-rooms.html
@@ -4404,6 +4404,7 @@
                                     }
                                     enemy.health = 0;
                                 }
+                                removeDeadEnemies();
                             }, 500);
                         }
                         break;
@@ -4437,9 +4438,7 @@
                 }
                 
                 // CRITICAL FIX: Remove dead enemies after abilities execute
-                setTimeout(() => {
-                    removeDeadEnemies();
-                }, 100);
+                removeDeadEnemies();
             }
 
             update() {


### PR DESCRIPTION
This change refactors the enemy cleanup logic in `games/shadow-assassin-safe-rooms.html`. It replaces a brittle 100ms `setTimeout` workaround with a more targeted approach: immediate cleanup for synchronous abilities and specific cleanup within the callback for the asynchronous `chainReaction` ability. This ensures that dead enemies are removed as soon as they take fatal damage, preventing logical inconsistencies. Verified with Playwright tests and visual screenshots.

---
*PR created automatically by Jules for task [13232213112339892785](https://jules.google.com/task/13232213112339892785) started by @thefoxssss*