### PR TITLE
Fix UI startup reference errors

### DIFF
--- a/core.js
+++ b/core.js
@@ -255,6 +255,18 @@ let cachedSeasonBoards = { solo: [], gang: [] };
 let hideStatus = false;
 let stopChatPresenceSync = null;
 let chatPresenceByUser = {};
+let chatCount = 0;
+let lastChatAt = 0;
+let lastChatMsg = "";
+let activeChatTab = "global";
+let stopChatListener = null;
+let stopChatMuteListener = null;
+let activeDmUser = "";
+let globallyMutedUsers = new Set();
+let isChatInitialized = false;
+let isChatModerationModeEnabled = true;
+const emittedBubbleMessageKeys = new Set();
+const MAX_EMITTED_BUBBLE_KEYS = 400;
 
 function getUserStatusState(lastLogin, isHidden = false) {
   if (isHidden) return "hidden";
@@ -3770,15 +3782,15 @@ export function updateUI() {
   setText("displayUser", myName);
   const bankEl = document.getElementById("globalBank");
   const bankOverlayEl = document.getElementById("bankDisplay");
-  const currentVal = getComparableMoney(bankEl.innerText);
+  const currentVal = getComparableMoney(bankEl?.innerText);
   myMoney = clampEconomyNumber(myMoney, { min: 0, max: MAX_BANK_MONEY });
   loanData.debt = clampEconomyNumber(loanData.debt, { min: 0, max: MAX_LOAN_DEBT });
   const nextVal = getComparableMoney(myMoney);
-  if (currentVal !== nextVal) {
+  if (bankEl && currentVal !== nextVal) {
     bankEl.style.color = nextVal > currentVal ? "#0f0" : "#f00";
     setTimeout(() => (bankEl.style.color = "var(--accent)"), 500);
   }
-  bankEl.innerText = formatBankAmount(myMoney);
+  if (bankEl) bankEl.innerText = formatBankAmount(myMoney);
   if (bankOverlayEl) bankOverlayEl.innerText = formatBankAmount(myMoney);
 
   if (typeof updateBankOverviewVisuals === 'function') {
@@ -3805,18 +3817,18 @@ export function updateUI() {
   renderCrewPanel();
   renderSeasonPanel();
   renderLiveOps();
-  const rank = getRank(myMoney);
-  const rankData = getRankData(myMoney);
+  const playerRankData = getRankData(myMoney);
+  const rank = playerRankData.label;
   setText("displayRank", "[" + rank + "]");
-  setText("displayRankBadge", rankData.badge);
+  setText("displayRankBadge", playerRankData.badge);
   setText("profRank", rank);
-  setText("profRankBadge", rankData.badge);
+  setText("profRankBadge", playerRankData.badge);
   setText("profSummaryRank", "[" + rank + "]");
   const rankBadgeEls = [document.getElementById("displayRankBadge"), document.getElementById("profRankBadge")];
   rankBadgeEls.forEach((el) => {
     if (!el) return;
-    el.className = `rank-badge ${rankData.className}`;
-    el.title = `${rankData.label} RANK BADGE`;
+    el.className = `rank-badge ${playerRankData.className}`;
+    el.title = `${playerRankData.label} RANK BADGE`;
   });
   const rankProgress = getRankProgress(myMoney);
   setText("profProgressLabel", rankProgress.label);
@@ -6143,18 +6155,6 @@ if (clockEl) {
   });
 }
 
-let chatCount = 0;
-let lastChatAt = 0;
-let lastChatMsg = "";
-let activeChatTab = "global";
-let stopChatListener = null;
-let stopChatMuteListener = null;
-let activeDmUser = "";
-let globallyMutedUsers = new Set();
-let isChatInitialized = false;
-let isChatModerationModeEnabled = true;
-const emittedBubbleMessageKeys = new Set();
-const MAX_EMITTED_BUBBLE_KEYS = 400;
 
 function getStatusStateForUser(username) {
   const normalized = normalizeUsername(username || "");
@@ -7225,7 +7225,7 @@ export function resetLossStreak() {
 // Listen for space/enter to quickly restart after game over.
 function quickRestartListener(e) {
   if (e.key === " " || e.key === "Enter") {
-    document.getElementById("goRestart").click();
+    document.getElementById("goRestart")?.click();
     window.removeEventListener("keydown", quickRestartListener);
   }
 }

--- a/script.js
+++ b/script.js
@@ -1400,20 +1400,26 @@ initHomeRecentGames();
 
 function hideGameOverModal() {
   const modal = document.getElementById("modalGameOver");
+  if (!modal) return;
   modal.classList.remove("active");
   document.querySelectorAll(".game-over-host").forEach((el) => el.classList.remove("game-over-host"));
   document.body.appendChild(modal);
 }
 
+function activateOverlay(id) {
+  document.getElementById(id)?.classList.add("active");
+}
+
 // Restart the last game from the game-over modal.
-document.getElementById("goRestart").onclick = () => {
+const restartButton = document.getElementById("goRestart");
+if (restartButton) restartButton.onclick = () => {
   hideGameOverModal();
   clearRestartListener();
   if (state.currentGame === "snake") initSnake();
   if (state.currentGame === "pong") initPong();
   if (state.currentGame === "runner") initRunner();
   if (state.currentGame === "geo") {
-    document.getElementById("overlayGeo").classList.add("active");
+    activateOverlay("overlayGeo");
     window.showGeoMenu();
   }
   if (state.currentGame === "flappy") initFlappy();
@@ -1438,41 +1444,42 @@ document.getElementById("goRestart").onclick = () => {
   if (state.currentGame === "hexfall") initHexfall();
   if (state.currentGame === "mines") {
     initMines();
-    document.getElementById("overlayMines").classList.add("active");
+    activateOverlay("overlayMines");
   }
   if (state.currentGame === "baccarat") {
     initBaccarat();
-    document.getElementById("overlayBaccarat").classList.add("active");
+    activateOverlay("overlayBaccarat");
   }
   if (state.currentGame === "craps") {
     initCraps();
-    document.getElementById("overlayCraps").classList.add("active");
+    activateOverlay("overlayCraps");
   }
   if (state.currentGame === "videopoker") {
     initVideoPoker();
-    document.getElementById("overlayVideopoker").classList.add("active");
+    activateOverlay("overlayVideopoker");
   }
   if (state.currentGame === "roulette") {
     initRoulette();
-    document.getElementById("overlayRoulette").classList.add("active");
+    activateOverlay("overlayRoulette");
   }
   if (state.currentGame === "slots") {
     initSlots();
-    document.getElementById("overlaySlots").classList.add("active");
+    activateOverlay("overlaySlots");
   }
   if (state.currentGame === "blackjack") {
     state.myMoney = 1000;
     initBJ();
-    document.getElementById("overlayBlackjack").classList.add("active");
+    activateOverlay("overlayBlackjack");
   }
   if (state.currentGame === "war") {
     initWar();
-    document.getElementById("overlayWar").classList.add("active");
+    activateOverlay("overlayWar");
   }
 };
 
 // Exit the current game and close all overlays.
-document.getElementById("goExit").onclick = () => {
+const exitButton = document.getElementById("goExit");
+if (exitButton) exitButton.onclick = () => {
   stopAllGames();
   closeOverlays();
   hideGameOverModal();


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes on startup/restart caused by missing DOM elements and uninitialized chat/rank state. 
- Make UI updates resilient when certain elements are absent (e.g. bank display, overlays) so the app can boot under partial DOM or with ad/network filters.

### Description
- core.js: hoisted and consolidated chat-related state variables earlier in the module to ensure `isChatInitialized` and other chat flags are defined before `updateUI()`/admin rendering runs. 
- core.js: made `updateUI()` defensive by checking `bankEl` before reading/writing `innerText`/styles and replaced local `rankData` usage with `playerRankData` to avoid TDZ/temporal-dead-zone issues when computing/displaying rank UI. 
- core.js: guarded the quick-restart keyboard handler by using optional chaining when triggering the `goRestart` click to avoid errors if the button is missing. 
- script.js: guarded `hideGameOverModal()` against a missing modal, added `activateOverlay(id)` helper and replaced direct `document.getElementById(...).classList.add("active")` calls with the helper, and attached restart/exit handlers only if those buttons exist to avoid `Cannot set properties of null` errors.

### Testing
- Parsed `core.js` and `script.js` with an ECMAScript parser (`acorn`) to validate syntax; both files parsed successfully. (succeeded)
- Ran `git diff --check` / whitespace and basic diff checks to ensure no obvious diff errors; no failures reported. (succeeded)
- Attempted headless UI startup validation with a Playwright script, but Playwright’s browser installation failed due to CDN HTTP 403 in this environment, so the browser-driven startup check could not run. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0ab199ec8326b6ad4a550daca57d)