### PR TITLE
Anchor desktop icon drag to cursor and snap icons to grid

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -310,6 +310,10 @@ body::before {
   border-color: var(--accent);
 }
 
+.desktop-icon.dragging {
+  transition: none;
+}
+
 .desktop-icon-img {
   font-size: 32px;
   filter: drop-shadow(0 0 5px var(--accent-glow));

--- a/desktop-shell.js
+++ b/desktop-shell.js
@@ -1,5 +1,6 @@
 import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
 import {
+    arrangeDesktopIcons,
     createDesktopIcon,
     initDesktop,
     installFallbackOpenGame,
@@ -24,3 +25,5 @@ GAME_DIRECTORY_ENTRIES.forEach((game) => {
         overlayId: toOverlayId(game.id),
     });
 });
+
+arrangeDesktopIcons();

--- a/script.js
+++ b/script.js
@@ -100,7 +100,7 @@ import { initMines } from "./games/mines.js";
 import "./games/fnaf.js";
 import { initFps } from "./games/fps.js";
 import { GAME_DIRECTORY_ENTRIES } from "./gameCatalog.js";
-import { initDesktop, createDesktopIcon } from "./wms.js";
+import { initDesktop, createDesktopIcon, arrangeDesktopIcons } from "./wms.js";
 import { getDesktopConfig } from "./core.js";
 
 // Expose select helpers globally for inline HTML event handlers.
@@ -1418,17 +1418,9 @@ GAME_DIRECTORY_ENTRIES.forEach(game => {
 });
 
 
-// Apply desktop config (positions)
+// Apply desktop config (positions), snapping to the desktop grid and nudging collisions.
 setTimeout(() => {
-    const config = getDesktopConfig();
-    Object.keys(config).forEach(appId => {
-        const icon = document.getElementById(`icon-${appId}`);
-        if (icon) {
-            icon.style.left = config[appId].left;
-            icon.style.top = config[appId].top;
-            icon.style.position = "absolute";
-        }
-    });
+    arrangeDesktopIcons(getDesktopConfig());
 }, 1000);
 
 // Taskbar Actions

--- a/wms.js
+++ b/wms.js
@@ -522,12 +522,150 @@ export function createDesktopIcon(app) {
 
     desktop.appendChild(icon);
     setupIconDraggable(icon, app.id);
+    arrangeDesktopIcons(typeof window.getDesktopConfig === "function" ? window.getDesktopConfig() : {});
     return icon;
 }
 
 const DESKTOP_ICON_GRID_X = 100;
 const DESKTOP_ICON_GRID_Y = 100;
 const DESKTOP_ICON_DRAG_THRESHOLD = 5;
