### PR TITLE
Add DrawSystem.circle() and .text() to fix Core Driller rendering crash

### DIFF
--- a/core.js
+++ b/core.js
@@ -525,11 +525,20 @@ export class DrawSystem {
     this.commands.push({ kind: "line", color, width, x1, y1, x2, y2 });
   }
 
+  circle(color, x, y, radius) {
+    this.commands.push({ kind: "circle", color, x, y, radius });
+  }
+
+  text(color, x, y, value, font = "16px monospace") {
+    this.commands.push({ kind: "text", color, x, y, value, font });
+  }
+
   flush() {
     const ctx = this.ctx;
     let fillStyle = "";
     let strokeStyle = "";
     let lineWidth = 1;
+    let font = "";
     for (const cmd of this.commands) {
       if (cmd.kind === "clear" || cmd.kind === "rect") {
         if (fillStyle !== cmd.color) {
@@ -537,6 +546,28 @@ export class DrawSystem {
           ctx.fillStyle = fillStyle;
         }
         ctx.fillRect(cmd.x, cmd.y, cmd.w, cmd.h);
+        continue;
+      }
+      if (cmd.kind === "circle") {
+        if (fillStyle !== cmd.color) {
+          fillStyle = cmd.color;
+          ctx.fillStyle = fillStyle;
+        }
+        ctx.beginPath();
+        ctx.arc(cmd.x, cmd.y, cmd.radius, 0, Math.PI * 2);
+        ctx.fill();
+        continue;
+      }
+      if (cmd.kind === "text") {
+        if (fillStyle !== cmd.color) {
+          fillStyle = cmd.color;
+          ctx.fillStyle = fillStyle;
+        }
+        if (font !== cmd.font) {
+          font = cmd.font;
+          ctx.font = font;
+        }
+        ctx.fillText(cmd.value, cmd.x, cmd.y);
         continue;
       }
       if (strokeStyle !== cmd.color) {


### PR DESCRIPTION
### Motivation
- `games/coredriller.js` calls `draw.circle(...)` and `draw.text(...)` but `DrawSystem` did not expose those helpers, causing a runtime `TypeError: draw.circle is not a function` during rendering.
- The change adds missing draw primitives so canvas-based game rendering can draw ore/vents and HUD text correctly.

### Description
- Added `DrawSystem.circle(color, x, y, radius)` which queues a `circle` draw command. 
- Added `DrawSystem.text(color, x, y, value, font = "16px monospace")` which queues a `text` draw command and carries an optional font parameter. 
- Extended `DrawSystem.flush()` to handle `circle` commands by calling `ctx.arc(...); ctx.fill()` and `text` commands by setting `ctx.font` and calling `ctx.fillText(...)`, with lightweight caching of `fillStyle` and `font` to avoid redundant context updates.

### Testing
- No automated tests were run for the browser/canvas rendering path in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8e01a0e08322a7a67c7bce5ca515)