### PR TITLE
Fix FPS map editor fly controls on Linux/Chromium

### DIFF
--- a/games/fps-map-builder.html
+++ b/games/fps-map-builder.html
@@ -68,7 +68,7 @@
       </select>
       <button id="btnFocus">Focus (F)</button>
     </div>
-    <canvas id="view"></canvas>
+    <canvas id="view" tabindex="0"></canvas>
     <div id="selectionBox" style="display:none; position:absolute; border:1px solid #3b82f6; background:rgba(59, 130, 246, 0.2); pointer-events:none;"></div>
   </main>
 
@@ -83,7 +83,7 @@
 <footer class="bottom-bar">
   <span id="statusText">Ready</span>
   <div style="flex:1"></div>
-  <span>Shortcuts: <span class="kbd">W</span> <span class="kbd">E</span> <span class="kbd">R</span> | <span class="kbd">F</span> Focus | <span class="kbd">Del</span> Delete | <span class="kbd">Ctrl+D</span> Duplicate | <span class="kbd">Ctrl+C</span> Copy | <span class="kbd">Ctrl+V</span> Paste | <span class="kbd">Ctrl+Z</span> Undo</span>
+  <span>Shortcuts: RMB + mouse to fly, <span class="kbd">WASD</span> move | <span class="kbd">W</span> <span class="kbd">E</span> <span class="kbd">R</span> tools | <span class="kbd">F</span> Focus | <span class="kbd">Del</span> Delete | <span class="kbd">Ctrl+D</span> Duplicate | <span class="kbd">Ctrl+C</span> Copy | <span class="kbd">Ctrl+V</span> Paste | <span class="kbd">Ctrl+Z</span> Undo</span>
 </footer>
 
 <input type="file" id="uploadInput" style="display:none" accept=".json">
@@ -294,12 +294,37 @@ function animate() {
 
 // Camera Movement (Fly Style)
 const keys = {};
-window.addEventListener('keydown', e => { if(document.activeElement.tagName !== 'INPUT') keys[e.key.toLowerCase()] = true; });
-window.addEventListener('keyup', e => keys[e.key.toLowerCase()] = false);
+const flyCameraKeyCodes = new Set(['KeyW', 'KeyA', 'KeyS', 'KeyD', 'ShiftLeft', 'ShiftRight']);
+
+function isTextEntryActive() {
+  const activeEl = document.activeElement;
+  if (!activeEl) return false;
+  const tag = activeEl.tagName;
+  return activeEl.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+function isFlyCameraActive() {
+  return document.pointerLockElement === canvas;
+}
+
+window.addEventListener('keydown', e => {
+  if (isTextEntryActive()) return;
+  keys[e.key.toLowerCase()] = true;
+  if (isFlyCameraActive() && flyCameraKeyCodes.has(e.code)) e.preventDefault();
+});
+window.addEventListener('keyup', e => {
+  keys[e.key.toLowerCase()] = false;
+  if (isFlyCameraActive() && flyCameraKeyCodes.has(e.code)) e.preventDefault();
+});
 
 let yaw = -Math.PI / 4, pitch = -Math.PI / 4;
+canvas.addEventListener('contextmenu', (e) => e.preventDefault());
 canvas.addEventListener('mousedown', (e) => {
-  if (e.button === 2) canvas.requestPointerLock();
+  if (e.button === 2) {
+    e.preventDefault();
+    canvas.focus({ preventScroll: true });
+    canvas.requestPointerLock();
+  }
 });
 document.addEventListener('mousemove', (e) => {
   if (document.pointerLockElement === canvas) {
@@ -308,8 +333,8 @@ document.addEventListener('mousemove', (e) => {
     pitch = Math.max(-Math.PI/2 + 0.1, Math.min(Math.PI/2 - 0.1, pitch));
   }
 });
-document.addEventListener('mouseup', () => {
-  if (document.pointerLockElement === canvas) document.exitPointerLock();
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 2 && isFlyCameraActive()) document.exitPointerLock();
 });
 
 function handleCameraMovement() {
@@ -904,7 +929,11 @@ function initEventListeners() {
       }
       return;
     }
-    if (document.activeElement.tagName === 'INPUT') return;
+    if (isTextEntryActive()) return;
+    if (isFlyCameraActive()) {
+      if (flyCameraKeyCodes.has(e.code)) e.preventDefault();
+      return;
+    }
 
     if (e.key.toLowerCase() === 'w') toolMove.click();
     if (e.key.toLowerCase() === 'e') toolRotate.click();


### PR DESCRIPTION
### Motivation
- Users on Linux/Chromium (e.g. Hyprland) could not reliably enter the editor fly camera because right-click opened the browser context menu and editor shortcuts intercepted `WASD` movement keys.

### Description
- Make the editor canvas focusable by adding `tabindex="0"` to the `#view` canvas so it can receive keyboard focus when pointer-locked (`games/fps-map-builder.html`).
- Prevent the browser context menu on the canvas and call `canvas.focus()` + `canvas.requestPointerLock()` on right mousedown, and only exit pointer lock on right mouseup, so RMB + mouse consistently enters and leaves fly mode.
- Add `isTextEntryActive()` and `isFlyCameraActive()` helpers and a `flyCameraKeyCodes` set to ensure `WASD`/Shift are reserved for camera movement while pointer lock is active and to prevent default browser/shortcut behavior during fly mode.
- Update the footer help text to document `RMB + mouse` fly mode and `WASD` movement, and adjust key handling in the editor keyboard listeners to skip tool shortcuts while fly camera is active.

### Testing
- Ran unit tests `node tests/agar_split.test.js`, which completed successfully.
- Parsed the `games/fps-map-builder.html` module with `acorn` and ran automated snippet checks for pointer-lock behavior, which passed.
- Ran `git diff --check` and local static checks, which passed.
- Attempted a Playwright headless verification script to screenshot/validate canvas behavior, but `npx playwright install chromium` failed due to the Playwright CDN returning HTTP 403 in this environment, so the browser-based end-to-end check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf54662508333a226ace297b96c0f)