### PR TITLE
Stop background game loops and scope game-over modal to active game

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -3800,17 +3800,21 @@ body.reduce-motion *::after {
 #modalGameOver {
   display: none;
   position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.9);
-  backdrop-filter: blur(10px);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(92vw, 420px);
+  min-height: 220px;
+  background: rgba(0, 0, 0, 0.94);
+  backdrop-filter: blur(6px);
   z-index: 2000;
   padding: 20px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
-  overflow: hidden;
   border: 4px solid #f00;
+  box-shadow: 0 0 0 2px #100, 0 18px 40px rgba(0, 0, 0, 0.65);
 }
 
 #modalGameOver.active {

--- a/core.js
+++ b/core.js
@@ -7423,11 +7423,17 @@ export function showGameOver(game, score) {
   setText("gameOverText", "SYSTEM_FAILURE: SCORE_" + score);
   showToast(`RUN COMPLETE: +$${rewards.cashReward}`, "💸", `+${rewards.xpReward} SEASON XP`);
   const modal = document.getElementById("modalGameOver");
+  const overlayByGame = game
+    ? document.getElementById(`overlay${String(game) === "ttt" ? "TTT" : String(game).charAt(0).toUpperCase() + String(game).slice(1)}`)
+    : null;
   const activeOverlays = Array.from(document.querySelectorAll(".overlay.active"));
   const activeGameOverlay =
+    overlayByGame ||
     activeOverlays.find((overlay) =>
       overlay.classList.contains("game-overlay") || overlay.querySelector("canvas, .embedded-game-frame")
-    ) || activeOverlays[activeOverlays.length - 1] || null;
+    ) ||
+    activeOverlays[activeOverlays.length - 1] ||
+    null;
 
   const gameSurface = activeGameOverlay?.querySelector("canvas, .embedded-game-frame");
   let modalHost = null;

--- a/script.js
+++ b/script.js
@@ -297,6 +297,8 @@ function initSharedGamebox() {
 // Launch a game by name, activate its overlay, and kick off its init routine.
 window.launchGame = (game, source = "direct") => {
   window.__goonerLastGameLaunchSource = source;
+  // Ensure previous game loops/intervals are fully stopped before starting another game.
+  if (typeof window.stopAllGames === "function") window.stopAllGames();
   // window.closeOverlays(); // Don't close others, we are in WMS
 
   // We bypass mountGameOverlayIntoGamebox so the game takes over the screen


### PR DESCRIPTION
### Motivation
- Prevent multiple games from continuing to run in the background when a new game is launched.  
- Ensure the death/game-over UI is shown only inside the overlay of the game that ended and does not cover the entire screen.

### Description
- Call `stopAllGames()` at the start of `window.launchGame` to ensure any running game loops/intervals are stopped before starting a new game (edited `script.js`).
- Update `showGameOver(game, score)` to prefer the specific overlay for the `game` argument (`overlayByGame`) so the modal mounts into the correct game surface instead of a global overlay (edited `core.js`).
- Restyle `#modalGameOver` from a fullscreen blackout to a centered panel with constrained width and drop shadow so the death message does not cover the entire screen (edited `Themes/theme.css`).

### Testing
- Ran a Node evaluation syntax check via `node -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea53acae08322b42b9b2e876c14d8)