### PR TITLE
Restore desktop apps, fix overlay/taskbar wiring, and persist desktop state

### DIFF
--- a/core.js
+++ b/core.js
@@ -799,6 +799,9 @@ function updateAdminMenu() {
   if (adminBtn) adminBtn.style.display = hasAccess ? "inline-block" : "none";
   const tbAdmin = document.getElementById("tabAdminMenu");
   if (tbAdmin) tbAdmin.style.display = hasAccess ? "block" : "none";
+  document.querySelectorAll(".admin-icon").forEach((icon) => {
+    icon.style.display = hasAccess ? "flex" : "none";
+  });
   if (adminName) adminName.innerText = hasAccess ? myName : "LOCKED";
   if (isChatInitialized && document.getElementById("chatHistory")) renderChatTab();
   syncMaintenanceOverlay();
@@ -3510,17 +3513,7 @@ export function closeConfigOverlay() {
 window.openConfigOverlay = openConfigOverlay;
 window.closeConfigOverlay = closeConfigOverlay;
 window.toggleConfigOverlay = () => {
-  if (typeof window.toggleTopPanelOverlay === "function") {
-    window.toggleTopPanelOverlay("overlayConfig");
-    return;
-  }
-  const configOverlay = document.getElementById("overlayConfig");
-  if (!configOverlay) return;
-  if (configOverlay.classList.contains("active")) {
-    closeConfigOverlay();
-  } else {
-    openConfigOverlay();
-  }
+  openGame("overlayConfig");
 };
 
 // --- Bank Internal Tab Navigation ---
@@ -3863,6 +3856,10 @@ function loadProfile(data) {
   updateMatrixToggle();
   updateAdminMenu();
   applyStatusVisibilityToggle(hideStatus);
+  if (typeof window.applyDesktopConfig === "function") window.applyDesktopConfig();
+  if (typeof window.restoreOpenDesktopApps === "function") {
+    requestAnimationFrame(() => window.restoreOpenDesktopApps());
+  }
 }
 
 // Render all user-facing UI fields based on the latest state.
@@ -7465,9 +7462,29 @@ export function updateBuilderInventoryState(hotbar, inventory, armor) {
     builderArmor = armor;
 }
 
-export function saveDesktopConfig(appId, left, top) {
-    desktopConfig[appId] = { left, top };
-    saveStats();
+let desktopConfigSaveTimer = null;
+
+export function saveDesktopConfig(appId, leftOrPatch, top, extra = {}) {
+    if (!appId) return;
+    const patch = typeof leftOrPatch === "object" && leftOrPatch !== null
+        ? leftOrPatch
+        : { left: leftOrPatch, top, ...extra };
+    const previous = desktopConfig[appId] || {};
+    const previousWindow = previous.window || {};
+    const nextWindow = patch.window ? { ...previousWindow, ...patch.window } : previousWindow;
+    desktopConfig[appId] = {
+        ...previous,
+        ...patch,
+        ...(patch.window ? { window: nextWindow } : {}),
+    };
+    if (myName !== "ANON") {
+        const localProfile = getLocalProfile(myName) || { name: myName, pin: localStorage.getItem("goonerPin") || "0000" };
+        saveLocalProfileSnapshot({ ...localProfile, desktopConfig });
+    }
+    clearTimeout(desktopConfigSaveTimer);
+    desktopConfigSaveTimer = setTimeout(() => {
+        saveStats().catch((error) => console.warn("Desktop config save failed", error));
+    }, 250);
 }
 
 export function getDesktopConfig() {
@@ -7475,5 +7492,6 @@ export function getDesktopConfig() {
 }
 
 window.saveDesktopConfig = saveDesktopConfig;
+window.getDesktopConfig = getDesktopConfig;
 
 export { builderHotbar, builderInventory, builderArmor };

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1"
     />
     <meta name="app-version" content="dev" />
-    <title>GOONER TERMINAL V32 [PVP FIX]</title>
+    <title>GOONER OS</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Roboto+Mono:wght@400;700&display=swap"
       rel="stylesheet"

--- a/index.html
+++ b/index.html
@@ -2697,9 +2697,28 @@
                 <span class="stat-label">CASH:</span> $<span id="taskbarBank">0</span>
             </div>
             <div class="taskbar-item sys-clock" id="taskbarClock">00:00:00</div>
-            <button id="taskbarConfigBtn" class="taskbar-item config-icon" title="Settings">⚙️</button>
+            <button id="taskbarConfigBtn" class="taskbar-item config-icon" title="Settings" onclick="window.openGame?.('overlayConfig')">⚙️</button>
         </div>
     </div>
+
+    <!-- Desktop shell bootstrap: keeps icons/taskbar usable even if the full app bundle is still loading. -->
+    <script type="module">
+      import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
+      import { initDesktop, createDesktopIcon, initTaskbarFallbacks } from "./wms.js";
+
+      initDesktop();
+      GAME_DIRECTORY_ENTRIES.forEach((game) => {
+        if (!game.hidden) {
+          createDesktopIcon({
+            id: game.id,
+            title: game.title,
+            icon: game.icon || "🎮",
+            overlayId: `overlay${game.id === "ttt" ? game.id.toUpperCase() : game.id.charAt(0).toUpperCase() + game.id.slice(1)}`,
+          });
+        }
+      });
+      initTaskbarFallbacks();
+    </script>
 
     <!-- Main entrypoint script (loads all game modules). -->
     <script type="module" src="script.js"></script>

--- a/wms.js
+++ b/wms.js
@@ -3,16 +3,59 @@
  * Handles window lifecycle, dragging, resizing, and taskbar integration.
  */
 
+const SYSTEM_DESKTOP_APPS = [
+  { id: "bank", title: "BANK", icon: "🏦", overlayId: "overlayBank" },
+  { id: "shop", title: "SHOP", icon: "🛒", overlayId: "overlayShop" },
+  { id: "inventory", title: "BAG", icon: "🎒", overlayId: "overlayInventory" },
+  { id: "profile", title: "PROFILE", icon: "👤", overlayId: "overlayProfile" },
+  { id: "season", title: "SEASON", icon: "🗓️", overlayId: "overlaySeason" },
+  { id: "crew", title: "CREW", icon: "🏴‍☠️", overlayId: "overlayCrew" },
+  { id: "chat", title: "CHAT", icon: "💬", overlayId: "globalChat" },
+  { id: "config", title: "CONFIG", icon: "⚙️", overlayId: "overlayConfig" },
+  { id: "games", title: "GAMES", icon: "🎮", overlayId: "overlayGamebox" },
+  { id: "trending", title: "TRENDING", icon: "📈", overlayId: "overlayTrending" },
+  { id: "recent", title: "RECENT", icon: "🕒", overlayId: "overlayRecentGames" },
+  { id: "updates", title: "UPDATES", icon: "📜", overlayId: "overlayUpdates" },
+  { id: "admin", title: "ADMIN", icon: "⚡", overlayId: "overlayAdmin", adminOnly: true },
+];
+
+const DEFAULT_WINDOW_STATE = { width: 800, height: 600, x: 100, y: 50 };
+
+function getDesktopConfig() {
+  return typeof window.getDesktopConfig === "function" ? window.getDesktopConfig() || {} : {};
+}
+
+function getConfigForApp(appId) {
+  return getDesktopConfig()[appId] || {};
+}
+
+function saveDesktopAppState(appId, patch = {}) {
+  if (typeof window.saveDesktopConfig === "function") {
+    window.saveDesktopConfig(appId, patch);
+  }
+}
+
+function getAppIdForOverlayId(overlayId) {
+  const systemApp = SYSTEM_DESKTOP_APPS.find((app) => app.overlayId === overlayId);
+  if (systemApp) return systemApp.id;
+  if (overlayId === "globalChat") return "chat";
+  if (!overlayId.startsWith("overlay")) return overlayId;
+  const raw = overlayId.slice("overlay".length);
+  if (raw === "TTT") return "ttt";
+  return raw.charAt(0).toLowerCase() + raw.slice(1);
+}
+
 export class AppWindow {
   constructor(id, title, contentElement, options = {}) {
     this.id = id;
+    this.appId = options.appId || getAppIdForOverlayId(id);
     this.title = title;
     this.contentElement = contentElement; // This is the original overlay content
+    this.contentPlaceholder = null;
+    const savedWindow = getConfigForApp(this.appId).window || {};
     this.options = {
-      width: options.width || 800,
-      height: options.height || 600,
-      x: options.x || 100,
-      y: options.y || 50,
+      ...DEFAULT_WINDOW_STATE,
+      ...savedWindow,
       minWidth: options.minWidth || 300,
       minHeight: options.minHeight || 200,
       icon: options.icon || "🎮",
@@ -34,8 +77,8 @@ export class AppWindow {
     win.className = "window";
     win.style.width = `${this.options.width}px`;
     win.style.height = `${this.options.height}px`;
-    win.style.left = `${this.options.x}px`;
-    win.style.top = `${this.options.y}px`;
+    win.style.left = `${Math.max(0, Math.min(this.options.x, window.innerWidth - 120))}px`;
+    win.style.top = `${Math.max(0, Math.min(this.options.y, window.innerHeight - 90))}px`;
     win.style.zIndex = this.zIndex;
 
     const resizer = document.createElement("div");
@@ -62,12 +105,13 @@ export class AppWindow {
         content.classList.add("game-container-16-9");
     }
 
-    // Move content from original overlay to window
+    // Move the original overlay node into the window so existing DOM queries by id
+    // keep working while CSS neutralizes the fullscreen overlay positioning.
     if (this.contentElement) {
-        // Some overlays might have multiple children, wrap them or move them all
-        while (this.contentElement.firstChild) {
-            content.appendChild(this.contentElement.firstChild);
-        }
+        this.contentPlaceholder = document.createComment(`wms-placeholder-${this.id}`);
+        this.contentElement.parentNode?.insertBefore(this.contentPlaceholder, this.contentElement);
+        this.contentElement.classList.remove("active");
+        content.appendChild(this.contentElement);
     }
 
     win.appendChild(header);
@@ -121,6 +165,20 @@ export class AppWindow {
     this.elements.window.onmousedown = () => this.focus();
   }
 
+  saveWindowState(extra = {}) {
+    saveDesktopAppState(this.appId, {
+      window: {
+        x: this.elements.window.offsetLeft,
+        y: this.elements.window.offsetTop,
+        width: this.elements.window.offsetWidth,
+        height: this.elements.window.offsetHeight,
+        isMaximized: this.isMaximized,
+        isMinimized: this.isMinimized,
+        ...extra,
+      },
+    });
+  }
+
   resizeStart(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -146,6 +204,7 @@ export class AppWindow {
     const stopResize = () => {
         document.removeEventListener('mousemove', doResize);
         document.removeEventListener('mouseup', stopResize);
+        this.saveWindowState();
     };
 
     document.addEventListener('mousemove', doResize);
@@ -233,6 +292,7 @@ export class AppWindow {
     const closeDragElement = () => {
       document.onmouseup = null;
       document.onmousemove = null;
+      this.saveWindowState();
     };
 
     document.onmousemove = elementDrag;
@@ -262,9 +322,11 @@ export class AppWindow {
     if (this.isMinimized) {
       this.elements.window.style.display = "none";
       this.elements.tab.classList.remove("active");
+      this.saveWindowState({ isMinimized: true });
     } else {
       this.elements.window.style.display = "flex";
       this.focus();
+      this.saveWindowState({ isMinimized: false });
     }
   }
 
@@ -307,9 +369,7 @@ export class AppWindow {
   toggleFavorite() {
     this.isFavorited = !this.isFavorited;
     this.elements.tab.classList.toggle("favorited", this.isFavorited);
-    if (window.saveDesktopConfig) {
-        window.saveDesktopConfig(this.id, this.elements.window.style.left, this.elements.window.style.top, { isFavorited: this.isFavorited });
-    }
+    saveDesktopAppState(this.appId, { isFavorited: this.isFavorited });
   }
 
   toggleMaximize() {
@@ -321,6 +381,7 @@ export class AppWindow {
     } else {
       this.elements.maximizeBtn.textContent = "🗖";
     }
+    this.saveWindowState();
   }
 
   close() {
@@ -332,11 +393,12 @@ export class AppWindow {
         }
     }
 
-    // Move content back to its original overlay container
-    if (this.contentElement) {
-        while (this.elements.content.firstChild) {
-            this.contentElement.appendChild(this.elements.content.firstChild);
-        }
+    // Move the original overlay node back where it came from.
+    if (this.contentElement && this.contentPlaceholder?.parentNode) {
+        this.contentElement.classList.remove("active");
+        this.contentPlaceholder.parentNode.insertBefore(this.contentElement, this.contentPlaceholder);
+        this.contentPlaceholder.remove();
+        this.contentPlaceholder = null;
     }
 
     this.elements.window.remove();
@@ -346,6 +408,8 @@ export class AppWindow {
         this.elements.tab.classList.remove("active");
         this.isMinimized = true;
     }
+
+    saveDesktopAppState(this.appId, { isOpen: false, window: { isMinimized: false } });
 
     // Notify WMS manager
     if (window.WMS) {
@@ -367,9 +431,14 @@ class WindowManager {
             return win;
         }
 
-        const win = new AppWindow(id, title, contentElement, options);
+        const appId = options?.appId || getAppIdForOverlayId(id);
+        const win = new AppWindow(id, title, contentElement, { ...options, appId });
         this.windows.set(id, win);
-        win.focus();
+        saveDesktopAppState(appId, { isOpen: true });
+        const savedWindow = getConfigForApp(appId).window || {};
+        if (savedWindow.isMaximized) win.toggleMaximize();
+        if (savedWindow.isMinimized) win.toggleMinimize();
+        if (!win.isMinimized) win.focus();
         return win;
     }
 
@@ -388,41 +457,19 @@ export function initDesktop() {
     const desktop = document.getElementById("desktop");
     if (!desktop) return;
 
-    // Filtered apps: removed those already in the taskbar or user menu
-    const apps = [
-        // { id: "bank", title: "BANK", icon: "🏦", overlayId: "overlayBank" },
-        // { id: "shop", title: "SHOP", icon: "🛒", overlayId: "overlayShop" },
-        // { id: "inventory", title: "BAG", icon: "🎒", overlayId: "overlayInventory" },
-        // { id: "profile", title: "PROFILE", icon: "👤", overlayId: "overlayProfile" },
-        // { id: "season", title: "SEASON", icon: "🗓️", overlayId: "overlaySeason" },
-        // { id: "crew", title: "CREW", icon: "🏴‍☠️", overlayId: "overlayCrew" },
-        // { id: "chat", title: "CHAT", icon: "💬", overlayId: "globalChat" },
-        // { id: "config", title: "CONFIG", icon: "⚙️", overlayId: "overlayConfig" },
-        // { id: "admin", title: "ADMIN", icon: "⚡", overlayId: "overlayAdmin", adminOnly: true },
-        // { id: "games", title: "GAMES", icon: "🎮", overlayId: "overlayGamebox" },
-    ];
-
-    // Load favorite/pinned apps from desktopConfig
-    if (typeof window.getDesktopConfig === "function") {
-        const config = window.getDesktopConfig();
-        Object.keys(config).forEach(appId => {
-            if (config[appId].isFavorited) {
-                // Pin logic handled by individual AppWindow instances,
-                // but icons can be recreated here if they represent non-system apps.
-            }
-        });
-    }
-
-    apps.forEach(app => {
+    SYSTEM_DESKTOP_APPS.forEach(app => {
         createDesktopIcon(app);
     });
+    applyDesktopConfig();
 }
 
 export function createDesktopIcon(app) {
     const desktop = document.getElementById("desktop");
+    if (!desktop || document.getElementById(`icon-${app.id}`)) return;
     const icon = document.createElement("div");
     icon.className = "desktop-icon";
     icon.id = `icon-${app.id}`;
+    icon.dataset.overlayId = app.overlayId;
     icon.innerHTML = `
         <div class="desktop-icon-img">${app.icon}</div>
         <div class="desktop-icon-label">${app.title}</div>
@@ -448,12 +495,20 @@ export function createDesktopIcon(app) {
         }
     };
 
+    const saved = getConfigForApp(app.id);
+    if (saved.left && saved.top) {
+        icon.style.left = saved.left;
+        icon.style.top = saved.top;
+        icon.style.position = "absolute";
+    }
+
     desktop.appendChild(icon);
     setupIconDraggable(icon, app.id);
 }
 
 function setupIconDraggable(icon, appId) {
     let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    let didDrag = false;
 
     icon.onmousedown = dragMouseDown;
 
@@ -461,6 +516,7 @@ function setupIconDraggable(icon, appId) {
         e.preventDefault();
         pos3 = e.clientX;
         pos4 = e.clientY;
+        didDrag = false;
         document.onmouseup = closeDragElement;
         document.onmousemove = elementDrag;
 
@@ -474,6 +530,7 @@ function setupIconDraggable(icon, appId) {
         pos2 = pos4 - e.clientY;
         pos3 = e.clientX;
         pos4 = e.clientY;
+        didDrag = true;
         icon.style.top = (icon.offsetTop - pos2) + "px";
         icon.style.left = (icon.offsetLeft - pos1) + "px";
         icon.style.position = "absolute";
@@ -484,8 +541,38 @@ function setupIconDraggable(icon, appId) {
         document.onmousemove = null;
 
         // Save position to state
-        if (window.saveDesktopConfig) {
-            window.saveDesktopConfig(appId, icon.style.left, icon.style.top);
+        if (didDrag && window.saveDesktopConfig) {
+            window.saveDesktopConfig(appId, { left: icon.style.left, top: icon.style.top });
         }
     }
 }
+
+
+export function applyDesktopConfig() {
+    const config = getDesktopConfig();
+    Object.keys(config).forEach(appId => {
+        const icon = document.getElementById(`icon-${appId}`);
+        const appConfig = config[appId] || {};
+        if (icon && appConfig.left && appConfig.top) {
+            icon.style.left = appConfig.left;
+            icon.style.top = appConfig.top;
+            icon.style.position = "absolute";
+        }
+    });
+}
+
+export function restoreOpenDesktopApps() {
+    const config = getDesktopConfig();
+    Object.keys(config).forEach(appId => {
+        const appConfig = config[appId] || {};
+        if (!appConfig.isOpen) return;
+        const icon = document.getElementById(`icon-${appId}`);
+        const overlayId = icon?.dataset.overlayId || SYSTEM_DESKTOP_APPS.find((app) => app.id === appId)?.overlayId;
+        if (overlayId && typeof window.openGame === "function") {
+            window.openGame(overlayId);
+        }
+    });
+}
+
+window.applyDesktopConfig = applyDesktopConfig;
+window.restoreOpenDesktopApps = restoreOpenDesktopApps;

--- a/wms.js
+++ b/wms.js
@@ -45,6 +45,19 @@ function getAppIdForOverlayId(overlayId) {
   return raw.charAt(0).toLowerCase() + raw.slice(1);
 }
 
+function getFallbackAppInfo(overlayId) {
+  const appId = getAppIdForOverlayId(overlayId);
+  const systemApp = SYSTEM_DESKTOP_APPS.find((app) => app.id === appId || app.overlayId === overlayId);
+  if (systemApp) return systemApp;
+  const icon = document.querySelector(`.desktop-icon[data-overlay-id="${overlayId}"]`);
+  return {
+    id: appId,
+    title: icon?.dataset.title || appId.toUpperCase(),
+    icon: icon?.dataset.icon || "🎮",
+    overlayId,
+  };
+}
+
 export class AppWindow {
   constructor(id, title, contentElement, options = {}) {
     this.id = id;
@@ -451,7 +464,37 @@ class WindowManager {
     }
 }
 
-window.WMS = new WindowManager();
+window.WMS = window.WMS || new WindowManager();
+
+export function openDesktopApp(overlayId) {
+    const contentElement = document.getElementById(overlayId);
+    if (!contentElement || !window.WMS) return null;
+    const app = getFallbackAppInfo(overlayId);
+    return window.WMS.createWindow(overlayId, app.title, contentElement, { icon: app.icon, appId: app.id });
+}
+
+if (typeof window.openGame !== "function") {
+    window.openGame = openDesktopApp;
+}
+
+export function initTaskbarFallbacks() {
+    const configBtn = document.getElementById("taskbarConfigBtn");
+    if (configBtn && configBtn.dataset.desktopFallbackReady !== "1") {
+        configBtn.dataset.desktopFallbackReady = "1";
+        configBtn.onclick = () => window.openGame?.("overlayConfig");
+    }
+
+    const userMenuBtn = document.getElementById("userMenuBtn");
+    const userMenuDropdown = document.getElementById("userMenuDropdown");
+    if (userMenuBtn && userMenuDropdown && userMenuBtn.dataset.desktopFallbackReady !== "1") {
+        userMenuBtn.dataset.desktopFallbackReady = "1";
+        userMenuBtn.onclick = (event) => {
+            event.stopPropagation();
+            userMenuDropdown.classList.toggle("active");
+        };
+        document.addEventListener("click", () => userMenuDropdown.classList.remove("active"));
+    }
+}
 
 export function initDesktop() {
     const desktop = document.getElementById("desktop");
@@ -470,6 +513,8 @@ export function createDesktopIcon(app) {
     icon.className = "desktop-icon";
     icon.id = `icon-${app.id}`;
     icon.dataset.overlayId = app.overlayId;
+    icon.dataset.title = app.title;
+    icon.dataset.icon = app.icon || "🎮";
     icon.innerHTML = `
         <div class="desktop-icon-img">${app.icon}</div>
         <div class="desktop-icon-label">${app.title}</div>
@@ -480,19 +525,21 @@ export function createDesktopIcon(app) {
         icon.classList.add("admin-icon");
     }
 
-    icon.ondblclick = () => {
+    const openApp = () => {
         if (typeof window.openGame === "function") {
             window.openGame(app.overlayId);
+        } else {
+            openDesktopApp(app.overlayId);
         }
     };
 
-    // Support single click for mobile
-    icon.onclick = (e) => {
-        if (window.innerWidth <= 768) {
-            if (typeof window.openGame === "function") {
-                window.openGame(app.overlayId);
-            }
+    icon.ondblclick = openApp;
+    icon.onclick = () => {
+        if (icon.dataset.dragged === "1") {
+            icon.dataset.dragged = "0";
+            return;
         }
+        openApp();
     };
 
     const saved = getConfigForApp(app.id);
@@ -531,6 +578,7 @@ function setupIconDraggable(icon, appId) {
         pos3 = e.clientX;
         pos4 = e.clientY;
         didDrag = true;
+        icon.dataset.dragged = "1";
         icon.style.top = (icon.offsetTop - pos2) + "px";
         icon.style.left = (icon.offsetLeft - pos1) + "px";
         icon.style.position = "absolute";


### PR DESCRIPTION
### Motivation
- Desktop icons and app windows stopped appearing because overlay content was being detached from the DOM when WMS created windows, and bottom/taskbar buttons were not using the unified open path; the UI also needed persistent app state across refresh.
- The page title was outdated and should display the product name.
- Users expect icon positions and open windows to survive a page refresh and be saved to the player profile.

### Description
- Restored system desktop icons and made them deterministic by introducing `SYSTEM_DESKTOP_APPS` and generating icons via `initDesktop()`/`createDesktopIcon()` in `wms.js`, with duplicate guards and `data-overlay-id` metadata.
- Fixed WMS mounting so the original overlay node is moved into the WMS window (keeps original DOM IDs/queries intact) instead of stripping children, and the node is restored on close (`wms.js`).
- Added per-app state persistence: icon positions, window position/size/minimized/maximized, `isOpen` and `isFavorited` are saved via an extended `saveDesktopConfig()` (now accepts a patch object) and written into the player/local snapshot; `applyDesktopConfig()` and `restoreOpenDesktopApps()` reapply these on load (`wms.js`, `core.js`).
- Only save icon location when an actual drag occurred (introduces `didDrag`) and save window state on resize/drag/close/maximize/minimize via `saveWindowState()` (`wms.js`).
- Routed the settings button to the WMS/open path by making `toggleConfigOverlay()` call `openGame('overlayConfig')` so bottom buttons open windows correctly (`core.js`).
- Show/hide admin-only desktop icons based on `isGodUser()` by toggling `.admin-icon` visibility in `updateAdminMenu()` (`core.js`).
- Updated browser tab title to `GOONER OS` in `index.html`.

### Testing
- Ran syntax/static checks with `node --check` for `script.js`, `wms.js`, `core.js`, and `server.js`, which succeeded.
- Attempted end-to-end UI validation with a headless Playwright script; Playwright browser install failed due to the Playwright CDN returning HTTP 403 in this environment, so automated browser screenshot validation could not run.
- Verified the new persistence API by simulating save flows locally and confirmed `saveDesktopConfig()` updates the local profile snapshot and triggers `saveStats()` (delayed write) without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd603d7eb48326a355a08bca505f3d)