### PR TITLE
Clamp window dragging to viewport bounds

### DIFF
--- a/wms.js
+++ b/wms.js
@@ -361,10 +361,18 @@ export class AppWindow {
       let top = this.elements.window.offsetTop - pos2;
       let left = this.elements.window.offsetLeft - pos1;
 
+      const taskbarHeight = 50;
+      const clampToViewport = () => {
+          const maxLeft = Math.max(0, window.innerWidth - this.elements.window.offsetWidth);
+          const maxTop = Math.max(0, window.innerHeight - taskbarHeight - this.elements.window.offsetHeight);
+          left = Math.min(Math.max(left, 0), maxLeft);
+          top = Math.min(Math.max(top, 0), maxTop);
+      };
+
       // Snap to edges
       const snapThreshold = 20;
       const screenWidth = window.innerWidth;
-      const screenHeight = window.innerHeight - 50; // Taskbar height
+      const screenHeight = window.innerHeight - taskbarHeight;
 
       if (left < snapThreshold) left = 0;
       if (top < snapThreshold) top = 0;
@@ -374,6 +382,8 @@ export class AppWindow {
       if (screenHeight - (top + this.elements.window.offsetHeight) < snapThreshold) {
           top = screenHeight - this.elements.window.offsetHeight;
       }
+
+      clampToViewport();
 
       // Prevent overlapping by snapping to sides
       if (window.WMS) {
@@ -406,6 +416,8 @@ export class AppWindow {
               }
           });
       }
+
+      clampToViewport();
 
       this.elements.window.style.top = top + "px";
       this.elements.window.style.left = left + "px";


### PR DESCRIPTION
### Motivation
- Windows could be dragged or snapped partially off-screen (sticking to edges or snapping above the visible desktop), making them inaccessible.

### Description
- Added a `taskbarHeight` constant and a `clampToViewport()` helper inside `AppWindow.dragStart` to ensure `left`/`top` stay within the visible desktop bounds in `wms.js`.
- Replaced the hardcoded bottom check with `taskbarHeight` and call `clampToViewport()` immediately after edge-snapping.
- Added a second `clampToViewport()` pass after the overlap-snap/collision adjustments so collision logic cannot push windows off-screen.

### Testing
- Ran `node --check wms.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea60a80e08322839c8c0e5dd8edce)