### PR TITLE
Convert overlay menus to multi-window draggable tabs with icon controls

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -1438,7 +1438,10 @@ body::before {
   left: 2vw;
   width: min(96vw, 1100px);
   height: calc(100vh - var(--topbar-clearance) - 64px);
-  resize: both;
+  max-width: 96vw;
+  max-height: calc(100vh - var(--topbar-clearance) - 56px);
+  border: 2px solid var(--accent);
+  box-sizing: border-box;
   overflow: auto;
 }
 .window-overlay.overlay-fullscreen {
@@ -1453,9 +1456,9 @@ body::before {
   z-index: 9999;
   background: #000;
 }
-#overlayTabHost {
+#overlayTaskbar {
   position: fixed;
-  top: var(--topbar-clearance);
+  bottom: 0;
   left: 0;
   right: 0;
   z-index: 1700;
@@ -1463,9 +1466,11 @@ body::before {
   gap: 6px;
   padding: 4px 8px;
   overflow-x: auto;
+  background: rgba(0, 0, 0, 0.95);
+  border-top: 2px solid var(--accent);
 }
 .overlay-tab-chip {
-  border: 1px solid var(--accent);
+  border: 2px solid var(--accent);
   background: rgba(0,0,0,.85);
   color: var(--accent);
   display: inline-flex;
@@ -1473,7 +1478,9 @@ body::before {
   gap: 8px;
   padding: 4px 8px;
   font-size: 10px;
+  cursor: grab;
 }
+.overlay-tab-chip:active { cursor: grabbing; }
 .overlay-tab-actions i { font-style: normal; padding: 0 4px; cursor: pointer; }
 
 

--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -1432,6 +1432,49 @@ body::before {
   opacity: 1;
   transform: translateY(0);
 }
+.window-overlay {
+  position: fixed;
+  top: calc(var(--topbar-clearance) + 44px);
+  left: 2vw;
+  width: min(96vw, 1100px);
+  height: calc(100vh - var(--topbar-clearance) - 64px);
+  resize: both;
+  overflow: auto;
+}
+.window-overlay.overlay-fullscreen {
+  top: var(--topbar-clearance);
+  left: 0;
+  width: 100vw;
+  height: calc(100vh - var(--topbar-clearance));
+  resize: none;
+}
+#overlayLogin.secure-login-only {
+  inset: 0;
+  z-index: 9999;
+  background: #000;
+}
+#overlayTabHost {
+  position: fixed;
+  top: var(--topbar-clearance);
+  left: 0;
+  right: 0;
+  z-index: 1700;
+  display: flex;
+  gap: 6px;
+  padding: 4px 8px;
+  overflow-x: auto;
+}
+.overlay-tab-chip {
+  border: 1px solid var(--accent);
+  background: rgba(0,0,0,.85);
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 10px;
+}
+.overlay-tab-actions i { font-style: normal; padding: 0 4px; cursor: pointer; }
 
 
 /* Menu-style overlays sit above the home scene so chat/glow stay visible. */

