### PR TITLE
Fix homepage click blocking and improve Firestore compatibility

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -1788,7 +1788,6 @@ body::before {
   background: rgba(0, 0, 0, 0.95);
   backdrop-filter: blur(20px);
   z-index: 9000;
-  display: flex;
   justify-content: center;
   align-items: center;
 }

--- a/core.js
+++ b/core.js
@@ -6,7 +6,7 @@ import {
   onAuthStateChanged,
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
 import {
-  getFirestore,
+  initializeFirestore,
   collection,
   doc,
   setDoc,
@@ -132,7 +132,9 @@ export function handleFirebaseError(error, context = "FIREBASE", fallback = "") 
 }
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
-const db = getFirestore(app);
+const db = initializeFirestore(app, {
+  experimentalAutoDetectLongPolling: true,
+});
 
 // Local player state (mirrors Firestore on sync).
 let myUid = null;


### PR DESCRIPTION
### Motivation
- The homepage was unclickable because the login overlay (`#overlayLogin`) kept a forced `display: flex`, leaving a transparent fixed element that intercepted pointer events even when not active.
- Firestore streaming calls produced errors that look like client-side blocking (e.g. `ERR_BLOCKED_BY_CLIENT` for Listen/Write channels), so we need a more robust client fallback when streaming is blocked.

### Description
- Remove the forced `display: flex` from `#overlayLogin` in `Themes/theme.css` so the overlay's visibility is controlled only by its `.active` state.
- Replace `getFirestore` with `initializeFirestore` and initialize `db` using `initializeFirestore(app, { experimentalAutoDetectLongPolling: true })` in `core.js` to enable Firestore long-polling fallback when streaming is unavailable.
- Changes are limited to `Themes/theme.css` and `core.js` and are designed to be minimal and backward-compatible.

### Testing
- Ran `node --check core.js` which succeeded.
- Ran `node --check script.js` which succeeded.
- Ran `git diff --check` which succeeded.
- Attempted to run a Playwright-based page probe, but `npx playwright install` failed due to the browser download CDN returning `403 Forbidden`, so end-to-end browser verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4b737254832682faebc335cf2f64)