### PR TITLE
Fix colyseus.js K[e] is not a function error

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="Themes/theme.css" />
     <!-- Colyseus Client Script -->
     <script type="module">
-      import * as Colyseus from "https://cdn.jsdelivr.net/npm/colyseus.js@0.15.28/+esm";
+      import * as Colyseus from "https://esm.sh/colyseus.js@0.15.28";
       window.Colyseus = Colyseus;
     </script>
     <!-- Three.js for 3D Games -->


### PR DESCRIPTION
Fix `TypeError: K[e] is not a function` affecting all online games due to a broken ESM build of `colyseus.js` on `cdn.jsdelivr.net`. The internal `httpie` module failed at runtime for HTTP requests (like server matchmaking). Replacing the CDN import with `https://esm.sh/colyseus.js@0.15.28` correctly bundles the package for the browser without this bug.

---
*PR created automatically by Jules for task [14569965758849338378](https://jules.google.com/task/14569965758849338378) started by @thefoxssss*