### PR TITLE
Add controllable air speed gain to FPS movement

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -43,9 +43,9 @@ const crouchSpeed = 20.0;
 const jumpVelocity = 15.0;
 const gravity = 40.0;
 const groundFriction = 10.0;
-const airFriction = 1.2;
-const airAcceleration = 55.0;
-const maxAirSpeed = 95.0;
+const airFriction = 3.5;
+const airAcceleration = 22.0;
+const maxAirSpeed = 60.0;
 let prevTime = performance.now();
 
 // Bullet tracers

--- a/games/fps.js
+++ b/games/fps.js
@@ -42,6 +42,10 @@ const sprintSpeed = 70.0;
 const crouchSpeed = 20.0;
 const jumpVelocity = 15.0;
 const gravity = 40.0;
+const groundFriction = 10.0;
+const airFriction = 1.2;
+const airAcceleration = 55.0;
+const maxAirSpeed = 95.0;
 let prevTime = performance.now();
 
 // Bullet tracers
@@ -1990,8 +1994,10 @@ function animate() {
 
   if (controls.isLocked && localPlayer.health > 0) {
     const movementLockedByWeapon = time < gatlingMovementLockUntil;
-    velocity.x -= velocity.x * 10.0 * delta;
-    velocity.z -= velocity.z * 10.0 * delta;
+    const onGround = canJump;
+    const friction = onGround ? groundFriction : airFriction;
+    velocity.x -= velocity.x * friction * delta;
+    velocity.z -= velocity.z * friction * delta;
     velocity.y -= gravity * delta; // 100.0 = mass
 
     direction.z = movementLockedByWeapon ? 0 : Number(moveForward) - Number(moveBackward);
@@ -2002,8 +2008,21 @@ function animate() {
     if (isSprinting) currentSpeed = sprintSpeed;
     if (isCrouching) currentSpeed = crouchSpeed;
 
-    if (!movementLockedByWeapon && (moveForward || moveBackward)) velocity.z -= direction.z * currentSpeed * delta;
-    if (!movementLockedByWeapon && (moveLeft || moveRight)) velocity.x -= direction.x * currentSpeed * delta;
+    if (!movementLockedByWeapon && (moveForward || moveBackward || moveLeft || moveRight)) {
+      if (onGround) {
+        velocity.z -= direction.z * currentSpeed * delta;
+        velocity.x -= direction.x * currentSpeed * delta;
+      } else {
+        velocity.z -= direction.z * airAcceleration * delta;
+        velocity.x -= direction.x * airAcceleration * delta;
+        const horizontalSpeed = Math.hypot(velocity.x, velocity.z);
+        if (horizontalSpeed > maxAirSpeed) {
+          const clamp = maxAirSpeed / horizontalSpeed;
+          velocity.x *= clamp;
+          velocity.z *= clamp;
+        }
+      }
+    }
 
     const playerRadius = 0.5;
     const dx = -velocity.x * delta;


### PR DESCRIPTION
### Motivation
- Enable players to build and control horizontal speed while airborne to support classic FPS-style air control and bunnyhopping behavior.
- Provide tunable parameters for ground vs air movement so designers can balance mid-air mobility without breaking ground movement.

### Description
- Introduced new movement tuning constants: `groundFriction`, `airFriction`, `airAcceleration`, and `maxAirSpeed` in `games/fps.js`.
- Reworked the per-frame movement block to apply lighter friction when airborne and to use `airAcceleration` for input-driven airborne acceleration while preserving ground acceleration behavior.
- Added a horizontal speed clamp while airborne using `maxAirSpeed` to prevent runaway velocities and to keep movement deterministic.
- No other gameplay systems or files were modified.

### Testing
- Ran a syntax check with `node --check games/fps.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb806d88bc832b891bee99c0911db3)