### PR TITLE
Disable auto-maximize when window dragged to top

### DIFF
--- a/wms.js
+++ b/wms.js
@@ -257,14 +257,6 @@ export class AppWindow {
           top = screenHeight - this.elements.window.offsetHeight;
       }
 
-      // Top-middle snap logic
-      if (top === 0 && Math.abs(left + this.elements.window.offsetWidth / 2 - screenWidth / 2) < snapThreshold * 2) {
-          if (!this.isMaximized) {
-              this.toggleMaximize();
-              return;
-          }
-      }
-
       // Prevent overlapping by snapping to sides
       if (window.WMS) {
           window.WMS.windows.forEach((win, id) => {


### PR DESCRIPTION
### Motivation
- Prevent windows (including games) from being automatically maximized/fullscreened when moved to the top-center of the screen while keeping existing edge snapping and overlap-avoidance behavior.

### Description
- Removed the top-middle snap logic in `wms.js` that invoked `toggleMaximize()` when a window was dragged to the top-center, preserving other snapping and non-overlap adjustments.

### Testing
- Ran `node --check wms.js` to validate syntax, which succeeded.
- Ran `git diff --check` to ensure no diff/whitespace issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9e4bd9ec832698c504230dbf5a2f)