### PR TITLE
Fix Colyseus browser runtime errors by loading ESM client

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,10 @@
 
     <link rel="stylesheet" href="Themes/theme.css" />
     <!-- Colyseus Client Script -->
-    <script src="https://cdn.jsdelivr.net/npm/buffer@6.0.3/index.min.js"></script>
-    <script>
-      if (window.buffer?.Buffer && !window.Buffer) window.Buffer = window.buffer.Buffer;
+    <script type="module">
+      import * as Colyseus from "https://cdn.jsdelivr.net/npm/colyseus.js@0.15.28/+esm";
+      window.Colyseus = Colyseus;
     </script>
-    <script src="/vendor/colyseus.js" onerror="this.onerror=null;this.src='https://unpkg.com/colyseus.js@0.15.0/dist/colyseus.js'"></script>
     <!-- Three.js for 3D Games -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/PointerLockControls.js"></script>


### PR DESCRIPTION
### Motivation
- Replace the Node-style UMD Colyseus bundle that caused browser runtime errors like `require is not defined` and `Buffer.alloc is not a function` with the browser-friendly ESM build.

### Description
- Update `index.html` to remove the legacy `/vendor/colyseus.js` and buffer shim and instead import `colyseus.js@0.15.28/+esm` via an inline `<script type="module">`, assigning the module to `window.Colyseus` so existing code using `window.Colyseus.Client` continues to work.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffe1c2efe48331bffa1a7824432124)