### PR TITLE
Fix Colyseus Buffer error in browser and harden builder server-list parsing

### DIFF
--- a/games/builder.js
+++ b/games/builder.js
@@ -980,7 +980,16 @@ const blockColors = {
         btnRefreshServers.textContent = "LOADING...";
         try {
             const response = await fetch(`${getServerHttpBase()}/builder-servers`);
-            const payload = await response.json();
+            const raw = await response.text();
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${raw.slice(0, 120)}`);
+            }
+            let payload;
+            try {
+                payload = JSON.parse(raw);
+            } catch {
+                throw new Error(`Expected JSON but received: ${raw.slice(0, 120)}`);
+            }
             renderServerList(payload.servers || []);
         } catch (error) {
             console.error("Failed to load server list", error);

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
 
     <link rel="stylesheet" href="Themes/theme.css" />
     <!-- Colyseus Client Script -->
+    <script src="https://cdn.jsdelivr.net/npm/buffer@6.0.3/index.min.js"></script>
+    <script>
+      if (window.buffer?.Buffer && !window.Buffer) window.Buffer = window.buffer.Buffer;
+    </script>
     <script src="/vendor/colyseus.js" onerror="this.onerror=null;this.src='https://unpkg.com/colyseus.js@0.15.0/dist/colyseus.js'"></script>
     <!-- Three.js for 3D Games -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>


### PR DESCRIPTION
### Motivation
- The client failed to initialize Colyseus in browsers due to `Buffer is not defined`, causing multiplayer boot errors and broken `window.Colyseus.Client` usage.
- The builder server list sometimes returned non-JSON (HTML error pages) which produced `Unexpected token '<'` and opaque parse failures.

### Description
- Inserted a browser-friendly Buffer polyfill before loading `/vendor/colyseus.js` by adding `https://cdn.jsdelivr.net/npm/buffer@6.0.3/index.min.js` and assigning `window.Buffer` when available in `index.html`.
- Replaced direct `response.json()` in `games/builder.js` with `response.text()` followed by `response.ok` validation and a guarded `JSON.parse` with explicit error messages when the payload is not valid JSON.
- The server-list loader now surfaces HTTP status and a snippet of the unexpected response to aid debugging.

### Testing
- Searched codepaths for Colyseus and `Buffer` usage and inspected the bundled client and consumer sites with `rg` and file snippet printing to confirm locations updated, and the commands completed successfully.
- Printed the modified regions of `index.html` and `games/builder.js` with `nl` to verify the new polyfill bootstrap and the hardened `refreshServerList` implementation were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffdebdb27c8331ba0c1fb6ca19a205)