### PR TITLE
Fix FPS map builder Three.js module resolution

### DIFF
--- a/games/fps-map-builder.html
+++ b/games/fps-map-builder.html
@@ -191,8 +191,16 @@ body{margin:0;font-family:Inter,system-ui,Arial,sans-serif;background:var(--bg-d
 
 <input type="file" id="uploadInput" style="display:none" accept=".json">
 
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+import * as THREE from 'three';
 import { TransformControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/controls/TransformControls.js';
 
 // State


### PR DESCRIPTION
### Motivation
- The page was failing with `Uncaught TypeError: Failed to resolve module specifier "three"` because `TransformControls` and other example modules use the bare `three` specifier which needs an import map (or bundler) in browser environments.

### Description
- Added an `importmap` mapping `"three"` to `https://unpkg.com/three@0.161.0/build/three.module.js` and updated the main module import to `import * as THREE from 'three';` in `games/fps-map-builder.html`.

### Testing
- Ran `git diff -- games/fps-map-builder.html` to verify the diff and it reported the expected changes (succeeded). 
- Displayed the updated section with `nl -ba games/fps-map-builder.html | sed -n '186,214p'` to confirm the import map and import statement (succeeded). 
- Committed the change with `git commit -m "Fix FPS map builder three.js module resolution"` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0013cc58832b92bb7695c52e6d26)