### PR TITLE
Fix gambling game layouts on small screens

### DIFF
--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -2148,7 +2148,7 @@ canvas {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .gamebox-mounted {
@@ -2158,9 +2158,9 @@ canvas {
   width: 100%;
   height: auto;
   min-height: 0;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-start;
-  overflow: hidden;
+  overflow: auto;
   padding: 0;
   border: 0;
 }
@@ -4760,7 +4760,31 @@ body.reduce-motion *::after {
   width: min(94vw, 720px);
   border: 1px solid var(--accent-dim);
   padding: 10px;
-  margin-bottom: 95px;
+  margin-bottom: 18px;
+}
+
+@media (max-width: 760px) {
+  .overlay.game-overlay {
+    padding: 10px 10px 14px;
+  }
+
+  .game-content-shell {
+    width: min(100%, 1200px);
+    padding: 8px 10px 10px;
+  }
+
+  .roulette-status {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+
+  .roulette-presets {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .roulette-actions {
+    grid-template-columns: 1fr;
+  }
 }
 
 .roulette-bet-row {

--- a/Themes/theme.css
+++ b/Themes/theme.css
@@ -4763,6 +4763,19 @@ body.reduce-motion *::after {
   margin-bottom: 18px;
 }
 
+#overlayRoulette,
+#overlaySlots,
+#overlayMines,
+#overlayBaccarat,
+#overlayCraps,
+#overlayVideopoker {
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  align-items: center;
+  padding-bottom: 18px;
+}
+
 @media (max-width: 760px) {
   .overlay.game-overlay {
     padding: 10px 10px 14px;


### PR DESCRIPTION
### Motivation
- Ensure gambling mini-games and embedded game frames remain fully accessible and visible in constrained or small UI windows by allowing scrolling and adjusting alignment.
- Prevent important controls (especially roulette actions) from being pushed off-screen on narrow viewports.

### Description
- Updated `Themes/theme.css` to change `.gamebox-content` overflow from `hidden` to `auto` so game panels can scroll when space is limited.
- Adjusted `.gamebox-mounted` alignment to `align-items: flex-start` and set `overflow: auto` to surface the top of embedded games and allow vertical scrolling.
- Reduced bottom spacing in `.roulette-controls` by changing `margin-bottom` from `95px` to `18px` to keep action buttons visible.
- Added a mobile-focused `@media (max-width: 760px)` block that tightens overlay and shell padding, enables `.roulette-status` wrapping, changes `.roulette-presets` to a 3-column grid, and stacks `.roulette-actions` for narrow screens.

### Testing
- No automated tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea6a21e0083228769823cf639b2ad)