### PR TITLE
Replace Live Ops panel with Recent Games on home

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,13 +521,6 @@
           <span class="trending-count">LAUNCH</span>
         </button>
       </section>
-      <section class="trending-games" aria-label="Trending games">
-        <h2><button class="panel-title-btn" type="button" data-open-overlay="overlayTrending">TRENDING GAMES // LAST 24H</button></h2>
-        <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>
-        <div class="trending-games-list" id="trendingGamesList">
-          <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
-        </div>
-      </section>
       <section class="update-log" aria-label="Update log" id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="webstie">
         <h2><button class="panel-title-btn" type="button" data-open-overlay="overlayUpdates">UPDATE LOG</button></h2>
         <ul id="updateLogList">
@@ -539,6 +532,13 @@
         <div class="trending-meta" id="recentGamesMeta">YOUR MOST RECENTLY PLAYED GAMES.</div>
         <div class="trending-games-list" id="recentGamesList">
           <div class="trending-empty">NO RECENT GAMES YET.</div>
+        </div>
+      </section>
+      <section class="trending-games" aria-label="Trending games">
+        <h2><button class="panel-title-btn" type="button" data-open-overlay="overlayTrending">TRENDING GAMES // LAST 24H</button></h2>
+        <div class="trending-meta" id="trendingGamesMeta">SCANNING PLAYER TRAFFIC...</div>
+        <div class="trending-games-list" id="trendingGamesList">
+          <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
         </div>
       </section>
     </div>

--- a/index.html
+++ b/index.html
@@ -534,14 +534,11 @@
           <li><span>#01</span> LOADING LATEST UPDATES...</li>
         </ul>
       </section>
-      <section class="live-ops" aria-label="Live operations">
-        <h2>LIVE OPS</h2>
-        <div class="live-ops-line" id="liveOpsNow">LOADING EVENT...</div>
-        <div class="live-ops-grid">
-          <div><span>MODE</span><strong id="liveOpsMode">SYNCING...</strong></div>
-          <div><span>REWARD</span><strong id="liveOpsReward">SYNCING...</strong></div>
-          <div><span>FEATURED</span><strong id="liveOpsFeatured">SYNCING...</strong></div>
-          <div><span>HOT ROOM</span><strong id="liveOpsRoom">----</strong></div>
+      <section class="recent-games" aria-label="Recent games">
+        <h2>RECENT GAMES</h2>
+        <div class="trending-meta" id="recentGamesMeta">YOUR MOST RECENTLY PLAYED GAMES.</div>
+        <div class="trending-games-list" id="recentGamesList">
+          <div class="trending-empty">NO RECENT GAMES YET.</div>
         </div>
       </section>
     </div>

--- a/index.html
+++ b/index.html
@@ -521,12 +521,6 @@
           <span class="trending-count">LAUNCH</span>
         </button>
       </section>
-      <section class="update-log" aria-label="Update log" id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="webstie">
-        <h2><button class="panel-title-btn" type="button" data-open-overlay="overlayUpdates">UPDATE LOG</button></h2>
-        <ul id="updateLogList">
-          <li><span>#01</span> LOADING LATEST UPDATES...</li>
-        </ul>
-      </section>
       <section class="recent-games" aria-label="Recent games">
         <h2>RECENT GAMES</h2>
         <div class="trending-meta" id="recentGamesMeta">YOUR MOST RECENTLY PLAYED GAMES.</div>
@@ -540,6 +534,12 @@
         <div class="trending-games-list" id="trendingGamesList">
           <div class="trending-empty">NO TRAFFIC SIGNAL YET.</div>
         </div>
+      </section>
+      <section class="update-log" aria-label="Update log" id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="webstie">
+        <h2><button class="panel-title-btn" type="button" data-open-overlay="overlayUpdates">UPDATE LOG</button></h2>
+        <ul id="updateLogList">
+          <li><span>#01</span> LOADING LATEST UPDATES...</li>
+        </ul>
       </section>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -489,6 +489,55 @@ function updateRecentGames(game) {
   writeStoredGameList(GAME_LIBRARY_RECENTS_KEY, recents);
 }
 
