### PR TITLE
Gate Gatling behind 5-kill streak

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -4,7 +4,7 @@ let room = null;
 let scene, camera, renderer, controls;
 let raycaster;
 let floorMesh;
-let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, weapon: 0, team: 0 };
+let localPlayer = { id: "", x: 0, y: 1.5, z: 0, health: 100, kills: 0, killStreak: 0, weapon: 0, team: 0 };
 let otherPlayers = {}; // id -> { mesh, data, targetPos, targetRotY, lastNetUpdate }
 let gunMesh;
 let muzzleFlash, muzzleLight;
@@ -244,6 +244,8 @@ function setupRoom() {
   });
 
   room.onMessage("killed", (data) => {
+    localPlayer.killStreak = 0;
+    if (localPlayer.weapon === 3) switchWeapon(0);
     unzoomSniper();
     fpsDeathMessage.textContent = `FRAGGED BY ${data.killer}`;
     fpsDeathScreen.style.display = "flex";
@@ -307,6 +309,7 @@ function setupRoom() {
       localPlayer.id = sessionId;
       localPlayer.health = player.health;
       localPlayer.kills = player.kills;
+      localPlayer.killStreak = player.killStreak;
       localPlayer.team = player.team;
       grenades = 2;
       updateGrenadeUI();
@@ -320,6 +323,9 @@ function setupRoom() {
       player.listen("kills", (val) => {
         localPlayer.kills = val;
         fpsKills.textContent = val;
+      });
+      player.listen("killStreak", (val) => {
+        localPlayer.killStreak = val;
         if (!isGatlingUnlocked() && localPlayer.weapon === 3) {
           switchWeapon(0);
         }
@@ -1246,7 +1252,7 @@ const WEAPONS = [
   { name: "PISTOL", color: 0x555555, cooldown: 400, damage: 25, spread: 0, magSize: 12, reloadTime: 1200 },
   { name: "SHOTGUN", color: 0x882222, cooldown: 1000, damage: 20, spread: 0.1, bullets: 5, magSize: 6, reloadTime: 2000 },
   { name: "SNIPER", color: 0x228822, cooldown: 1500, damage: 100, spread: 0, magSize: 2, reloadTime: 2500 },
-  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3600, immobilizesOnFire: true }
+  { name: "GATLING", color: 0xccaa22, cooldown: 80, damage: 10, spread: 0.03, magSize: 250, reloadTime: 3600, immobilizesOnFire: true, unlockKillStreak: 5 }
 ];
 
 function resetGatlingRamp() {
@@ -1552,11 +1558,18 @@ function createGunModel(id) {
   }
 }
 
+function isGatlingUnlocked() {
+  return isWeaponUnlocked(3);
+}
+
 function isWeaponUnlocked(id) {
   if (id === 3 && isGodUser()) {
     return true;
   }
   const w = WEAPONS[id];
+  if (w && w.unlockKillStreak) {
+    return localPlayer.killStreak >= w.unlockKillStreak;
+  }
   if (w && w.unlockKills) {
     return localPlayer.kills >= w.unlockKills;
   }
@@ -1565,7 +1578,13 @@ function isWeaponUnlocked(id) {
 
 function switchWeapon(id) {
   if (id >= WEAPONS.length) return;
-  if (!isWeaponUnlocked(id)) return;
+  if (!isWeaponUnlocked(id)) {
+    const w = WEAPONS[id];
+    if (w && w.unlockKillStreak) {
+      fpsHint.textContent = `${w.name} unlocks at a ${w.unlockKillStreak}-kill streak.`;
+    }
+    return;
+  }
   unzoomSniper();
   isReloading = false;
   resetGatlingRamp();
@@ -1639,6 +1658,11 @@ function tryFireWeapon() {
   if (!controls.isLocked) return;
   if (localPlayer.health <= 0) return;
   if (isReloading) return; // Cannot fire while reloading
+
+  if (!isWeaponUnlocked(localPlayer.weapon)) {
+    switchWeapon(0);
+    return;
+  }
 
   const weapon = WEAPONS[localPlayer.weapon];
   const now = performance.now();
@@ -2200,6 +2224,7 @@ export function initFps() {
   resetGatlingRamp();
   isPrimaryFireHeld = false;
   localPlayer.team = 0;
+  localPlayer.killStreak = 0;
   updateGrenadeUI();
   updateCtfHud();
   updateTeamSelectUI();

--- a/games/fps.js
+++ b/games/fps.js
@@ -1,4 +1,4 @@
-import { state, isInputFocused, escapeHtml, isGodUser } from "../core.js";
+import { state, isInputFocused, escapeHtml } from "../core.js";
 
 let room = null;
 let scene, camera, renderer, controls;
@@ -1563,9 +1563,6 @@ function isGatlingUnlocked() {
 }
 
 function isWeaponUnlocked(id) {
-  if (id === 3 && isGodUser()) {
-    return true;
-  }
   const w = WEAPONS[id];
   if (w && w.unlockKillStreak) {
     return localPlayer.killStreak >= w.unlockKillStreak;

--- a/index.html
+++ b/index.html
@@ -2328,7 +2328,7 @@
           <div style="position: absolute; top: 0; left: 50%; width: 1px; height: 100%; background: rgba(0,0,0,0.8);"></div>
         </div>
         <div id="fpsHint" style="position: absolute; bottom: 10px; width: 100%; text-align: center; color: rgba(255,255,255,0.7); font-family: monospace; font-size: 12px; pointer-events: none;">
-          CLICK TO LOCK MOUSE | WASD: MOVE | CLICK: SHOOT | RCLICK: SCOPE | G: GRENADE | SPACE: JUMP | 1-3: WEAPONS
+          CLICK TO LOCK MOUSE | WASD: MOVE | CLICK: SHOOT | RCLICK: SCOPE | G: GRENADE | SPACE: JUMP | 1-4: WEAPONS | GATLING: 5-KILL STREAK
         </div>
 
         <div id="fpsDeathScreen" style="display: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,0,0,0.4); flex-direction: column; justify-content: center; align-items: center; z-index: 10;">

--- a/server.js
+++ b/server.js
@@ -3041,6 +3041,8 @@ class FPSRoom extends colyseus.Room {
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
+      const weaponId = Number(data.weaponId);
+      if (weaponId === 3 && shooter.killStreak < 5) return;
 
       this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
 
@@ -3091,8 +3093,9 @@ class FPSRoom extends colyseus.Room {
 
       if (hitClient) {
         let damage = 25;
-        if (data.weaponId === 1) damage = 20; // Shotgun per bullet
-        if (data.weaponId === 2) damage = 100; // Sniper
+        if (weaponId === 1) damage = 20; // Shotgun per bullet
+        if (weaponId === 2) damage = 100; // Sniper
+        if (weaponId === 3) damage = 10; // Gatling
         const target = hitClient.player;
 
         if (target.armor > 0) {


### PR DESCRIPTION
### Motivation
- Prevent the Gatling weapon from being available unless a player achieves a 5-kill streak (kills without dying) to make it a reward for consecutive performance.
- Ensure both client and server enforce the requirement so the weapon can't be selected or fired without meeting the streak.
- Provide clear HUD feedback when Gatling is locked.

### Description
- Track per-player kill streak on the client by adding `killStreak` to `localPlayer`, keeping it in sync with server state, and resetting it on death and init (`games/fps.js`).
- Add `unlockKillStreak: 5` to the Gatling weapon entry and extend `isWeaponUnlocked` to support `unlockKillStreak`, plus a convenience `isGatlingUnlocked()` helper; prevent switching to or firing a locked weapon and show a hint when it is locked (`games/fps.js`, `index.html`).
- Enforce the gate server-side by rejecting `shoot` messages for `weaponId === 3` (Gatling) unless `shooter.killStreak >= 5`, and ensure server uses a `weaponId` variable for damage resolution including Gatling damage (`server.js`).

### Testing
- Ran `node --check server.js && node --check games/fps.js` with no syntax errors (success).
- Ran `git diff --check` and basic repository checks (success).
- Started the Colyseus server with `npm start` as a smoke test (server started successfully).
- Attempted an automated Playwright screenshot (`node .ai-artifacts/playwright/scripts/fps-gatling-screenshot.js`) to validate HUD text, but it failed because Playwright’s Chromium binary could not be downloaded (`npx playwright install chromium` returned CDN 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82b60dac833095b11e5e8334c93b)