### PR TITLE
Fix taskbar tab scaling and scope taskbar close-button styling

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -257,7 +257,7 @@ body::before {
   border: 1px solid var(--accent-dim);
   color: var(--accent);
   height: 36px;
-  padding: 0 15px;
+  padding: 0 10px 0 12px;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -284,7 +284,36 @@ body::before {
 }
 
 .tab-icon {
+  flex: 0 0 auto;
   font-size: 14px;
+}
+
+
+.tab-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.taskbar-tab .tab-close-btn {
+  flex: 0 0 auto;
+  margin-left: 2px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #fff;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.taskbar-tab .tab-close-btn:hover,
+.taskbar-tab .tab-close-btn:focus-visible {
+  background: transparent;
+  color: #fff;
 }
 
 .desktop-icon {


### PR DESCRIPTION
### Motivation
- Ensure taskbar tab labels truncate before the close control so the taskbar "X" always has room. 
- Make the taskbar close control render as white text with no background while leaving other close buttons untouched.

### Description
- Updated `Themes/theme.css` to reduce horizontal padding for `.taskbar-tab` so the close button has reserved space (`padding: 0 10px 0 12px`).
- Added `.tab-text` with `flex` + ellipsis rules so the label shrinks/truncates first instead of crowding the close control.
- Made `.tab-icon` non-shrinking by adding `flex: 0 0 auto` so icon and close button remain stable while text compresses.
- Scoped close-button styling to taskbar tabs with `.taskbar-tab .tab-close-btn`, setting a transparent background and white text (including hover/focus) so only the TASKBAR X is affected.

### Testing
- Ran `git diff -- Themes/theme.css` to verify the CSS changes (succeeded).
- Committed the change with `git commit` to record the update (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea574317c8322a9768298143abb2d)