### PR TITLE
CoreDriller: clamp thrust fuel/heat, improve canvas/overlay id robustness

### DIFF
--- a/games/coredriller.js
+++ b/games/coredriller.js
@@ -121,8 +121,10 @@ export function updateCoreDriller() {
   const thrustPower = 78 + upgrades.drill * 8;
   if (thrustOn && drill.fuel > 0) {
     drill.vy += thrustPower * dt;
-    drill.fuel = Math.max(0, drill.fuel - (11 - upgrades.fuel * 0.55) * dt);
-    drill.heat += (13 - upgrades.coolant * 0.75) * dt;
+    const thrustFuelDrain = Math.max(2.5, 11 - upgrades.fuel * 0.55);
+    const thrustHeatGain = Math.max(1.5, 13 - upgrades.coolant * 0.75);
+    drill.fuel = Math.max(0, drill.fuel - thrustFuelDrain * dt);
+    drill.heat += thrustHeatGain * dt;
   } else {
     drill.vy += 28 * dt;
   }
@@ -238,8 +240,11 @@ export function initCoreDriller() {
   state.currentGame = "coredriller";
   loadHighScores();
 
-  const canvas = document.getElementById("coreDrillerCanvas");
-  if (!canvas) return;
+  const canvas = document.getElementById("coreDrillerCanvas") || document.getElementById("coredrillerCanvas");
+  if (!canvas) {
+    showToast("CORE DRILLER UI FAILED TO LOAD", "⚠️");
+    return;
+  }
   draw = new DrawSystem(canvas.getContext("2d"));
   kernel = new EngineKernel({ fixedHz: 60 });
 

--- a/script.js
+++ b/script.js
@@ -238,6 +238,10 @@ function renderInGameShopPanel(game, overlayId) {
 function getOverlayIdForGame(gameId) {
   if (!gameId) return "";
   if (gameId === "voice") return "globalChat";
+  if (gameId === "coredriller") {
+    // Support both historical ID variants used in markup.
+    return document.getElementById("overlayCoredriller") ? "overlayCoredriller" : "overlayCoreDriller";
+  }
   return `overlay${gameId === "ttt" ? gameId.toUpperCase() : gameId.charAt(0).toUpperCase() + gameId.slice(1)}`;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent extreme or negative thrust fuel drain and heat gain values from upgrades and handle legacy DOM ID variants for the Core Driller UI and overlay mounting.

### Description
- Clamp thrust fuel drain and heat gain by introducing `thrustFuelDrain = Math.max(2.5, 11 - upgrades.fuel * 0.55)` and `thrustHeatGain = Math.max(1.5, 13 - upgrades.coolant * 0.75)` and apply those values when thrusting.
- Fall back to an alternate canvas ID in `initCoreDriller` by using `document.getElementById("coreDrillerCanvas") || document.getElementById("coredrillerCanvas")` and show a toast and return early if no canvas is found.
- Make overlay lookup for the coredriller game tolerant of historical ID variants by returning either `overlayCoredriller` or `overlayCoreDriller` based on DOM presence.

### Testing
- Ran the project's automated test suite and linters; they completed without failures.
- Performed a smoke check of the Core Driller initialization path to confirm the canvas lookup fallback and the overlay ID resolution behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86607fac8322ac123ffc96244986)