### PR TITLE
Fix game loading and multiplayer endpoints

### DIFF
--- a/games/agar.js
+++ b/games/agar.js
@@ -1,25 +1,14 @@
 import { escapeHtml, state } from "../core.js";
+import { getColyseusHttpUrl, getColyseusWsUrl } from "./network.js";
 
 export function initAgar() {
-    const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
     const networkSelect = document.getElementById("agarNetwork");
-    const defaultServer = isLocal ? "local" : "prod";
     if (networkSelect && !networkSelect.value) {
         networkSelect.value = "auto";
     }
 
-    const getServerUrl = () => {
-        const selected = networkSelect?.value || "auto";
-        if (selected === "local") return "ws://localhost:2567";
-        if (selected === "prod") return "wss://seahorse-app-mv4sg.ondigitalocean.app";
-        return defaultServer === "local" ? "ws://localhost:2567" : "wss://seahorse-app-mv4sg.ondigitalocean.app";
-    };
-    const getServerHttpBase = () => {
-        const wsUrl = getServerUrl();
-        if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice(6)}`;
-        if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice(5)}`;
-        return wsUrl;
-    };
+    const getServerUrl = () => getColyseusWsUrl(networkSelect);
+    const getServerHttpBase = () => getColyseusHttpUrl(networkSelect);
 
     let room;
     let client;

--- a/games/builder.js
+++ b/games/builder.js
@@ -1,25 +1,14 @@
 import { state, isInputFocused, saveStats, builderHotbar, builderInventory, builderArmor, updateBuilderInventoryState, isGodUser, escapeHtml, openBuilderCharacterEditor } from "../core.js";
+import { getColyseusHttpUrl, getColyseusWsUrl } from "./network.js";
 
 export function initBuilder() {
-    const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || !window.location.hostname || window.location.search.includes("local=1");
     const networkSelect = document.getElementById("builderNetwork");
-    const defaultServer = isLocal ? "local" : "prod";
     if (networkSelect && !networkSelect.value) {
         networkSelect.value = "auto";
     }
 
-    const getServerUrl = () => {
-        const selected = networkSelect?.value || "auto";
-        if (selected === "local") return "ws://localhost:2567";
-        if (selected === "prod") return "wss://seahorse-app-mv4sg.ondigitalocean.app";
-        return defaultServer === "local" ? "ws://localhost:2567" : "wss://seahorse-app-mv4sg.ondigitalocean.app";
-    };
-    const getServerHttpBase = () => {
-        const wsUrl = getServerUrl();
-        if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice(6)}`;
-        if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice(5)}`;
-        return wsUrl;
-    };
+    const getServerUrl = () => getColyseusWsUrl(networkSelect);
+    const getServerHttpBase = () => getColyseusHttpUrl(networkSelect);
 
     let room;
     let client;

--- a/games/fnaf.js
+++ b/games/fnaf.js
@@ -1,5 +1,6 @@
 // fnaf.js - 3D Multiplayer Horror Survival Game (Raycaster)
 import { state } from "../core.js";
+import { getColyseusHttpUrl, getColyseusWsUrl, hasColyseusClient } from "./network.js";
 
 let canvas, ctx;
 let animationId;
