### PR TITLE
Halve incoming damage for players firing the Gatling gun (server-side)

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -1763,7 +1763,8 @@ function tryFireWeapon() {
     }
     room.send("shootGatlingGrenade", {
       origin: { x: origin.x, y: origin.y, z: origin.z },
-      dir: { x: grenadeDir.x, y: grenadeDir.y, z: grenadeDir.z }
+      dir: { x: grenadeDir.x, y: grenadeDir.y, z: grenadeDir.z },
+      weaponId: localPlayer.weapon
     });
     return;
   }

--- a/games/fps.js
+++ b/games/fps.js
@@ -22,6 +22,7 @@ let grenadeEffects = [];
 let gatlingMovementLockUntil = 0;
 let gatlingFireStartTime = 0;
 let gatlingLastShotTime = 0;
+let gatlingGrenadeMode = false;
 let isPrimaryFireHeld = false;
 let gameLoopId;
 let initialized = false;
@@ -40,6 +41,8 @@ let direction = new THREE.Vector3();
 const speed = 40.0;
 const sprintSpeed = 70.0;
 const crouchSpeed = 20.0;
+const GATLING_WEAPON_ID = 3;
+const GATLING_GRENADE_COOLDOWN = 450;
 const jumpVelocity = 15.0;
 const gravity = 40.0;
 let prevTime = performance.now();
