### PR TITLE
Show FPS killstreaks on leaderboard

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -405,6 +405,9 @@ function setupRoom() {
     player.listen("kills", () => {
       updateLeaderboard();
     });
+    player.listen("killStreak", () => {
+      updateLeaderboard();
+    });
     updateLeaderboard();
   });
 
@@ -472,9 +475,11 @@ function updateLeaderboard() {
   room.state.players.forEach(p => players.push(p));
   players.sort((a,b) => b.kills - a.kills);
 
-  fpsLeaderboardList.innerHTML = players.map(p =>
-    `<div>${escapeHtml(p.name)}: ${p.kills}</div>`
-  ).join("");
+  fpsLeaderboardList.innerHTML = players.map(p => {
+    const kills = Number(p.kills) || 0;
+    const killStreak = Number(p.killStreak) || 0;
+    return `<div>${escapeHtml(p.name)}: ${kills} kills | ${killStreak} streak</div>`;
+  }).join("");
 }
 
 function teamLabel(teamId) {


### PR DESCRIPTION
### Motivation
- Players and spectators should see each player's current killstreak on the FPS leaderboard in addition to total kills so streaks are visible in the UI.

### Description
- Added a `player.listen("killStreak", ...)` subscription so the FPS leaderboard refreshes when a player's kill streak changes in `games/fps.js`.
- Updated `updateLeaderboard()` in `games/fps.js` to render rows showing both `kills` and `killStreak` (formatted as `N kills | M streak`).
- Kept existing sorting by total kills and preserved previous leaderboard update behavior.

### Testing
- Ran `node --check games/fps.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86010a948330850e591dd616e289)