@@ -83,15 +84,8 @@ async function refreshFnafServers() {
   const listEl = document.getElementById("fnafServerList");
   listEl.innerHTML = "LOADING SERVERS...";
 
-  let networkSelect = document.getElementById("fnafNetwork");
-  let selected = networkSelect ? networkSelect.value : "auto";
-  const isLocalEnv = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || window.location.search.includes("local=1");
-  let defaultServer = isLocalEnv ? "local" : "prod";
-
-  let endpoint = selected === "local" ? "http://localhost:2567" : "https://seahorse-app-mv4sg.ondigitalocean.app";
-  if (selected === "auto") {
-      endpoint = defaultServer === "local" ? "http://localhost:2567" : "https://seahorse-app-mv4sg.ondigitalocean.app";
-  }
+  const networkSelect = document.getElementById("fnafNetwork");
+  const endpoint = getColyseusHttpUrl(networkSelect);
 
 
   try {
@@ -149,16 +143,10 @@ async function startFnafGame(options) {
 
   // Colyseus Connect
   try {
-      let networkSelect = document.getElementById("fnafNetwork");
-      let selected = networkSelect ? networkSelect.value : "auto";
-      const isLocalEnv = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || window.location.search.includes("local=1");
-      let defaultServer = isLocalEnv ? "local" : "prod";
-
-      let endpoint = selected === "local" ? "ws://localhost:2567" : "wss://seahorse-app-mv4sg.ondigitalocean.app";
-      if (selected === "auto") {
-          endpoint = defaultServer === "local" ? "ws://localhost:2567" : "wss://seahorse-app-mv4sg.ondigitalocean.app";
-      }
-      const client = new Colyseus.Client(endpoint);
+      if (!hasColyseusClient()) throw new Error("Colyseus client failed to load");
+      const networkSelect = document.getElementById("fnafNetwork");
+      const endpoint = getColyseusWsUrl(networkSelect);
+      const client = new window.Colyseus.Client(endpoint);
 
       if (options.create) {
          fnafRoom = await client.create("fnaf_room", { serverName: options.serverName });

--- a/games/fps.js
+++ b/games/fps.js
@@ -1,4 +1,5 @@
 import { state, isInputFocused, escapeHtml } from "../core.js";
+import { getColyseusHttpUrl, getColyseusWsUrl, hasColyseusClient } from "./network.js";
 
 let room = null;
 let scene, camera, renderer, controls;
@@ -35,8 +36,8 @@ let isSprinting = false;
 let isCrouching = false;
 let canJump = false;
 let isSniperZoomed = false;
-let velocity = new THREE.Vector3();
-let direction = new THREE.Vector3();
+let velocity;
+let direction;
 const speed = 40.0;
 const sprintSpeed = 70.0;
 const crouchSpeed = 20.0;
@@ -112,7 +113,7 @@ function renderMapMenus() {
 
 async function loadAvailableMaps() {
   try {
-    const endpoint = getColyseusEndpoint().replace("ws", "http");
+    const endpoint = getColyseusHttpUrl(networkSelect);
     const res = await fetch(`${endpoint}/fps-maps`);
     if (!res.ok) return;
     const payload = await res.json();
@@ -126,20 +127,27 @@ async function loadAvailableMaps() {
 }
 
 function getColyseusEndpoint() {
-  const mode = networkSelect.value;
-  if (mode === "local") return "ws://localhost:2567";
-  if (mode === "prod") return "wss://seahorse-app-mv4sg.ondigitalocean.app";
-  // Auto
-  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
-    return "ws://localhost:2567";
+  return getColyseusWsUrl(networkSelect);
+}
+
+function ensureFpsDependencies() {
+  if (!window.THREE || !window.THREE.PointerLockControls) {
+    fpsMenu.innerHTML = '<div style="color:#f66">3D ENGINE FAILED TO LOAD. REFRESH OR CHECK STATIC ASSET SERVING.</div>' + fpsMenu.innerHTML;
+    return false;
   }
-  return "wss://seahorse-app-mv4sg.ondigitalocean.app";
+  if (!hasColyseusClient()) {
+    fpsMenu.innerHTML = '<div style="color:#f66">MULTIPLAYER CLIENT FAILED TO LOAD. REFRESH OR CHECK /vendor/colyseus.js.</div>' + fpsMenu.innerHTML;
+    return false;
+  }
+  if (!velocity) velocity = new THREE.Vector3();
+  if (!direction) direction = new THREE.Vector3();
+  return true;
 }
 
 async function fetchServers() {
   serverList.innerHTML = "<div>SCANNING...</div>";
   try {
-    const endpoint = getColyseusEndpoint().replace("ws", "http");
+    const endpoint = getColyseusHttpUrl(networkSelect);
     const res = await fetch(`${endpoint}/fps-servers`);
     const payload = await res.json();
     const fpsRooms = payload.servers || [];
@@ -197,7 +205,7 @@ async function createRoom() {
   const mapId = mapSelect ? Number(mapSelect.value) : 0;
 
   try {
-    const client = new Colyseus.Client(getColyseusEndpoint());
+    const client = new window.Colyseus.Client(getColyseusEndpoint());
     room = await client.create("fps_room", { serverName, playerName: state.myName, mapId });
     setupRoom();
   } catch (err) {
@@ -208,7 +216,7 @@ async function createRoom() {
 
 async function joinRoom(roomId) {
   try {
-    const client = new Colyseus.Client(getColyseusEndpoint());
+    const client = new window.Colyseus.Client(getColyseusEndpoint());
     if (roomId) {
       room = await client.joinById(roomId, { playerName: state.myName });
     } else {
@@ -2218,6 +2226,7 @@ function animate() {
 
 export function initFps() {
   fpsMenu.style.display = "block";
+  if (!ensureFpsDependencies()) return;
   fpsGame.style.display = "none";
   fpsDeathScreen.style.display = "none";
   grenades = 2;

--- a/games/hexfall.js
+++ b/games/hexfall.js
@@ -4,6 +4,7 @@ import {
   dispatch,
   showToast
 } from "../core.js";
+import { getColyseusHttpUrl, getColyseusWsUrl, hasColyseusClient } from "./network.js";
 
 let room;
 let scene, camera, renderer, controls;
@@ -12,9 +13,9 @@ let playerMeshes = {};
 let localPlayerId = null;
 let isDead = false;
 let moveInterval;
-let velocity = new THREE.Vector3();
-let direction = new THREE.Vector3();
-let raycaster = new THREE.Raycaster();
+let velocity;
+let direction;
+let raycaster;
 let animationId;
 let prevTime = performance.now();
 let lastSyncTime = 0;
@@ -30,27 +31,36 @@ let hexfallKeyUpHandler = null;
 
 const HEX_RADIUS = 2.5;
 
+function getNetworkSelect() {
+  return document.getElementById("hexfallNetwork");
+}
+
 function getNetworkUrl() {
-  const select = document.getElementById("hexfallNetwork");
-  const net = select ? select.value : "auto";
-  if (net === "local") return "ws://localhost:2567";
-  if (net === "prod") return "wss://seahorse-app-mv4sg.ondigitalocean.app";
-  // auto
-  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
-    return "ws://localhost:2567";
-  }
-  return "wss://seahorse-app-mv4sg.ondigitalocean.app";
+  return getColyseusWsUrl(getNetworkSelect());
 }
 
 function getApiUrl() {
-  const wsUrl = getNetworkUrl();
-  if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice(6)}`;
-  if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice(5)}`;
-  return wsUrl;
+  return getColyseusHttpUrl(getNetworkSelect());
+}
+
+function ensureHexfallDependencies() {
+  if (!window.THREE || !window.THREE.PointerLockControls) {
+    showToast("3D ENGINE MISSING", "⚠️", "Refresh or check static assets.");
+    return false;
+  }
+  if (!hasColyseusClient()) {
+    showToast("MULTIPLAYER CLIENT MISSING", "⚠️", "Refresh or check /vendor/colyseus.js.");
+    return false;
+  }
+  if (!velocity) velocity = new THREE.Vector3();
+  if (!direction) direction = new THREE.Vector3();
+  if (!raycaster) raycaster = new THREE.Raycaster();
+  return true;
 }
 
 export function initHexfall() {
   dispatch({ type: "SET_CURRENT_GAME", payload: "hexfall" });
+  if (!ensureHexfallDependencies()) return;
   document.getElementById("hexfallMenu").style.display = "block";
   document.getElementById("hexfallGame").style.display = "none";
   document.getElementById("hexfallDeathScreen").style.display = "none";
@@ -109,7 +119,7 @@ function joinServer(options) {
   document.getElementById("hexfallGame").style.display = "block";
   document.getElementById("hexfallStatus").innerText = "CONNECTING...";
 
-  const client = new Colyseus.Client(getNetworkUrl());
+  const client = new window.Colyseus.Client(getNetworkUrl());
 
   const joinOpts = { playerName: state.bio?.name || state.username || "Guest" };
   if (options.create) {

--- a/games/network.js
+++ b/games/network.js
@@ -1,0 +1,35 @@
+const LEGACY_PROD_HOST = "seahorse-app-mv4sg.ondigitalocean.app";
+
+function isLocalHost(hostname = window.location.hostname) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || !hostname;
+}
+
+function normalizeServerMode(selectOrMode) {
+  if (typeof selectOrMode === "string") return selectOrMode || "auto";
+  return selectOrMode?.value || "auto";
+}
+
+function currentHost() {
+  if (window.GOONER_MULTIPLAYER_HOST) return String(window.GOONER_MULTIPLAYER_HOST).replace(/^https?:\/\//, "").replace(/^wss?:\/\//, "");
+  if (isLocalHost()) return "localhost:2567";
+  return window.location.host || LEGACY_PROD_HOST;
+}
+
+export function getColyseusWsUrl(selectOrMode = "auto") {
+  const mode = normalizeServerMode(selectOrMode);
+  if (mode === "local") return "ws://localhost:2567";
+  if (mode === "prod") return `wss://${LEGACY_PROD_HOST}`;
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  return `${protocol}://${currentHost()}`;
+}
+
+export function getColyseusHttpUrl(selectOrMode = "auto") {
+  const wsUrl = getColyseusWsUrl(selectOrMode);
+  if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice(6)}`;
+  if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice(5)}`;
+  return wsUrl;
+}
+
+export function hasColyseusClient() {
+  return Boolean(window.Colyseus?.Client);
+}

--- a/games/smasharena.js
+++ b/games/smasharena.js
@@ -1,15 +1,12 @@
 // Smash-style platform fighter with local bot mode and Colyseus online duels.
 import { registerGameStop, setText, showToast, state, firebase, isInputFocused, escapeHtml } from "../core.js";
+import { getColyseusWsUrl, hasColyseusClient } from "./network.js";
 
 const { doc, setDoc, onSnapshot, runTransaction, updateDoc } = firebase;
 // Colyseus client setup
 let colyseusClient = null;
-if (typeof Colyseus !== 'undefined') {
-  const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-  const wsHost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
-    ? "localhost:2567"
-    : "seahorse-app-mv4sg.ondigitalocean.app";
-  colyseusClient = new Colyseus.Client(`${wsProtocol}://${wsHost}`);
+if (hasColyseusClient()) {
+  colyseusClient = new window.Colyseus.Client(getColyseusWsUrl());
 }
 const GRAVITY = 0.72;
 const FRICTION = 0.86;
@@ -70,12 +67,8 @@ function resetOverlay() {
 export function initSmashArena() {
   stopSession();
   resetOverlay();
-  if (!colyseusClient && typeof Colyseus !== 'undefined') {
-    const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-    const wsHost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
-      ? "localhost:2567"
-      : "seahorse-app-mv4sg.ondigitalocean.app";
-    colyseusClient = new Colyseus.Client(`${wsProtocol}://${wsHost}`);
+  if (!colyseusClient && hasColyseusClient()) {
+    colyseusClient = new window.Colyseus.Client(getColyseusWsUrl());
   }
 }
 

--- a/games/voice.js
+++ b/games/voice.js
@@ -1,3 +1,5 @@
+import { getColyseusWsUrl, hasColyseusClient } from "./network.js";
+
 let voiceRoom = null;
 let localStream = null;
 let peers = {}; // mapping from sessionId to RTCPeerConnection
@@ -30,12 +32,8 @@ export function initVoice() {
 
 async function refreshVoiceRooms() {
     try {
-        if (typeof window.Colyseus === 'undefined') return;
-        const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-        const wsHost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
-          ? "localhost:2567"
-          : "seahorse-app-mv4sg.ondigitalocean.app";
-        const client = new window.Colyseus.Client(`${wsProtocol}://${wsHost}`);
+        if (!hasColyseusClient()) return;
+        const client = new window.Colyseus.Client(getColyseusWsUrl());
 
         const rooms = await client.getAvailableRooms("voice_room");
 
@@ -105,16 +103,12 @@ async function refreshVoiceRooms() {
 
 async function createOrJoinVoiceRoom(isCreate, joinRoomId = null) {
     try {
-        if (typeof window.Colyseus === 'undefined') {
+        if (!hasColyseusClient()) {
             alert("Colyseus library not loaded.");
             return;
         }
 
-        const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-        const wsHost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
-          ? "localhost:2567"
-          : "seahorse-app-mv4sg.ondigitalocean.app";
-        const client = new window.Colyseus.Client(`${wsProtocol}://${wsHost}`);
+        const client = new window.Colyseus.Client(getColyseusWsUrl());
 
         // Get microphone access FIRST
         try {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
     <link rel="stylesheet" href="Themes/theme.css" />
     <!-- Colyseus Client Script -->
-    <script src="https://unpkg.com/colyseus.js@0.15.0/dist/colyseus.js"></script>
+    <script src="/vendor/colyseus.js" onerror="this.onerror=null;this.src='https://unpkg.com/colyseus.js@0.15.0/dist/colyseus.js'"></script>
     <!-- Three.js for 3D Games -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/PointerLockControls.js"></script>

--- a/server.js
+++ b/server.js
@@ -79,6 +79,23 @@ function layeredNoise(x, y, octaves, persistence, scale) {
 
 const app = express();
 app.use(cors());
+
+app.get("/vendor/colyseus.js", (req, res) => {
+  res.sendFile(path.join(__dirname, "node_modules", "colyseus.js", "dist", "colyseus.js"));
+});
+app.use((req, res, next) => {
+  if (/^\/(?:\.git|node_modules|__pycache__|archive)(?:\/|$)/.test(req.path) || /^\/(?:server\.js|package(?:-lock)?\.json)$/.test(req.path)) {
+    return res.sendStatus(404);
+  }
+  next();
+});
+app.use(express.static(__dirname, {
+  index: "index.html",
+  setHeaders(res, filePath) {
+    if (filePath.endsWith(".js")) res.type("application/javascript");
+  },
+}));
+
 const port = process.env.PORT || 2567;
 const OIL_QUOTE_SOURCES = [
   {


### PR DESCRIPTION
### Motivation
- Games were failing to launch because some multiplayer clients hard-coded a legacy production host instead of resolving the current server, and 3D game modules referenced `THREE`/constructed vectors at import time which could break the central launcher when CDN assets were missing or slow.
- The web UI relied on an external CDN for the Colyseus browser client and had no local fallback, making multiplayer unavailable if the CDN or network failed.

### Description
- Add a shared network helper `games/network.js` that provides `getColyseusWsUrl`, `getColyseusHttpUrl`, and `hasColyseusClient` so games resolve `local|prod|auto` modes and `auto` defaults to the current host.
- Update multiplayer game modules (`agar`, `builder`, `fnaf`, `fps`, `hexfall`, `smasharena`, `voice`, etc.) to use the new helper and to construct `Colyseus.Client` via `window.Colyseus` and `getColyseusWsUrl` so they no longer hard-code the legacy host.
- Defer 3D initializations for FPS/Hexfall (avoid immediate `new THREE.Vector3()`/`PointerLockControls`) and add `ensure*Dependencies()` checks that surface a game-specific error if `THREE` or the Colyseus client is not available, preventing unrelated games from breaking the launcher.
- Make the Node server serve the app statically and expose `/vendor/colyseus.js` from `node_modules` (with a small static-route safeguard to block internal paths), and change `index.html` to load the local `/vendor/colyseus.js` first with the CDN as a fallback.

### Testing
- Module parse smoke checks with `node --check` and an `acorn` parse over `script.js`, `core.js`, `wms.js`, and `games/*.js` completed successfully.
- Started the server and verified root static serving and vendor script serving via `curl -I` against `/` and `/vendor/colyseus.js`, which returned `200 OK`.
- Exercised multiplayer end-to-end by launching a server instance and running a `colyseus.js` client that `joinOrCreate`d and left `agar_room`, which succeeded (client reported a valid `sessionId`).
- Playwright browser checks could not run because `npx playwright install chromium` failed due to the environment blocking the browser download (HTTP 403), so automated browser-based checks did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9f01ba8483269d0d786a488c5e25)