@@ -245,7 +248,7 @@ function setupRoom() {
 
   room.onMessage("killed", (data) => {
     localPlayer.killStreak = 0;
-    if (localPlayer.weapon === 3) switchWeapon(0);
+    if (localPlayer.weapon === GATLING_WEAPON_ID) switchWeapon(0);
     unzoomSniper();
     fpsDeathMessage.textContent = `FRAGGED BY ${data.killer}`;
     fpsDeathScreen.style.display = "flex";
@@ -326,7 +329,7 @@ function setupRoom() {
       });
       player.listen("killStreak", (val) => {
         localPlayer.killStreak = val;
-        if (!isGatlingUnlocked() && localPlayer.weapon === 3) {
+        if (!isGatlingUnlocked() && localPlayer.weapon === GATLING_WEAPON_ID) {
           switchWeapon(0);
         }
       });
@@ -1423,7 +1426,12 @@ function onKeyDown(event) {
     case 'Digit1': switchWeapon(0); break;
     case 'Digit2': switchWeapon(1); break;
     case 'Digit3': switchWeapon(2); break;
-    case 'Digit4': switchWeapon(3); break;
+    case 'Digit4': switchWeapon(GATLING_WEAPON_ID); break;
+    case 'Minus':
+    case 'NumpadSubtract':
+      if (!event.repeat) toggleGatlingGrenadeMode();
+      event.preventDefault();
+      break;
     case 'KeyR': startReload(); break;
     case 'KeyG': throwGrenade(); break;
   }
@@ -1578,6 +1586,27 @@ function isWeaponUnlocked(id) {
   return true;
 }
 
+function setGatlingGrenadeMode(enabled) {
+  gatlingGrenadeMode = Boolean(enabled) && localPlayer.weapon === GATLING_WEAPON_ID && isWeaponUnlocked(GATLING_WEAPON_ID);
+  const w = WEAPONS[localPlayer.weapon];
+  const weaponSpan = document.getElementById("fpsWeapon");
+  if (weaponSpan && w) {
+    weaponSpan.textContent = gatlingGrenadeMode ? `${w.name}-GL` : w.name;
+  }
+  updateAmmoUI();
+}
+
+function toggleGatlingGrenadeMode() {
+  if (localPlayer.weapon !== GATLING_WEAPON_ID || !isWeaponUnlocked(GATLING_WEAPON_ID)) {
+    fpsHint.textContent = "Press - while holding the Gatling to toggle grenade mode.";
+    return;
+  }
+  setGatlingGrenadeMode(!gatlingGrenadeMode);
+  fpsHint.textContent = gatlingGrenadeMode
+    ? "Gatling grenade mode armed. Hold fire to launch grenades."
+    : "Gatling bullet mode armed.";
+}
+
 function switchWeapon(id) {
   if (id >= WEAPONS.length) return;
   if (!isWeaponUnlocked(id)) {
@@ -1590,15 +1619,15 @@ function switchWeapon(id) {
   unzoomSniper();
   isReloading = false;
   resetGatlingRamp();
+  if (id !== GATLING_WEAPON_ID) gatlingGrenadeMode = false;
   if (gunMesh) {
     gunMesh.rotation.x = 0;
     gunMesh.rotation.y = 0;
     gunMesh.rotation.z = 0;
   }
   localPlayer.weapon = id;
-  const w = WEAPONS[id];
-  document.getElementById("fpsWeapon").textContent = w.name;
-  updateAmmoUI();
+  if (room) room.send("switchWeapon", id);
+  setGatlingGrenadeMode(gatlingGrenadeMode);
   createGunModel(id);
 }
 
@@ -1610,7 +1639,8 @@ function updateAmmoUI() {
     ammoSpan.textContent = "RELOADING...";
     ammoSpan.style.color = "red";
   } else {
-    ammoSpan.textContent = currentAmmo + "/" + w.magSize;
+    const mode = gatlingGrenadeMode && localPlayer.weapon === GATLING_WEAPON_ID ? " GL" : "";
+    ammoSpan.textContent = currentAmmo + "/" + w.magSize + mode;
     ammoSpan.style.color = currentAmmo === 0 ? "red" : "orange";
   }
 }
@@ -1668,7 +1698,7 @@ function tryFireWeapon() {
 
   const weapon = WEAPONS[localPlayer.weapon];
   const now = performance.now();
-  if (localPlayer.weapon === 3 && gatlingLastShotTime > 0 && now - gatlingLastShotTime > 250) {
+  if (localPlayer.weapon === GATLING_WEAPON_ID && gatlingLastShotTime > 0 && now - gatlingLastShotTime > 250) {
     resetGatlingRamp();
   }
   if (now < nextFireTime) return;
@@ -1683,9 +1713,11 @@ function tryFireWeapon() {
   updateAmmoUI();
 
   let shotCooldown = weapon.cooldown;
-  if (localPlayer.weapon === 3) {
+  const isGatling = localPlayer.weapon === GATLING_WEAPON_ID;
+  const isGatlingGrenadeShot = isGatling && gatlingGrenadeMode;
+  if (isGatling) {
     if (!gatlingFireStartTime) gatlingFireStartTime = now;
-    shotCooldown = getGatlingCooldown(now);
+    shotCooldown = isGatlingGrenadeShot ? GATLING_GRENADE_COOLDOWN : getGatlingCooldown(now);
     gatlingLastShotTime = now;
   }
   nextFireTime = now + shotCooldown;
@@ -1717,8 +1749,23 @@ function tryFireWeapon() {
 
   const bullets = weapon.bullets || 1;
   let spread = weapon.spread || 0;
-  if (localPlayer.weapon === 3) {
+  if (isGatling) {
     spread = getGatlingSpread(now, spread);
+  }
+
+  if (isGatlingGrenadeShot) {
+    const grenadeDir = dir.clone();
+    if (spread > 0) {
+      grenadeDir.x += (Math.random() - 0.5) * spread;
+      grenadeDir.y += (Math.random() - 0.5) * spread;
+      grenadeDir.z += (Math.random() - 0.5) * spread;
+      grenadeDir.normalize();
+    }
+    room.send("shootGatlingGrenade", {
+      origin: { x: origin.x, y: origin.y, z: origin.z },
+      dir: { x: grenadeDir.x, y: grenadeDir.y, z: grenadeDir.z }
+    });
+    return;
   }
 
   for (let i = 0; i < bullets; i++) {
@@ -2208,7 +2255,7 @@ function animate() {
     gunMesh.rotation.x += (targetRotX - gunMesh.rotation.x) * dampFactor;
   }
 
-  if (isPrimaryFireHeld && localPlayer.weapon === 3) {
+  if (isPrimaryFireHeld && localPlayer.weapon === GATLING_WEAPON_ID) {
     tryFireWeapon();
   }
 

--- a/server.js
+++ b/server.js
@@ -2431,6 +2431,8 @@ const AGAR_MERGE_COOLDOWN_MS = 9000;
 const FPS_GATLING_WEAPON_ID = 3;
 const FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER = 0.5;
 const FPS_GATLING_FIRING_GRACE_MS = 250;
+const FPS_GATLING_GRENADE_SPEED = 1.6;
+const FPS_GATLING_GRENADE_LIFE_MS = 1200;
 
 const agarServerDirectory = new Map();
 
@@ -2447,6 +2449,7 @@ class FPSPlayer extends schema.Schema {
     this.name = "Unknown";
     this.team = 0; // 0=FFA, 1=Red, 2=Blue
     this.killStreak = 0;
+    this.weapon = 0;
     this.gatlingFiringUntil = 0;
   }
 }
@@ -2461,6 +2464,7 @@ schema.defineTypes(FPSPlayer, {
   name: "string",
   team: "number",
   killStreak: "number",
+  weapon: "number",
   gatlingFiringUntil: "number"
 });
 
@@ -2955,9 +2959,29 @@ class FPSRoom extends colyseus.Room {
     });
   }
 
+  createFpsGrenadeProjectile(ownerId, origin, dir, options = {}) {
+    if (!origin || !dir) return null;
+    const proj = new FPSProjectile();
+    proj.id = Math.random().toString(36).substr(2, 9);
+    proj.ownerId = ownerId;
+    proj.type = options.type || 1; // 1=Frag, 2=Smoke, 3=Flash
+    proj.x = origin.x;
+    proj.y = origin.y;
+    proj.z = origin.z;
+    proj.dx = dir.x;
+    proj.dy = dir.y + (options.arc ?? 0.2);
+    proj.dz = dir.z;
+    proj.speed = options.speed || 1.0;
+    proj.life = options.life || 1500;
+    if (![proj.x, proj.y, proj.z, proj.dx, proj.dy, proj.dz].every(Number.isFinite)) return null;
+    this.state.projectiles.set(proj.id, proj);
+    return proj;
+  }
+
   handleElimination(shooter, shooterClient, victim, victimClient) {
     victim.health = 0;
     victim.killStreak = 0;
+    victim.weapon = 0;
     if (shooter && shooterClient && shooter !== victim) {
       shooter.kills += 1;
       shooter.killStreak += 1;
@@ -3039,6 +3063,16 @@ class FPSRoom extends colyseus.Room {
       this.broadcast("mapVotes", this.mapVotes);
     });
 
+    this.onMessage("switchWeapon", (client, weaponId) => {
+      if (this.state.roundOver) return;
+      const player = this.state.players.get(client.sessionId);
+      if (!player || player.health <= 0) return;
+      const id = Number(weaponId);
+      if (!Number.isInteger(id) || id < 0 || id > FPS_GATLING_WEAPON_ID) return;
+      if (id === FPS_GATLING_WEAPON_ID && player.killStreak < 5) return;
+      player.weapon = id;
+    });
+
     this.onMessage("move", (client, data) => {
       if (this.state.roundOver) return;
       const player = this.state.players.get(client.sessionId);
@@ -3058,6 +3092,9 @@ class FPSRoom extends colyseus.Room {
       if (this.state.mapId === 5 && shooter.team === 0) return;
       const weaponId = Number(data.weaponId);
       if (weaponId === FPS_GATLING_WEAPON_ID && shooter.killStreak < 5) return;
+      if (Number.isInteger(weaponId) && weaponId >= 0 && weaponId <= FPS_GATLING_WEAPON_ID) {
+        shooter.weapon = weaponId;
+      }
       if (weaponId === FPS_GATLING_WEAPON_ID) {
         shooter.gatlingFiringUntil = Date.now() + FPS_GATLING_FIRING_GRACE_MS;
       }
@@ -3165,25 +3202,31 @@ class FPSRoom extends colyseus.Room {
       });
     });
 
+    this.onMessage("shootGatlingGrenade", (client, data) => {
+      if (this.state.roundOver) return;
+      const shooter = this.state.players.get(client.sessionId);
+      if (!shooter || shooter.health <= 0) return;
+      if (this.state.mapId === 5 && shooter.team === 0) return;
+      if (shooter.weapon !== FPS_GATLING_WEAPON_ID || shooter.killStreak < 5) return;
+
+      shooter.gatlingFiringUntil = Date.now() + FPS_GATLING_FIRING_GRACE_MS;
+      this.createFpsGrenadeProjectile(client.sessionId, data.origin, data.dir, {
+        type: 1,
+        arc: 0.08,
+        speed: FPS_GATLING_GRENADE_SPEED,
+        life: FPS_GATLING_GRENADE_LIFE_MS
+      });
+    });
+
     this.onMessage("throwGrenade", (client, data) => {
       if (this.state.roundOver) return;
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
 
-      const proj = new FPSProjectile();
-      proj.id = Math.random().toString(36).substr(2, 9);
-      proj.ownerId = client.sessionId;
-      proj.type = (data.type || 0) + 1; // 1=Frag, 2=Smoke, 3=Flash
-      proj.x = data.origin.x;
-      proj.y = data.origin.y;
-      proj.z = data.origin.z;
-      proj.dx = data.dir.x;
-      proj.dy = data.dir.y + 0.2; // slight upward throw
-      proj.dz = data.dir.z;
-      proj.speed = 1.0;
-      proj.life = 1500; // 1.5 seconds until boom
-      this.state.projectiles.set(proj.id, proj);
+      this.createFpsGrenadeProjectile(client.sessionId, data.origin, data.dir, {
+        type: (data.type || 0) + 1
+      });
     });
 
     this.onMessage("joinTeam", (client, teamId) => {

--- a/server.js
+++ b/server.js
@@ -2428,6 +2428,9 @@ const AGAR_MAX_CELLS = 8;
 const AGAR_SPLIT_MIN_RADIUS = 24;
 const AGAR_SPLIT_LAUNCH_SPEED = 24;
 const AGAR_MERGE_COOLDOWN_MS = 9000;
+const FPS_GATLING_WEAPON_ID = 3;
+const FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER = 0.5;
+const FPS_GATLING_FIRING_GRACE_MS = 250;
 
 const agarServerDirectory = new Map();
 
@@ -2444,6 +2447,7 @@ class FPSPlayer extends schema.Schema {
     this.name = "Unknown";
     this.team = 0; // 0=FFA, 1=Red, 2=Blue
     this.killStreak = 0;
+    this.gatlingFiringUntil = 0;
   }
 }
 schema.defineTypes(FPSPlayer, {
@@ -2456,7 +2460,8 @@ schema.defineTypes(FPSPlayer, {
   kills: "number",
   name: "string",
   team: "number",
-  killStreak: "number"
+  killStreak: "number",
+  gatlingFiringUntil: "number"
 });
 
 class FPSPickup extends schema.Schema {
@@ -2858,6 +2863,28 @@ class FPSRoom extends colyseus.Room {
     }
   }
 
+  isPlayerFiringGatling(player) {
+    return player && player.gatlingFiringUntil && Date.now() <= player.gatlingFiringUntil;
+  }
+
+  getDamageAfterPlayerMitigation(target, amount) {
+    if (this.isPlayerFiringGatling(target)) {
+      return amount * FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER;
+    }
+    return amount;
+  }
+
+  applyDamageToPlayer(target, amount) {
+    const damage = this.getDamageAfterPlayerMitigation(target, amount);
+    if (target.armor > 0) {
+      const armorDmg = Math.min(target.armor, damage);
+      target.armor -= armorDmg;
+      target.health -= (damage - armorDmg);
+    } else {
+      target.health -= damage;
+    }
+  }
+
   explodeRocket(ex, ey, ez, ownerId) {
     this.broadcast("rocketExplode", { x: ex, y: ey, z: ez });
     const radius = 15;
@@ -2873,13 +2900,7 @@ class FPSRoom extends colyseus.Room {
       const dist = Math.sqrt((target.x - ex)**2 + (target.y - ey)**2 + (target.z - ez)**2);
       if (dist <= radius) {
         const damage = Math.floor(maxDamage * (1 - (dist / radius)));
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, damage);
 
         let hitClient = this.clients.find(c => c.sessionId === targetId);
         if (hitClient) {
@@ -2911,13 +2932,7 @@ class FPSRoom extends colyseus.Room {
       if (type === 1) { // Frag
           if (dist <= radius) {
             const damage = Math.floor(maxDamage * (1 - (dist / radius)));
-            if (target.armor > 0) {
-              const armorDmg = Math.min(target.armor, damage);
-              target.armor -= armorDmg;
-              target.health -= (damage - armorDmg);
-            } else {
-              target.health -= damage;
-            }
+            this.applyDamageToPlayer(target, damage);
 
             let hitClient = this.clients.find(c => c.sessionId === targetId);
             if (hitClient) {
@@ -3042,7 +3057,10 @@ class FPSRoom extends colyseus.Room {
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
       const weaponId = Number(data.weaponId);
-      if (weaponId === 3 && shooter.killStreak < 5) return;
+      if (weaponId === FPS_GATLING_WEAPON_ID && shooter.killStreak < 5) return;
+      if (weaponId === FPS_GATLING_WEAPON_ID) {
+        shooter.gatlingFiringUntil = Date.now() + FPS_GATLING_FIRING_GRACE_MS;
+      }
 
       this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
 
@@ -3095,16 +3113,10 @@ class FPSRoom extends colyseus.Room {
         let damage = 25;
         if (weaponId === 1) damage = 20; // Shotgun per bullet
         if (weaponId === 2) damage = 100; // Sniper
-        if (weaponId === 3) damage = 10; // Gatling
+        if (weaponId === FPS_GATLING_WEAPON_ID) damage = 10; // Gatling
         const target = hitClient.player;
 
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, damage);
 
         if (target.health > 0) {
           client.send("hitmarker", { killed: false });
@@ -3145,13 +3157,7 @@ class FPSRoom extends colyseus.Room {
 
         const t = 1 - (dist / radius);
         const damage = Math.max(20, Math.round(100 * t));
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, damage);
         if (target.health <= 0) {
           const victimClient = this.clients.find(c => c.sessionId === targetId);
           this.handleElimination(shooter, client, target, victimClient);

--- a/server.js
+++ b/server.js
@@ -2713,6 +2713,18 @@ class FPSRoom extends colyseus.Room {
     }
   }
 
+  projectileHitPlayer(proj) {
+    let hit = false;
+    const owner = this.state.players.get(proj.ownerId);
+    this.state.players.forEach((target, targetId) => {
+      if (hit || target.health <= 0 || targetId === proj.ownerId) return;
+      if (this.state.mapId === 5 && owner && owner.team !== 0 && owner.team === target.team) return;
+      const dist = Math.sqrt((target.x - proj.x)**2 + (target.y - proj.y)**2 + (target.z - proj.z)**2);
+      if (dist < 3) hit = true;
+    });
+    return hit;
+  }
+
   simulateTick() {
     if (this.state.roundOver) return;
 
@@ -2758,7 +2770,7 @@ class FPSRoom extends colyseus.Room {
 
         this.bounceGrenadeOnWalls(proj);
 
-        if (proj.life <= 0) {
+        if (this.projectileHitPlayer(proj) || proj.life <= 0) {
            this.explodeGrenade(proj.x, proj.y, proj.z, proj.ownerId, proj.type);
            this.state.projectiles.delete(projId);
         }
@@ -3207,8 +3219,10 @@ class FPSRoom extends colyseus.Room {
       const shooter = this.state.players.get(client.sessionId);
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
-      if (shooter.weapon !== FPS_GATLING_WEAPON_ID || shooter.killStreak < 5) return;
+      const weaponId = Number(data.weaponId);
+      if (weaponId !== FPS_GATLING_WEAPON_ID || shooter.killStreak < 5) return;
 
+      shooter.weapon = FPS_GATLING_WEAPON_ID;
       shooter.gatlingFiringUntil = Date.now() + FPS_GATLING_FIRING_GRACE_MS;
       this.createFpsGrenadeProjectile(client.sessionId, data.origin, data.dir, {
         type: 1,


### PR DESCRIPTION
### Motivation
- Reduce the amount of damage players take while they are actively firing the Gatling to make the weapon feel more survivable and reward its use.

### Description
- Added constants `FPS_GATLING_WEAPON_ID`, `FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER` (0.5) and `FPS_GATLING_FIRING_GRACE_MS` and tracked a `gatlingFiringUntil` timestamp on `FPSPlayer` to know when a player is (recently) firing the Gatling.
- Introduced `isPlayerFiringGatling`, `getDamageAfterPlayerMitigation` and `applyDamageToPlayer` helper methods and routed FPS damage through `applyDamageToPlayer` so mitigation is applied consistently while preserving existing armor handling.
- Updated `onMessage("shoot")` to mark the shooter as firing the Gatling for a short grace window and replaced direct `target.health` adjustments in bullet, barrel and explosion logic with `applyDamageToPlayer` calls.

### Testing
- Ran a syntax check with `node --check server.js` which completed without errors.
- Ran unit tests `node tests/agar_split.test.js` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb88052d448330b3f59b4f6430fb59)