+function initHomeRecentGames() {
+  const listEl = document.getElementById("recentGamesList");
+  const metaEl = document.getElementById("recentGamesMeta");
+  if (!listEl || !Array.isArray(window.GAME_DIRECTORY_ENTRIES)) return;
+
+  const directoryById = new Map(
+    window.GAME_DIRECTORY_ENTRIES.map((entry) => [entry.id, entry]),
+  );
+
+  const renderRecentGames = () => {
+    const recents = readStoredGameList(GAME_LIBRARY_RECENTS_KEY)
+      .filter((gameId) => directoryById.has(gameId))
+      .slice(0, GAME_LIBRARY_RECENT_LIMIT);
+
+    if (metaEl) {
+      metaEl.textContent = recents.length
+        ? `LAST ${recents.length} GAME${recents.length === 1 ? "" : "S"} PLAYED.`
+        : "PLAY A GAME TO FILL THIS LIST.";
+    }
+
+    if (!recents.length) {
+      listEl.innerHTML = '<div class="trending-empty">NO RECENT GAMES YET.</div>';
+      return;
+    }
+
+    listEl.innerHTML = "";
+    recents.forEach((gameId, index) => {
+      const entry = directoryById.get(gameId);
+      if (!entry) return;
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "trending-game-btn";
+      button.innerHTML = `
+        <span class="trending-rank">#${index + 1}</span>
+        <span>${entry.title || gameId}</span>
+        <span class="trending-count">${entry.icon || "🎮"}</span>
+      `;
+      button.addEventListener("click", () => window.launchGame(gameId, "home-recent"));
+      listEl.appendChild(button);
+    });
+  };
+
+  renderRecentGames();
+  document.addEventListener("gooner:games-library-updated", renderRecentGames);
+  window.addEventListener("storage", (event) => {
+    if (event.key === GAME_LIBRARY_RECENTS_KEY) renderRecentGames();
+  });
+}
+
 
 function sizeCanvasToViewport(canvas) {
   if (!canvas) return;
@@ -1347,6 +1396,7 @@ initGameCanvasSizing();
 initGameVisibilityGuards();
 initGameScroller();
 initMainSiteSearch();
+initHomeRecentGames();
 
 function hideGameOverModal() {
   const modal = document.getElementById("modalGameOver");

--- a/script.js
+++ b/script.js
@@ -492,10 +492,10 @@ function updateRecentGames(game) {
 function initHomeRecentGames() {
   const listEl = document.getElementById("recentGamesList");
   const metaEl = document.getElementById("recentGamesMeta");
-  if (!listEl || !Array.isArray(window.GAME_DIRECTORY_ENTRIES)) return;
+  if (!listEl || !Array.isArray(GAME_DIRECTORY_ENTRIES)) return;
 
   const directoryById = new Map(
-    window.GAME_DIRECTORY_ENTRIES.map((entry) => [entry.id, entry]),
+    GAME_DIRECTORY_ENTRIES.map((entry) => [entry.id, entry]),
   );
 
   const renderRecentGames = () => {


### PR DESCRIPTION
### Motivation
- The home screen Live Ops panel was removed to surface player-centric content and make the home page more relevant to returning players.
- Showing recently played games gives quick access to games the user played and complements the existing trending and game-picker UI.

### Description
- Replaced the `LIVE OPS` section in `index.html` with a `RECENT GAMES` section containing `recentGamesMeta` and `recentGamesList` containers.
- Added `initHomeRecentGames()` to `script.js` which reads recents from `localStorage` (`GAME_LIBRARY_RECENTS_KEY`) and renders clickable recent game buttons that call `window.launchGame` when clicked.
- The renderer uses `window.GAME_DIRECTORY_ENTRIES` to resolve game metadata, shows an empty state when no recents exist, and updates the meta copy to reflect the number of items.
- The recent-games list is refreshed on the existing `gooner:games-library-updated` event and on `storage` events, and `initHomeRecentGames()` is initialized during app startup.

### Testing
- Ran a static syntax check with `node --check script.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8789c7a88322a234dd278b7599c3)