### PR TITLE
Fix admin controls, enable self-unmute, and protect OIL on market crash

### DIFF
--- a/core.js
+++ b/core.js
@@ -4071,13 +4071,18 @@ async function adminApplySettingAction({ key, type, action, value, successLabel 
     mutateRemote: (targetData) => {
       const settings = { ...(targetData?.adminSettings || {}) };
       const currentValue = settings[key];
-      settings[key] = applySettingAction(currentValue, action, type, value);
-      return { adminSettings: settings };
+      const nextValue = applySettingAction(currentValue, action, type, value);
+      settings[key] = nextValue;
+      const patch = { adminSettings: settings };
+      if (["role", "status", "permissions", "tags", "restrictions"].includes(key)) patch[key] = nextValue;
+      return patch;
     },
     mutateLocal: () => {
       adminSettings = adminSettings || {};
       const currentValue = adminSettings[key];
-      adminSettings[key] = applySettingAction(currentValue, action, type, value);
+      const nextValue = applySettingAction(currentValue, action, type, value);
+      adminSettings[key] = nextValue;
+      if (key === "role") crewData.role = String(nextValue || crewData.role || "MEMBER");
     },
     successToast: (targets) => `${successLabel} FOR ${targets.length} PLAYER(S)`,
     failToast: "SETTING UPDATE FAILED",
@@ -4276,16 +4281,30 @@ export async function adminSetPortfolioSharesFromInput() {
   });
 }
 
-async function setMarketShift(multiplier, minimumPrice = 3, fallbackPrice = minimumPrice) {
+async function setMarketShift(multiplier, minimumPrice = 3, fallbackPrice = minimumPrice, excludedSymbols = []) {
   const ref = marketDocRef();
   const floor = Math.max(0, Number(minimumPrice) || 0);
   const fallback = Math.max(floor, Number(fallbackPrice) || floor);
+  const skipSymbols = new Set(
+    (Array.isArray(excludedSymbols) ? excludedSymbols : [excludedSymbols])
+      .map((symbol) => String(symbol || "").trim().toUpperCase())
+      .filter(Boolean)
+  );
   try {
     await runTransaction(db, async (t) => {
       const snap = await t.get(ref);
       const payload = snap.exists() ? snap.data() : getInitialMarketPayload();
       const shifted = normalizeMarketStocks(payload.stocks).map((stock) => {
         const current = Math.max(floor, Number(stock.price) || fallback);
+        if (skipSymbols.has(String(stock.symbol || "").toUpperCase())) {
+          const history = [...(Array.isArray(stock.history) ? stock.history : []), current].slice(-80);
+          return {
+            ...stock,
+            price: current,
+            lastMove: 0,
+            history,
+          };
+        }
         const next = Math.max(floor, Number((current * multiplier).toFixed(2)));
         const history = [...(Array.isArray(stock.history) ? stock.history : []), next].slice(-80);
         return {
@@ -4311,6 +4330,15 @@ async function setMarketShift(multiplier, minimumPrice = 3, fallbackPrice = mini
   } catch {
     marketState.stocks = normalizeMarketStocks(marketState.stocks).map((stock) => {
       const current = Math.max(floor, Number(stock.price) || fallback);
+      if (skipSymbols.has(String(stock.symbol || "").toUpperCase())) {
+        const history = [...(Array.isArray(stock.history) ? stock.history : []), current].slice(-80);
+        return {
+          ...stock,
+          price: current,
+          lastMove: 0,
+          history,
+        };
+      }
       const next = Math.max(floor, Number((current * multiplier).toFixed(2)));
       const history = [...(Array.isArray(stock.history) ? stock.history : []), next].slice(-80);
       return {
@@ -4326,7 +4354,7 @@ async function setMarketShift(multiplier, minimumPrice = 3, fallbackPrice = mini
 
 export async function adminMarketCrashToZero() {
   if (!isGodUser()) return;
-  await setMarketShift(0, 0.01, 0.01);
+  await setMarketShift(0, 0.01, 0.01, [OIL_SYMBOL]);
   showToast("MARKET CRASHED TO ZERO", "📉");
   await saveStats();
 }
@@ -6329,7 +6357,7 @@ function renderChatTab() {
       }
       row.appendChild(text);
 
-      const canTargetUser = canReplyToUser;
+      const canTargetUser = user && user !== "ANON" && (canReplyToUser || canUseChatModeration());
       if (canTargetUser && !isContinuation) {
         const canModerateChat = canUseChatModeration();
 


### PR DESCRIPTION
### Motivation
- Admin actions (role/status/permissions/tags/restrictions) were being applied only to `adminSettings` and not to top-level player fields, so role/access/debt changes didn't take effect where the app reads direct fields.
- Admins could not easily unmute themselves because chat moderation controls weren't exposed on their own messages while in moderation mode.
- Crashing all markets inadvertently crushed the OIL symbol, which should remain stable during a global crash.

### Description
- Updated `adminApplySettingAction` to write critical keys (`role`, `status`, `permissions`, `tags`, `restrictions`) both into `adminSettings` and to top-level fields when mutating remote user docs, and to apply `role` changes to local `crewData.role` for immediate in-session effect (file: `core.js`).
- Allowed chat moderation UI to render moderation controls for the current user when moderation mode is enabled so admins can global-unmute themselves by exposing the global mute button on their own rows (file: `core.js`).
- Extended `setMarketShift` to accept an `excludedSymbols` list and skip shifts for those symbols, and updated `adminMarketCrashToZero` to exclude `OIL_SYMBOL` so OIL is not crashed to zero (file: `core.js`).

### Testing
- Ran `node --check core.js` to validate syntax, which succeeded.
- Ran `npm test` but the repository does not define a `test` script, so no automated test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb875f055c8322b3b4395e4e0951bd)