+
+function getDesktopMetrics() {
+    const desktop = document.getElementById("desktop");
+    const styles = desktop ? window.getComputedStyle(desktop) : null;
+    const paddingLeft = parseFloat(styles?.paddingLeft) || 0;
+    const paddingRight = parseFloat(styles?.paddingRight) || 0;
+    const paddingTop = parseFloat(styles?.paddingTop) || 0;
+    const paddingBottom = parseFloat(styles?.paddingBottom) || 0;
+
+    return {
+        desktop,
+        rect: desktop?.getBoundingClientRect() || { left: 0, top: 0 },
+        paddingLeft,
+        paddingRight,
+        paddingTop,
+        paddingBottom,
+    };
+}
+
+function parsePixelValue(value) {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getGridColumnCount() {
+    const { desktop, paddingLeft, paddingRight } = getDesktopMetrics();
+    if (!desktop) return 1;
+
+    const usableWidth = desktop.clientWidth - paddingLeft - paddingRight;
+    return Math.max(1, Math.floor(usableWidth / DESKTOP_ICON_GRID_X));
+}
+
+function clampToDesktop(icon, left, top, { allowVerticalOverflow = false } = {}) {
+    const { desktop, paddingRight, paddingBottom } = getDesktopMetrics();
+    if (!desktop) return { left, top };
+
+    const maxLeft = Math.max(0, desktop.clientWidth - paddingRight - icon.offsetWidth);
+    const maxTop = allowVerticalOverflow
+        ? Math.max(top, desktop.clientHeight - paddingBottom - icon.offsetHeight)
+        : Math.max(0, desktop.clientHeight - paddingBottom - icon.offsetHeight);
+
+    return {
+        left: Math.min(Math.max(left, 0), maxLeft),
+        top: Math.min(Math.max(top, 0), maxTop),
+    };
+}
+
+function snapToGrid(icon, left, top, options = {}) {
+    const { paddingLeft, paddingTop } = getDesktopMetrics();
+    const snappedLeft = paddingLeft + Math.round((left - paddingLeft) / DESKTOP_ICON_GRID_X) * DESKTOP_ICON_GRID_X;
+    const snappedTop = paddingTop + Math.round((top - paddingTop) / DESKTOP_ICON_GRID_Y) * DESKTOP_ICON_GRID_Y;
+    return clampToDesktop(icon, snappedLeft, snappedTop, options);
+}
+
+function gridKey(left, top) {
+    const { paddingLeft, paddingTop } = getDesktopMetrics();
+    const column = Math.round((left - paddingLeft) / DESKTOP_ICON_GRID_X);
+    const row = Math.round((top - paddingTop) / DESKTOP_ICON_GRID_Y);
+    return `${column},${row}`;
+}
+
+function findAvailableGridPosition(icon, preferredLeft, preferredTop, occupiedCells) {
+    const { paddingLeft, paddingTop } = getDesktopMetrics();
+    const columnCount = getGridColumnCount();
+    const preferred = snapToGrid(icon, preferredLeft, preferredTop, { allowVerticalOverflow: true });
+    const preferredColumn = Math.max(0, Math.round((preferred.left - paddingLeft) / DESKTOP_ICON_GRID_X));
+    const preferredRow = Math.max(0, Math.round((preferred.top - paddingTop) / DESKTOP_ICON_GRID_Y));
+    const startIndex = preferredRow * columnCount + Math.min(preferredColumn, columnCount - 1);
+    const maxAttempts = Math.max(occupiedCells.size + columnCount + 1, 2000);
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const index = startIndex + attempt;
+        const column = index % columnCount;
+        const row = Math.floor(index / columnCount);
+        const left = paddingLeft + column * DESKTOP_ICON_GRID_X;
+        const top = paddingTop + row * DESKTOP_ICON_GRID_Y;
+        const snapped = clampToDesktop(icon, left, top, { allowVerticalOverflow: true });
+        const key = gridKey(snapped.left, snapped.top);
+
+        if (!occupiedCells.has(key)) {
+            occupiedCells.add(key);
+            return snapped;
+        }
+    }
+
+    return preferred;
+}
+
+function setIconPosition(icon, left, top, options = {}) {
+    const clamped = clampToDesktop(icon, left, top, options);
+    icon.style.left = `${clamped.left}px`;
+    icon.style.top = `${clamped.top}px`;
+    icon.style.position = "absolute";
+}
+
+function positionIconOnGrid(icon, preferredLeft, preferredTop, occupiedCells) {
+    const { paddingLeft, paddingTop } = getDesktopMetrics();
+    const left = preferredLeft ?? (icon.offsetLeft || paddingLeft);
+    const top = preferredTop ?? (icon.offsetTop || paddingTop);
+    const position = findAvailableGridPosition(icon, left, top, occupiedCells);
+    setIconPosition(icon, position.left, position.top, { allowVerticalOverflow: true });
+    return position;
+}
+
+function getOccupiedGridCells(excludedIcon = null) {
+    const desktop = document.getElementById("desktop");
+    const occupiedCells = new Set();
+    if (!desktop) return occupiedCells;
+
+    desktop.querySelectorAll(".desktop-icon").forEach((icon) => {
+        if (icon === excludedIcon || icon.style.display === "none") return;
+
+        const snapped = snapToGrid(icon, icon.offsetLeft, icon.offsetTop, { allowVerticalOverflow: true });
+        occupiedCells.add(gridKey(snapped.left, snapped.top));
+    });
+
+    return occupiedCells;
+}
+
+export function arrangeDesktopIcons(config = {}) {
+    const desktop = document.getElementById("desktop");
+    if (!desktop) return;
+
+    const occupiedCells = new Set();
+    desktop.querySelectorAll(".desktop-icon").forEach((icon) => {
+        if (icon.style.display === "none") return;
+
+        const appId = icon.id?.startsWith("icon-") ? icon.id.slice(5) : "";
+        const savedConfig = config[appId] || {};
+        positionIconOnGrid(
+            icon,
+            parsePixelValue(savedConfig.left),
+            parsePixelValue(savedConfig.top),
+            occupiedCells,
+        );
+    });
+}
 
 function setupIconDraggable(icon, appId) {
     let startX = 0, startY = 0;
@@ -539,50 +677,6 @@ function setupIconDraggable(icon, appId) {
 
     icon.onmousedown = dragMouseDown;
 
-    function getDesktopMetrics() {
-        const desktop = document.getElementById("desktop");
-        const styles = desktop ? window.getComputedStyle(desktop) : null;
-        const paddingLeft = parseFloat(styles?.paddingLeft) || 0;
-        const paddingRight = parseFloat(styles?.paddingRight) || 0;
-        const paddingTop = parseFloat(styles?.paddingTop) || 0;
-        const paddingBottom = parseFloat(styles?.paddingBottom) || 0;
-
-        return {
-            desktop,
-            rect: desktop?.getBoundingClientRect() || { left: 0, top: 0 },
-            paddingLeft,
-            paddingRight,
-            paddingTop,
-            paddingBottom,
-        };
-    }
-
-    function clampToDesktop(left, top) {
-        const { desktop, paddingRight, paddingBottom } = getDesktopMetrics();
-        if (!desktop) return { left, top };
-
-        const maxLeft = Math.max(0, desktop.clientWidth - paddingRight - icon.offsetWidth);
-        const maxTop = Math.max(0, desktop.clientHeight - paddingBottom - icon.offsetHeight);
-
-        return {
-            left: Math.min(Math.max(left, 0), maxLeft),
-            top: Math.min(Math.max(top, 0), maxTop),
-        };
-    }
-
-    function snapToGrid(left, top) {
-        const { paddingLeft, paddingTop } = getDesktopMetrics();
-        const snappedLeft = paddingLeft + Math.round((left - paddingLeft) / DESKTOP_ICON_GRID_X) * DESKTOP_ICON_GRID_X;
-        const snappedTop = paddingTop + Math.round((top - paddingTop) / DESKTOP_ICON_GRID_Y) * DESKTOP_ICON_GRID_Y;
-        return clampToDesktop(snappedLeft, snappedTop);
-    }
-
-    function setIconPosition(left, top) {
-        const clamped = clampToDesktop(left, top);
-        icon.style.left = `${clamped.left}px`;
-        icon.style.top = `${clamped.top}px`;
-        icon.style.position = "absolute";
-    }
 
     function dragMouseDown(e) {
         if (e.button !== 0) return;
@@ -601,7 +695,7 @@ function setupIconDraggable(icon, appId) {
 
         // Convert flex-positioned icons to absolute positioning before dragging so
         // the pointer keeps the same grab point instead of jumping to an edge.
-        setIconPosition(iconRect.left - desktopRect.left, iconRect.top - desktopRect.top);
+        setIconPosition(icon, iconRect.left - desktopRect.left, iconRect.top - desktopRect.top);
 
         document.onmouseup = closeDragElement;
         document.onmousemove = elementDrag;
@@ -622,7 +716,7 @@ function setupIconDraggable(icon, appId) {
             icon.__suppressNextOpen = true;
         }
 
-        setIconPosition(nextLeft, nextTop);
+        setIconPosition(icon, nextLeft, nextTop);
     }
 
     function closeDragElement() {
@@ -637,8 +731,13 @@ function setupIconDraggable(icon, appId) {
             return;
         }
 
-        const snapped = snapToGrid(icon.offsetLeft, icon.offsetTop);
-        setIconPosition(snapped.left, snapped.top);
+        const snapped = findAvailableGridPosition(
+            icon,
+            icon.offsetLeft,
+            icon.offsetTop,
+            getOccupiedGridCells(icon),
+        );
+        setIconPosition(icon, snapped.left, snapped.top);
 
         // Save snapped position to state
         if (window.saveDesktopConfig) {

--- a/wms.js
+++ b/wms.js
@@ -525,49 +525,122 @@ export function createDesktopIcon(app) {
     return icon;
 }
 
+const DESKTOP_ICON_GRID_X = 100;
+const DESKTOP_ICON_GRID_Y = 100;
+const DESKTOP_ICON_DRAG_THRESHOLD = 5;
+
 function setupIconDraggable(icon, appId) {
-    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
     let startX = 0, startY = 0;
+    let dragOffsetX = 0, dragOffsetY = 0;
     let didDrag = false;
+    let previousInlinePosition = "";
+    let previousInlineLeft = "";
+    let previousInlineTop = "";
 
     icon.onmousedown = dragMouseDown;
 
+    function getDesktopMetrics() {
+        const desktop = document.getElementById("desktop");
+        const styles = desktop ? window.getComputedStyle(desktop) : null;
+        const paddingLeft = parseFloat(styles?.paddingLeft) || 0;
+        const paddingRight = parseFloat(styles?.paddingRight) || 0;
+        const paddingTop = parseFloat(styles?.paddingTop) || 0;
+        const paddingBottom = parseFloat(styles?.paddingBottom) || 0;
+
+        return {
+            desktop,
+            rect: desktop?.getBoundingClientRect() || { left: 0, top: 0 },
+            paddingLeft,
+            paddingRight,
+            paddingTop,
+            paddingBottom,
+        };
+    }
+
+    function clampToDesktop(left, top) {
+        const { desktop, paddingRight, paddingBottom } = getDesktopMetrics();
+        if (!desktop) return { left, top };
+
+        const maxLeft = Math.max(0, desktop.clientWidth - paddingRight - icon.offsetWidth);
+        const maxTop = Math.max(0, desktop.clientHeight - paddingBottom - icon.offsetHeight);
+
+        return {
+            left: Math.min(Math.max(left, 0), maxLeft),
+            top: Math.min(Math.max(top, 0), maxTop),
+        };
+    }
+
+    function snapToGrid(left, top) {
+        const { paddingLeft, paddingTop } = getDesktopMetrics();
+        const snappedLeft = paddingLeft + Math.round((left - paddingLeft) / DESKTOP_ICON_GRID_X) * DESKTOP_ICON_GRID_X;
+        const snappedTop = paddingTop + Math.round((top - paddingTop) / DESKTOP_ICON_GRID_Y) * DESKTOP_ICON_GRID_Y;
+        return clampToDesktop(snappedLeft, snappedTop);
+    }
+
+    function setIconPosition(left, top) {
+        const clamped = clampToDesktop(left, top);
+        icon.style.left = `${clamped.left}px`;
+        icon.style.top = `${clamped.top}px`;
+        icon.style.position = "absolute";
+    }
+
     function dragMouseDown(e) {
+        if (e.button !== 0) return;
         e.preventDefault();
-        pos3 = e.clientX;
-        pos4 = e.clientY;
+
+        const iconRect = icon.getBoundingClientRect();
+        const { rect: desktopRect } = getDesktopMetrics();
+        previousInlinePosition = icon.style.position;
+        previousInlineLeft = icon.style.left;
+        previousInlineTop = icon.style.top;
+        dragOffsetX = e.clientX - iconRect.left;
+        dragOffsetY = e.clientY - iconRect.top;
         startX = e.clientX;
         startY = e.clientY;
         didDrag = false;
+
+        // Convert flex-positioned icons to absolute positioning before dragging so
+        // the pointer keeps the same grab point instead of jumping to an edge.
+        setIconPosition(iconRect.left - desktopRect.left, iconRect.top - desktopRect.top);
+
         document.onmouseup = closeDragElement;
         document.onmousemove = elementDrag;
 
         document.querySelectorAll(".desktop-icon").forEach(i => i.classList.remove("selected"));
-        icon.classList.add("selected");
+        icon.classList.add("selected", "dragging");
     }
 
     function elementDrag(e) {
         e.preventDefault();
-        pos1 = pos3 - e.clientX;
-        pos2 = pos4 - e.clientY;
-        pos3 = e.clientX;
-        pos4 = e.clientY;
-        if (Math.hypot(e.clientX - startX, e.clientY - startY) > 5) {
+
+        const { rect: desktopRect } = getDesktopMetrics();
+        const nextLeft = e.clientX - desktopRect.left - dragOffsetX;
+        const nextTop = e.clientY - desktopRect.top - dragOffsetY;
+
+        if (Math.hypot(e.clientX - startX, e.clientY - startY) > DESKTOP_ICON_DRAG_THRESHOLD) {
             didDrag = true;
             icon.__suppressNextOpen = true;
         }
-        icon.style.top = (icon.offsetTop - pos2) + "px";
-        icon.style.left = (icon.offsetLeft - pos1) + "px";
-        icon.style.position = "absolute";
+
+        setIconPosition(nextLeft, nextTop);
     }
 
     function closeDragElement() {
         document.onmouseup = null;
         document.onmousemove = null;
+        icon.classList.remove("dragging");
 
-        if (!didDrag) return;
+        if (!didDrag) {
+            icon.style.position = previousInlinePosition;
+            icon.style.left = previousInlineLeft;
+            icon.style.top = previousInlineTop;
+            return;
+        }
 
-        // Save position to state
+        const snapped = snapToGrid(icon.offsetLeft, icon.offsetTop);
+        setIconPosition(snapped.left, snapped.top);
+
+        // Save snapped position to state
         if (window.saveDesktopConfig) {
             window.saveDesktopConfig(appId, icon.style.left, icon.style.top);
         }


### PR DESCRIPTION
### Motivation
- Icons were drifting and felt imprecise while being dragged because the implementation applied incremental mouse deltas and relied on flex layout; the goal is to make dragging feel anchored to the grab point and to snap icons to a tidy grid on drop.

### Description
- Replaced incremental-delta dragging with cursor-anchored dragging using a grab offset so the icon stays under the cursor during the drag (`wms.js`, `dragOffsetX/dragOffsetY`).
- Convert flex-positioned icons to absolute positioning at drag start and restore inline styles if the pointer did not move far enough to be considered a drag, preserving normal click behavior (`wms.js`).
- Add desktop bounds clamping and a grid snap on release, with grid sizes controlled by `DESKTOP_ICON_GRID_X` and `DESKTOP_ICON_GRID_Y`, and save the snapped position via `saveDesktopConfig` (`wms.js`).
- Add a `DESKTOP_ICON_DRAG_THRESHOLD` to control drag sensitivity (`wms.js`).
- Disable CSS transitions while dragging by adding `.desktop-icon.dragging { transition: none; }` to remove visual lag during drag (`Themes/theme.css`).

### Testing
- Ran syntax/checks with `node --check wms.js` and `node --check desktop-shell.js`, both succeeded.
- Ran repository checks with `git diff --check`, which reported no issues.
- Attempted an automated Playwright visual verification (`.ai-artifacts/playwright/scripts/verify_desktop_icon_drag.js`), but Playwright could not launch because the Chromium browser binary was unavailable and `npx playwright install chromium` failed with a download (`403`) from the Playwright CDN, so the visual test could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9f40b80c8326ac82e0906e8e2aa8)