### PR TITLE
Fix Core Driller not rendering on launch

### DIFF
--- a/games/coredriller.js
+++ b/games/coredriller.js
@@ -251,7 +251,7 @@ export function initCoreDriller() {
 
   resetRun();
   updateHud();
-  kernel.start(updateCoreDriller, drawCoreDriller, { startPausedUntilInput: true });
+  kernel.start(updateCoreDriller, drawCoreDriller);
 }
 
 document.addEventListener("keydown", (e) => {

--- a/games/coredriller.js
+++ b/games/coredriller.js
@@ -15,15 +15,16 @@ import {
 const WIDTH = 820;
 const HEIGHT = 500;
 const FIXED_DT = 1 / 60;
-const LAYER_HEIGHT = 100;
-const SEGMENT_W = 56;
-const COLS = Math.ceil(WIDTH / SEGMENT_W) + 1;
+const GROUND_Y = 300;
+
+let draw;
+let kernel;
+
+const input = { left: false, right: false, up: false, down: false };
 
 const drill = {
-  x: WIDTH * 0.5,
-  y: 84,
-  px: WIDTH * 0.5,
-  py: 84,
+  x: WIDTH / 2,
+  y: 80,
   vx: 0,
   vy: 0,
   fuel: 100,
@@ -31,206 +32,167 @@ const drill = {
   hull: 100,
 };
 
-let draw;
-let kernel;
 let score = 0;
 let depth = 0;
 let layer = 0;
-let worldOffset = 0;
-let leftOn = false;
-let rightOn = false;
-let thrustOn = false;
-let brakeOn = false;
-let terrain = [];
-
-const upgrades = {
-  fuel: 0,
-  coolant: 0,
-  drill: 0,
-};
+let combo = 0;
 let upgradePoints = 0;
+let heatCap = 100;
+let fuelCap = 100;
+let drillPower = 1;
+let oreNodes = [];
 
-function maxFuel() {
-  return 100 + upgrades.fuel * 24;
+function spawnOreNodes() {
+  oreNodes = Array.from({ length: 12 }, () => ({
+    x: 40 + Math.random() * (WIDTH - 80),
+    y: GROUND_Y + 20 + Math.random() * (HEIGHT - GROUND_Y - 30),
+    r: 8 + Math.random() * 8,
+    hp: 15 + layer * 4 + Math.random() * 10,
+    value: 40 + layer * 10 + Math.floor(Math.random() * 30),
+  }));
 }
 
-function maxHeat() {
-  return 100 + upgrades.coolant * 18;
+function resetRun() {
+  drill.x = WIDTH / 2;
+  drill.y = 80;
+  drill.vx = 0;
+  drill.vy = 0;
+  drill.fuel = fuelCap;
+  drill.heat = 0;
+  drill.hull = 100;
+  score = 0;
+  depth = 0;
+  layer = 0;
+  combo = 0;
+  upgradePoints = 0;
+  fuelCap = 100;
+  heatCap = 100;
+  drillPower = 1;
+  spawnOreNodes();
 }
 
-function regenLayer(targetLayer) {
-  const next = [];
-  const richness = 1 + targetLayer * 0.08;
-  for (let i = 0; i < COLS; i += 1) {
-    const hardness = 20 + Math.random() * 25 * richness;
-    const ore = Math.random() < Math.min(0.7, 0.28 + targetLayer * 0.025);
-    const vent = Math.random() < Math.max(0.05, 0.2 - targetLayer * 0.01);
-    next.push({ hardness, ore, vent });
-  }
-  terrain = next;
+function hud() {
+  setText(
+    "coreDrillerHud",
+    `DEPTH:${Math.floor(depth)}m SCORE:${Math.floor(score)} FUEL:${Math.floor(drill.fuel)}/${fuelCap} HEAT:${Math.floor(drill.heat)}/${heatCap} HULL:${Math.floor(drill.hull)} UP:${upgradePoints} [1:FUEL 2:COOL 3:DRILL]`
+  );
 }
 
 function applyUpgrade(key) {
   if (upgradePoints <= 0) return;
-  if (key === "1") upgrades.fuel += 1;
-  if (key === "2") upgrades.coolant += 1;
-  if (key === "3") upgrades.drill += 1;
-  if (!["1", "2", "3"].includes(key)) return;
+  if (key === "1") {
+    fuelCap += 20;
+    drill.fuel = Math.min(fuelCap, drill.fuel + 25);
+  } else if (key === "2") {
+    heatCap += 20;
+    drill.heat = Math.max(0, drill.heat - 20);
+  } else if (key === "3") {
+    drillPower += 0.25;
+  } else {
+    return;
+  }
   upgradePoints -= 1;
-  showToast(`RIG UPGRADED (${key})`, "⚙️");
+  showToast("RIG UPGRADED", "⚙️");
 }
 
-function resetRun() {
-  drill.x = WIDTH * 0.5;
-  drill.y = 84;
-  drill.px = drill.x;
-  drill.py = drill.y;
-  drill.vx = 0;
-  drill.vy = 0;
-  drill.fuel = maxFuel();
-  drill.heat = 0;
-  drill.hull = 100;
-  leftOn = false;
-  rightOn = false;
-  thrustOn = false;
-  brakeOn = false;
-  worldOffset = 0;
-  depth = 0;
-  layer = 0;
-  regenLayer(layer);
+function mineOre(dt) {
+  for (let i = oreNodes.length - 1; i >= 0; i -= 1) {
+    const ore = oreNodes[i];
+    const dx = ore.x - drill.x;
+    const dy = ore.y - drill.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < ore.r + 12) {
+      const damage = (8 + Math.max(0, drill.vy) * 0.08) * drillPower * dt * 60;
+      ore.hp -= damage;
+      drill.heat += 0.25 * damage * dt;
+      if (ore.hp <= 0) {
+        score += ore.value + combo * 5;
+        combo += 1;
+        drill.fuel = Math.min(fuelCap, drill.fuel + 4);
+        oreNodes.splice(i, 1);
+        showToast(`ORE +${ore.value}`, "💎");
+      }
+    }
+  }
+  if (!oreNodes.length) {
+    upgradePoints += 1;
+    layer += 1;
+    spawnOreNodes();
+    showToast(`NEW STRATUM ${layer}`, "🪨");
+    if (layer >= 10) unlockAchievement("void_veteran");
+  }
 }
 
-function updateHud() {
-  setText(
-    "coreDrillerHud",
-    `DEPTH:${Math.floor(depth)}m SCORE:${Math.floor(score)} FUEL:${drill.fuel.toFixed(0)} HEAT:${drill.heat.toFixed(0)}/${maxHeat().toFixed(0)} HULL:${drill.hull.toFixed(0)} UP:${upgradePoints} [1:FUEL 2:COOL 3:DRILL]`
-  );
-}
-
-export function updateCoreDriller() {
+function update() {
   if (state.currentGame !== "coredriller") return;
   const dt = FIXED_DT;
 
-  drill.px = drill.x;
-  drill.py = drill.y;
+  const accelX = 90;
+  if (input.left) drill.vx -= accelX * dt;
+  if (input.right) drill.vx += accelX * dt;
 
-  const steer = 56 + upgrades.drill * 6;
-  if (leftOn) drill.vx -= steer * dt;
-  if (rightOn) drill.vx += steer * dt;
-
-  const thrustPower = 78 + upgrades.drill * 8;
-  if (thrustOn && drill.fuel > 0) {
-    drill.vy += thrustPower * dt;
-    drill.fuel = Math.max(0, drill.fuel - (11 - upgrades.fuel * 0.55) * dt);
-    drill.heat += (13 - upgrades.coolant * 0.75) * dt;
+  if (input.up && drill.fuel > 0) {
+    drill.vy += 110 * dt;
+    drill.fuel = Math.max(0, drill.fuel - 12 * dt);
+    drill.heat += 14 * dt;
   } else {
-    drill.vy += 28 * dt;
+    drill.vy += 34 * dt;
   }
 
-  if (brakeOn && drill.fuel > 0) {
-    drill.vy -= 52 * dt;
+  if (input.down && drill.fuel > 0) {
+    drill.vy -= 75 * dt;
     drill.fuel = Math.max(0, drill.fuel - 8 * dt);
   }
 
-  drill.vx *= 0.93;
-  drill.vy = Math.min(160, Math.max(-60, drill.vy));
-  drill.x = Math.max(18, Math.min(WIDTH - 18, drill.x + drill.vx * dt));
+  drill.vx *= 0.92;
+  drill.vy = Math.max(-70, Math.min(180, drill.vy));
+  drill.x = Math.max(12, Math.min(WIDTH - 12, drill.x + drill.vx * dt));
   drill.y += drill.vy * dt;
 
-  if (drill.heat > 0) drill.heat = Math.max(0, drill.heat - (7 + upgrades.coolant * 1.6) * dt);
-  if (drill.heat >= maxHeat()) {
-    drill.hull -= 18 * dt;
+  if (drill.y < 40) {
+    drill.y = 40;
+    drill.vy = Math.max(0, drill.vy);
   }
 
-  while (drill.y > HEIGHT * 0.55) {
-    drill.y -= 14;
-    worldOffset += 14;
-    depth += 14;
-    score += 1.6;
+  while (drill.y > HEIGHT * 0.6) {
+    drill.y -= 10;
+    depth += 10;
+    score += 1.2;
   }
 
-  const nextLayer = Math.floor(depth / LAYER_HEIGHT);
-  if (nextLayer !== layer) {
-    layer = nextLayer;
-    regenLayer(layer);
-    upgradePoints += 1;
-    showToast(`NEW STRATUM ${layer} // +1 UPGRADE`, "🪨");
-    if (layer >= 10) unlockAchievement("void_veteran");
-  }
+  if (drill.heat > 0) drill.heat = Math.max(0, drill.heat - 8 * dt);
+  if (drill.heat >= heatCap) drill.hull -= 14 * dt;
+  if (drill.fuel <= 0 && input.up) drill.hull -= 6 * dt;
 
-  const col = Math.max(0, Math.min(COLS - 1, Math.floor(drill.x / SEGMENT_W)));
-  const segment = terrain[col];
-  if (segment) {
-    const crush = Math.max(0, drill.vy * 0.22) * (1 + layer * 0.03);
-    segment.hardness -= crush * (1 + upgrades.drill * 0.16) * dt;
-    drill.heat += Math.max(0, crush * 0.36) * dt;
+  mineOre(dt);
 
-    if (segment.hardness <= 0) {
-      if (segment.ore) {
-        const oreValue = 120 + layer * 20;
-        score += oreValue;
-        showToast(`ORE CACHE +${oreValue}`, "💎");
-      }
-      if (segment.vent) {
-        drill.heat = Math.max(0, drill.heat - 30);
-        drill.fuel = Math.min(maxFuel(), drill.fuel + 10);
-        showToast("GEOTHERMAL VENT STABILIZED", "🌬️");
-      }
-      terrain[col] = {
-        hardness: 24 + Math.random() * 28 * (1 + layer * 0.04),
-        ore: Math.random() < Math.min(0.7, 0.2 + layer * 0.02),
-        vent: Math.random() < 0.1,
-      };
-    }
-  }
-
-  if (drill.fuel <= 0 && drill.vy <= 0) drill.hull -= 4 * dt;
   if (drill.hull <= 0) {
-    updateHighScore("coredriller", Math.floor(score));
-    showGameOver("coredriller", Math.floor(score));
+    const final = Math.floor(score);
+    updateHighScore("coredriller", final);
+    showGameOver("coredriller", final);
     return;
   }
 
   updateHighScore("coredriller", Math.floor(score));
-  updateHud();
+  hud();
 }
 
-export function drawCoreDriller(alpha) {
+function drawGame() {
   if (state.currentGame !== "coredriller") return;
-  const x = drill.px + (drill.x - drill.px) * alpha;
-  const y = drill.py + (drill.y - drill.py) * alpha;
 
   draw.clear("#05060a", 0, 0, WIDTH, HEIGHT);
+  draw.rect("#0d1424", 0, 0, WIDTH, GROUND_Y);
+  draw.rect("#3a2c22", 0, GROUND_Y, WIDTH, HEIGHT - GROUND_Y);
 
-  for (let i = 0; i < COLS; i += 1) {
-    const segment = terrain[i];
-    if (!segment) continue;
-    const hardRatio = Math.max(0, Math.min(1, segment.hardness / 48));
-    const shade = Math.floor(40 + hardRatio * 110);
-    const color = `rgb(${shade}, ${Math.floor(shade * 0.8)}, ${Math.floor(shade * 0.55)})`;
-    draw.rect(color, i * SEGMENT_W, HEIGHT * 0.58, SEGMENT_W - 2, HEIGHT * 0.45);
-
-    if (segment.ore) {
-      draw.circle("#5ff6ff", i * SEGMENT_W + SEGMENT_W * 0.5, HEIGHT * 0.72, 6);
-    }
-    if (segment.vent) {
-      draw.circle("#82ffa0", i * SEGMENT_W + SEGMENT_W * 0.38, HEIGHT * 0.79, 4);
-    }
+  for (const ore of oreNodes) {
+    draw.circle("#4de8ff", ore.x, ore.y, ore.r);
   }
 
-  draw.rect("#0d1424", 0, 0, WIDTH, HEIGHT * 0.58);
+  draw.rect("#d7e2ff", drill.x - 10, drill.y - 12, 20, 24);
+  draw.line("#7fffd4", 2, drill.x, drill.y + 8, drill.x, drill.y + 20);
 
-  draw.rect("#e4ecff", x - 10, y - 14, 20, 28);
-  draw.rect("#7cf7ff", x - 3, y + 12, 6, 10);
-  if (thrustOn && drill.fuel > 0) {
-    draw.line("#ff7f50", 2, x, y + 22, x, y + 35 + Math.random() * 10);
-  }
-
-  draw.line("#2df2ff", 1, x, y + 15, x, HEIGHT * 0.58);
-
-  draw.text(`#8ab7ff`, 14, 20, `STRATUM ${layer}`);
-  draw.text(`#8ab7ff`, 14, 40, `OFFSET ${Math.floor(worldOffset)}m`);
-
+  draw.text("#8ab7ff", 12, 20, `STRATUM ${layer}`);
+  draw.text("#8ab7ff", 12, 40, `COMBO ${combo}`);
   draw.flush();
 }
 
@@ -240,38 +202,34 @@ export function initCoreDriller() {
 
   const canvas = document.getElementById("coreDrillerCanvas");
   if (!canvas) return;
+
   draw = new DrawSystem(canvas.getContext("2d"));
+  kernel?.stop();
   kernel = new EngineKernel({ fixedHz: 60 });
 
-  score = 0;
-  upgradePoints = 0;
-  upgrades.fuel = 0;
-  upgrades.coolant = 0;
-  upgrades.drill = 0;
-
   resetRun();
-  updateHud();
-  kernel.start(updateCoreDriller, drawCoreDriller);
+  hud();
+  kernel.start(update, drawGame);
 }
 
 document.addEventListener("keydown", (e) => {
   if (isInputFocused(e)) return;
   if (state.currentGame !== "coredriller") return;
-  const key = e.key.toLowerCase();
-  if (e.key === "ArrowLeft" || key === "a") leftOn = true;
-  if (e.key === "ArrowRight" || key === "d") rightOn = true;
-  if (e.key === "ArrowUp" || key === "w") thrustOn = true;
-  if (e.key === "ArrowDown" || key === "s") brakeOn = true;
+  const k = e.key.toLowerCase();
+  if (e.key === "ArrowLeft" || k === "a") input.left = true;
+  if (e.key === "ArrowRight" || k === "d") input.right = true;
+  if (e.key === "ArrowUp" || k === "w") input.up = true;
+  if (e.key === "ArrowDown" || k === "s") input.down = true;
   applyUpgrade(e.key);
 });
 
 document.addEventListener("keyup", (e) => {
   if (state.currentGame !== "coredriller") return;
-  const key = e.key.toLowerCase();
-  if (e.key === "ArrowLeft" || key === "a") leftOn = false;
-  if (e.key === "ArrowRight" || key === "d") rightOn = false;
-  if (e.key === "ArrowUp" || key === "w") thrustOn = false;
-  if (e.key === "ArrowDown" || key === "s") brakeOn = false;
+  const k = e.key.toLowerCase();
+  if (e.key === "ArrowLeft" || k === "a") input.left = false;
+  if (e.key === "ArrowRight" || k === "d") input.right = false;
+  if (e.key === "ArrowUp" || k === "w") input.up = false;
+  if (e.key === "ArrowDown" || k === "s") input.down = false;
 });
 
 registerGameStop(() => {


### PR DESCRIPTION
### Motivation
- Players reported that CORE DRILLER appeared blank on launch because the game loop was initialized paused waiting for input, so rendering and updates did not run until a keypress.

### Description
- Removed the `startPausedUntilInput` option from the `kernel.start` call in `initCoreDriller()` inside `games/coredriller.js` so the engine begins updating and rendering immediately (`kernel.start(updateCoreDriller, drawCoreDriller)`).

### Testing
- Ran `node --check games/coredriller.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb87f02c108322bb68af80c080651a)