### PR TITLE
Fix Wordle tile spin glitch after a guess

### DIFF
--- a/games/wordle.js
+++ b/games/wordle.js
@@ -9,6 +9,7 @@ let currentGuess = "";
 let guesses = [];
 let gameFinished = false;
 let keyStates = {}; // 'correct', 'present', 'absent'
+let pendingFlipRow = -1;
 
 // Default stats
 const DEFAULT_STATS = {
@@ -60,6 +61,7 @@ function startNewGame() {
   guesses = [];
   gameFinished = false;
   keyStates = {};
+  pendingFlipRow = -1;
 
   updateGrid();
   updateKeyboard();
@@ -162,6 +164,7 @@ function submitGuess() {
     });
 
     currentGuess = "";
+    pendingFlipRow = guesses.length - 1;
     updateGrid();
     updateKeyboard();
 
@@ -231,15 +234,19 @@ function updateGrid() {
 
             if (row < guesses.length) {
                 cell.classList.add(guessStates[col]);
-                // Add a small delay for animation effect
-                cell.style.animationDelay = `${col * 0.1}s`;
-                cell.classList.add('flip');
+                if (row === pendingFlipRow) {
+                    // Animate only the newly submitted row once.
+                    cell.style.animationDelay = `${col * 0.1}s`;
+                    cell.classList.add('flip');
+                }
             }
 
             rowDiv.appendChild(cell);
         }
         grid.appendChild(rowDiv);
     }
+
+    pendingFlipRow = -1;
 }
 
 function updateKeyboard() {


### PR DESCRIPTION
### Motivation
- Prevent previously guessed rows from re-triggering the flip animation when the grid is re-rendered while typing after submitting a guess.

### Description
- Introduced `pendingFlipRow` (initialized to `-1`) to mark the newly submitted row for a one-time flip animation.
- Set `pendingFlipRow = guesses.length - 1` in `submitGuess()` so only the just-submitted row gets the flip delay and `flip` class.
- Updated `updateGrid()` to apply `cell.style.animationDelay` and `cell.classList.add('flip')` only when `row === pendingFlipRow`, and reset `pendingFlipRow` to `-1` after rendering. 
- Reset `pendingFlipRow` in `startNewGame()` to ensure a clean state on new games.

### Testing
- Automated attempt to import the module with `node -e "import('./games/wordle.js')"` failed due to Node ESM/browser-only import loader behavior (warning/error unrelated to the logic change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5050902c8327bb7ec2634831e132)