### PR TITLE
Fix taskbar hidden by dangling HTML comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,11 +570,6 @@
           </div>
           <div class="badge-grid" id="badgeGrid"></div>
         </div>
-        <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button><!--
-          class="term-btn"
-          style="margin-top: 20px"
-        >
-
         <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button>
       </div>
     </div>
@@ -587,17 +582,7 @@
         <div id="bdRarity">COMMON</div>
         <p id="bdDesc">This achievement is locked.</p>
         <div id="bdReward">REWARD: $???</div>
-        <button class="term-btn" onclick="document.getElementById('modalBadgeDetail').classList.remove('active')">CLOSE</button><!--
-          class="term-btn"
-          style="margin-top: 20px"
-          onclick="
-            document
-              .getElementById('modalBadgeDetail')
-              .classList.remove('active')
-          "
-        >
-
-        <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button>
+        <button class="term-btn" onclick="document.getElementById('modalBadgeDetail').classList.remove('active')">CLOSE</button>
       </div>
     </div>
 
@@ -749,11 +734,6 @@
         <div class="inventory-grid" id="inventoryList">
           <div class="inventory-empty">BAG IS EMPTY.</div>
         </div>
-        <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button><!--
-          class="term-btn"
-          style="margin-top: 20px"
-        >
-
         <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button>
       </div>
     </div>
@@ -766,11 +746,6 @@
           BALANCE: $<span id="shopBank">0</span>
         </div>
         <div class="shop-list" id="shopList"></div>
-        <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button><!--
-          class="term-btn"
-          style="margin-top: 20px"
-        >
-
         <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button>
       </div>
     </div>
@@ -1181,11 +1156,6 @@
         >
           LOGOUT
         </button>
-        <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button><!--
-          class="term-btn"
-          style="margin-top: 20px"
-        >
-
         <button class="term-btn" onclick="window.closeOverlays()">CLOSE</button>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- A number of unterminated HTML comment fragments after inline CLOSE buttons caused later page markup to be swallowed, which nested the taskbar inside overlay markup and made it non-interactive.
- Restore correct document structure so the taskbar renders at the bottom of the page and UI clicks work normally.

### Description
- Removed malformed/unterminated close-button comment fragments from `index.html` (profile/achievements modal, inventory, shop, and config overlays) so the HTML closes correctly and the taskbar remains top-level.
- Kept changes minimal and localized to the affected inline CLOSE button sections in `index.html` to avoid touching unrelated UI or JS code.
- Ensured overlays remain as `.overlay` siblings of the top-level `#desktop`/`#taskbar` markup instead of being accidentally commented into other blocks.

### Testing
- Ran an HTML-structure checker (`python3` HTMLParser script) that verifies no dangling close-button comments remain and that `taskbar`/`desktop`/key overlays are not nested, and it passed.
- Parsed `script.js`, `core.js`, and `wms.js` with `acorn` to confirm JavaScript syntax was unaffected, and the parse checks passed.
- Served the site with a simple static server (`python3 -m http.server`) and verified `index.html` responds with `HTTP 200` using `curl`, which succeeded.
- Attempted Playwright-based visual/interaction validation, but `npx playwright install chromium` failed in this environment due to a browser download (CDN) HTTP 403, so automated browser screenshots could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49be452483268eef7fa1a199415e)