### PR TITLE
Reveal Wordle answer on win

### DIFF
--- a/games/wordle.js
+++ b/games/wordle.js
@@ -10,7 +10,7 @@ let guesses = [];
 let gameFinished = false;
 let keyStates = {}; // 'correct', 'present', 'absent'
 let pendingFlipRow = -1;
-let gameOutcome = null; // 'win', 'lose', or null for active game
+let lastLostWord = "";
 
 // Default stats
 const DEFAULT_STATS = {
@@ -63,7 +63,7 @@ function startNewGame() {
   gameFinished = false;
   keyStates = {};
   pendingFlipRow = -1;
-  gameOutcome = null;
+  lastLostWord = "";
 
   updateGrid();
   updateKeyboard();
@@ -173,8 +173,8 @@ function submitGuess() {
     const lastGuess = guesses[guesses.length - 1];
     if (lastGuess === targetWord) {
         gameFinished = true;
-        setText('wordleStatus', `ACCESS GRANTED — WORD: ${targetWord}`);
-        gameOutcome = 'win';
+        setText('wordleStatus', 'ACCESS GRANTED');
+        lastLostWord = "";
         playSuccessSound();
         updateAndSaveStats(true, guesses.length);
         setTimeout(() => {
@@ -182,7 +182,7 @@ function submitGuess() {
         }, 1500);
     } else if (guesses.length >= 6) {
         gameFinished = true;
-        gameOutcome = 'lose';
+        lastLostWord = targetWord;
         setText('wordleStatus', `TRACE FAILED — WORD: ${targetWord}`);
         updateAndSaveStats(false, guesses.length);
         setTimeout(() => {
@@ -280,9 +280,9 @@ function updateStatsUI() {
 
     const revealEl = document.getElementById('wordleStatsReveal');
     if (revealEl) {
-        if (gameOutcome === 'lose') {
+        if (lastLostWord) {
             revealEl.style.display = 'block';
-            revealEl.innerText = `WORD WAS: ${targetWord}`;
+            revealEl.innerText = `WORD WAS: ${lastLostWord}`;
         } else {
             revealEl.style.display = 'none';
             revealEl.innerText = '';

--- a/games/wordle.js
+++ b/games/wordle.js
@@ -10,6 +10,7 @@ let guesses = [];
 let gameFinished = false;
 let keyStates = {}; // 'correct', 'present', 'absent'
 let pendingFlipRow = -1;
+let gameOutcome = null; // 'win', 'lose', or null for active game
 
 // Default stats
 const DEFAULT_STATS = {
@@ -62,6 +63,7 @@ function startNewGame() {
   gameFinished = false;
   keyStates = {};
   pendingFlipRow = -1;
+  gameOutcome = null;
 
   updateGrid();
   updateKeyboard();
@@ -172,6 +174,7 @@ function submitGuess() {
     if (lastGuess === targetWord) {
         gameFinished = true;
         setText('wordleStatus', `ACCESS GRANTED — WORD: ${targetWord}`);
+        gameOutcome = 'win';
         playSuccessSound();
         updateAndSaveStats(true, guesses.length);
         setTimeout(() => {
@@ -179,6 +182,7 @@ function submitGuess() {
         }, 1500);
     } else if (guesses.length >= 6) {
         gameFinished = true;
+        gameOutcome = 'lose';
         setText('wordleStatus', `TRACE FAILED — WORD: ${targetWord}`);
         updateAndSaveStats(false, guesses.length);
         setTimeout(() => {
@@ -272,6 +276,18 @@ function updateStatsUI() {
     if (distContainer) {
         distContainer.innerHTML = '';
         const maxDist = Math.max(...stats.guessDistribution, 1);
+
+
+    const revealEl = document.getElementById('wordleStatsReveal');
+    if (revealEl) {
+        if (gameOutcome === 'lose') {
+            revealEl.style.display = 'block';
+            revealEl.innerText = `WORD WAS: ${targetWord}`;
+        } else {
+            revealEl.style.display = 'none';
+            revealEl.innerText = '';
+        }
+    }
 
         stats.guessDistribution.forEach((count, i) => {
             const row = document.createElement('div');

--- a/games/wordle.js
+++ b/games/wordle.js
@@ -171,7 +171,7 @@ function submitGuess() {
     const lastGuess = guesses[guesses.length - 1];
     if (lastGuess === targetWord) {
         gameFinished = true;
-        setText('wordleStatus', 'ACCESS GRANTED');
+        setText('wordleStatus', `ACCESS GRANTED — WORD: ${targetWord}`);
         playSuccessSound();
         updateAndSaveStats(true, guesses.length);
         setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -1817,6 +1817,7 @@
       <div id="wordleStatsModal" class="wordle-stats-modal" style="display: none;">
         <div class="wordle-stats-content">
           <h2>STATISTICS</h2>
+          <div id="wordleStatsReveal" style="display: none; margin-bottom: 10px; font-size: 14px; color: #f8d66d;"></div>
           <div class="wordle-stats-row">
             <div class="wordle-stat-item">
               <div class="wordle-stat-val" id="wordleStatPlayed">0</div>


### PR DESCRIPTION
### Motivation
- Ensure parity between win and lose states by revealing the solved word in the status line when a player wins.

### Description
- Update `games/wordle.js` to change the win status from `ACCESS GRANTED` to `ACCESS GRANTED — WORD: ${targetWord}` so the answer is displayed on victory.

### Testing
- No automated tests were executed for this small UI text change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb539152588322a6c9738dd1644010)