--- a/core.js
+++ b/core.js
@@ -3531,15 +3531,7 @@ window.toggleTopPanelOverlay = (id) => {
   const target = document.getElementById(id);
   if (!target) return;
 
-  const isClosingSameOverlay = target.classList.contains("active");
-
-  TOP_PANEL_OVERLAY_IDS.forEach((overlayId) => {
-    if (overlayId === id) return;
-    const overlay = document.getElementById(overlayId);
-    if (overlay) overlay.classList.remove("active");
-  });
-
-  if (isClosingSameOverlay) {
+  if (target.classList.contains("active")) {
     target.classList.remove("active");
   } else {
     target.classList.add("active");
@@ -3557,10 +3549,10 @@ export function openGame(id) {
     openConfigOverlay();
     return;
   }
-  closeOverlays();
   const el = document.getElementById(id);
   if (el) el.classList.add("active");
-  document.body.classList.toggle("overlay-open", Boolean(el));
+  const hasActiveOverlay = Boolean(document.querySelector(".overlay.active"));
+  document.body.classList.toggle("overlay-open", hasActiveOverlay);
   runOverlayOpenHooks(id);
 }
 

--- a/script.js
+++ b/script.js
@@ -1285,16 +1285,38 @@ function initOverlayTabsWindowManager() {
   const loginOverlay = document.getElementById("overlayLogin");
   if (loginOverlay) loginOverlay.classList.add("secure-login-only");
   const tabHost = document.createElement("div");
-  tabHost.id = "overlayTabHost";
+  tabHost.id = "overlayTaskbar";
   document.body.appendChild(tabHost);
   let zIndex = 1600;
   const windows = Array.from(document.querySelectorAll(".overlay")).filter((overlay) => overlay.id !== "overlayLogin");
   const icon = { min: "▁", full: "⛶", close: "✕" };
+  const windowState = new Map();
 
   const titleFor = (overlay) => {
     const label = overlay.querySelector("h1, h2, .score-title")?.textContent?.trim();
     return (label || overlay.id.replace(/^overlay/, "") || "WINDOW").slice(0, 24);
   };
+  const clampWindowToViewport = (overlay) => {
+    const topClearance = Number.parseInt(getComputedStyle(document.documentElement).getPropertyValue("--topbar-clearance"), 10) || 50;
+    const taskbarHeight = 48;
+    const rect = overlay.getBoundingClientRect();
+    const maxLeft = Math.max(0, window.innerWidth - rect.width - 8);
+    const maxTop = Math.max(topClearance + 8, window.innerHeight - taskbarHeight - rect.height - 8);
+    const nextLeft = Math.min(Math.max(0, rect.left), maxLeft);
+    const nextTop = Math.min(Math.max(topClearance + 8, rect.top), maxTop);
+    overlay.style.left = `${nextLeft}px`;
+    overlay.style.top = `${nextTop}px`;
+  };
+
+  const scaleWindow = (overlay, delta) => {
+    const current = windowState.get(overlay.id) || { scale: 1 };
+    const nextScale = Math.max(0.75, Math.min(1.5, (current.scale || 1) + delta));
+    windowState.set(overlay.id, { ...current, scale: nextScale });
+    overlay.style.transform = `scale(${nextScale})`;
+    overlay.style.transformOrigin = "top left";
+    clampWindowToViewport(overlay);
+  };
+
   const syncTabs = () => {
     const active = windows.filter((w) => w.classList.contains("active"));
     tabHost.innerHTML = "";
@@ -1316,6 +1338,31 @@ function initOverlayTabsWindowManager() {
           overlay.style.zIndex = String(++zIndex);
         }
       });
+      tab.addEventListener("wheel", (event) => {
+        event.preventDefault();
+        scaleWindow(overlay, event.deltaY > 0 ? -0.05 : 0.05);
+      }, { passive: false });
+      tab.addEventListener("mousedown", (event) => {
+        if (event.target?.dataset?.act) return;
+        const rect = overlay.getBoundingClientRect();
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const startLeft = rect.left;
+        const startTop = rect.top;
+        const onMove = (moveEvent) => {
+          const nextLeft = startLeft + (moveEvent.clientX - startX);
+          const nextTop = startTop + (moveEvent.clientY - startY);
+          overlay.style.left = `${nextLeft}px`;
+          overlay.style.top = `${nextTop}px`;
+          clampWindowToViewport(overlay);
+        };
+        const onUp = () => {
+          document.removeEventListener("mousemove", onMove);
+          document.removeEventListener("mouseup", onUp);
+        };
+        document.addEventListener("mousemove", onMove);
+        document.addEventListener("mouseup", onUp);
+      });
       tab.addEventListener("dragstart", () => tab.classList.add("dragging"));
       tab.addEventListener("dragend", () => tab.classList.remove("dragging"));
       tabHost.appendChild(tab);
@@ -1334,6 +1381,7 @@ function initOverlayTabsWindowManager() {
 
   windows.forEach((overlay) => {
     overlay.classList.add("window-overlay");
+    if (!windowState.has(overlay.id)) windowState.set(overlay.id, { scale: 1 });
     overlay.addEventListener("mousedown", () => {
       overlay.style.zIndex = String(++zIndex);
     });

--- a/script.js
+++ b/script.js
@@ -1281,6 +1281,72 @@ function initOverlayBackdropExit() {
   });
 }
 
+function initOverlayTabsWindowManager() {
+  const loginOverlay = document.getElementById("overlayLogin");
+  if (loginOverlay) loginOverlay.classList.add("secure-login-only");
+  const tabHost = document.createElement("div");
+  tabHost.id = "overlayTabHost";
+  document.body.appendChild(tabHost);
+  let zIndex = 1600;
+  const windows = Array.from(document.querySelectorAll(".overlay")).filter((overlay) => overlay.id !== "overlayLogin");
+  const icon = { min: "▁", full: "⛶", close: "✕" };
+
+  const titleFor = (overlay) => {
+    const label = overlay.querySelector("h1, h2, .score-title")?.textContent?.trim();
+    return (label || overlay.id.replace(/^overlay/, "") || "WINDOW").slice(0, 24);
+  };
+  const syncTabs = () => {
+    const active = windows.filter((w) => w.classList.contains("active"));
+    tabHost.innerHTML = "";
+    active.forEach((overlay) => {
+      const tab = document.createElement("button");
+      tab.className = "overlay-tab-chip";
+      tab.draggable = true;
+      tab.dataset.overlayId = overlay.id;
+      tab.innerHTML = `<span>${titleFor(overlay)}</span><span class="overlay-tab-actions"><i data-act="min">${icon.min}</i><i data-act="full">${icon.full}</i><i data-act="close">${icon.close}</i></span>`;
+      tab.addEventListener("click", (event) => {
+        const action = event.target?.dataset?.act;
+        if (action === "close" || action === "min") {
+          overlay.classList.remove("active", "overlay-fullscreen");
+        } else if (action === "full") {
+          overlay.classList.toggle("overlay-fullscreen");
+          overlay.classList.add("active");
+        } else {
+          overlay.classList.add("active");
+          overlay.style.zIndex = String(++zIndex);
+        }
+      });
+      tab.addEventListener("dragstart", () => tab.classList.add("dragging"));
+      tab.addEventListener("dragend", () => tab.classList.remove("dragging"));
+      tabHost.appendChild(tab);
+    });
+    document.body.classList.toggle("overlay-open", active.length > 0 || Boolean(loginOverlay?.classList.contains("active")));
+  };
+
+  tabHost.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    const dragging = tabHost.querySelector(".dragging");
+    if (!dragging) return;
+    const after = Array.from(tabHost.querySelectorAll(".overlay-tab-chip:not(.dragging)")).find((el) => event.clientX < el.getBoundingClientRect().left + el.offsetWidth / 2);
+    if (!after) tabHost.appendChild(dragging);
+    else tabHost.insertBefore(dragging, after);
+  });
+
+  windows.forEach((overlay) => {
+    overlay.classList.add("window-overlay");
+    overlay.addEventListener("mousedown", () => {
+      overlay.style.zIndex = String(++zIndex);
+    });
+    const observer = new MutationObserver(syncTabs);
+    observer.observe(overlay, { attributes: true, attributeFilter: ["class"] });
+  });
+  if (loginOverlay) {
+    const observer = new MutationObserver(syncTabs);
+    observer.observe(loginOverlay, { attributes: true, attributeFilter: ["class"] });
+  }
+  syncTabs();
+}
+
 function initAprilFoolsBibiMode() {
   const now = new Date();
   const isAprilFools = now.getUTCMonth() === 3 && now.getUTCDate() === 1;
@@ -1390,6 +1456,7 @@ disableInGameExitButtons();
 initPerGameFullscreenButtons();
 initTopBarOverlayControls();
 initOverlayBackdropExit();
+initOverlayTabsWindowManager();
 initAprilFoolsBibiMode();
 initAdminTabs();
 initGameCanvasSizing();


### PR DESCRIPTION
### Motivation

- Replace the old single-open overlay behavior with a multi-window/tab system so menus can remain open concurrently and be managed like movable windows. 
- Keep the login screen isolated and always present as a secure full-screen surface while other overlays are managed as windows.

### Description

- Changed `window.toggleTopPanelOverlay` to stop auto-closing other top-panel overlays and to recalculate `overlay-open` from actual active overlays.  (`core.js`)
- Updated `openGame` to preserve other open overlays and to update `overlay-open` based on actual active overlays instead of always calling `closeOverlays`. (`core.js`)
- Added an overlay tab/window manager `initOverlayTabsWindowManager` that builds a draggable tab strip, creates one tab per open overlay (excludes login), supports reordering, and provides icon-only controls for minimize (`▁`), fullscreen (`⛶`), and close (`✕`). (`script.js`)
- Made overlays behave like windows by adding a `window-overlay` class and an `overlay-fullscreen` mode, added a `secure-login-only` modifier for `#overlayLogin`, and implemented UI rules for the tab host and tab chips. (`Themes/theme.css`)
- Integrated the tab manager into startup sequence so tabs are synchronized with overlay visibility. (`script.js`)

### Testing

- Ran `npm test -- --runInBand` to exercise the test task, but the repo has no `test` script and the command failed with `Missing script: "test"` (no other automated tests were defined).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc6b831848322bd0e3a5cb233c1a4)