### PR TITLE
Improve FNAF networking error diagnostics for non-JSON /fnaf_servers responses

### DIFF
--- a/games/fnaf.js
+++ b/games/fnaf.js
@@ -91,6 +91,11 @@ async function refreshFnafServers() {
   try {
     const res = await fetch(`${endpoint}/fnaf_servers`);
     if (!res.ok) throw new Error("Failed to fetch fnaf servers");
+    const contentType = (res.headers.get("content-type") || "").toLowerCase();
+    if (!contentType.includes("application/json")) {
+      const sample = (await res.text()).slice(0, 120).replace(/\s+/g, " ");
+      throw new Error(`Server list returned non-JSON (${contentType || "unknown content-type"}): ${sample}`);
+    }
     const servers = await res.json();
 
     listEl.innerHTML = "";
@@ -124,8 +129,8 @@ async function refreshFnafServers() {
       listEl.appendChild(row);
     });
   } catch (err) {
-    console.error(err);
-    listEl.innerHTML = "<div style='color:red;'>ERROR LOADING SERVERS</div>";
+    console.error("refreshFnafServers failed:", err);
+    listEl.innerHTML = `<div style='color:red;'>ERROR LOADING SERVERS<br/><small>${String(err.message || err)}</small></div>`;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The `/fnaf_servers` endpoint sometimes returns HTML or an error page which causes `Unexpected token '<'` when parsed as JSON, obscuring the root cause. 
- Provide clearer diagnostics in the UI and console so developers can see content-type and a short sample of the response instead of a raw JSON parse error.

### Description
- Added a `content-type` check before calling `res.json()` in `refreshFnafServers()` in `games/fnaf.js` to detect non-JSON responses. 
- When the response is not `application/json` the code reads a short text sample and throws a descriptive error including the content-type and payload snippet. 
- Improved console logging and the UI error message to show the error message string so failures are easier to diagnose.

### Testing
- Applied the patch and committed changes to `games/fnaf.js` using the repository tooling and the commit succeeded. 
- Verified the modified function lines with `nl`/`sed` and searched relevant symbols with `rg` to confirm the updated logic is present. 
- No automated unit test suite was executed as part of this change; the change is limited to runtime error handling and was validated by the above automated inspections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea41cc3588322863759a68fecd0e0)