### PR TITLE
🧹 Fix Colyseus getAvailableRooms TypeError by using custom fetch endpoints

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -204,39 +204,8 @@ async function fetchServers() {
       serverList.appendChild(row);
     });
   } catch (err) {
-    console.warn("Primary FPS server catalog lookup failed; using Colyseus room listing fallback.", err);
-    try {
-      const client = new window.Colyseus.Client(getColyseusEndpoint());
-      const fpsRooms = await client.getAvailableRooms("fps_room");
-      serverList.innerHTML = "";
-      if (!fpsRooms.length) {
-        serverList.innerHTML = "<div>NO ACTIVE SERVERS. CREATE ONE.</div>";
-        return;
-      }
-      fpsRooms.forEach((r) => {
-        const row = document.createElement("div");
-        row.style.display = "flex";
-        row.style.justifyContent = "space-between";
-        row.style.padding = "5px";
-        row.style.borderBottom = "1px solid #333";
-
-        const info = document.createElement("span");
-        info.textContent = `${r.metadata?.serverName || r.roomId} (${r.clients}/${r.maxClients})`;
-
-        const btn = document.createElement("button");
-        btn.className = "term-btn";
-        btn.textContent = "JOIN";
-        btn.style.padding = "2px 8px";
-        btn.onclick = () => joinRoom(r.roomId);
-
-        row.appendChild(info);
-        row.appendChild(btn);
-        serverList.appendChild(row);
-      });
-    } catch (fallbackErr) {
-      serverList.innerHTML = "<div>ERROR FETCHING SERVERS.</div>";
-      console.error("FPS server listing fallback failed:", fallbackErr);
-    }
+    console.warn("Primary FPS server catalog lookup failed.", err);
+    serverList.innerHTML = "<div>ERROR FETCHING SERVERS.</div>";
   }
 }
 

--- a/games/voice.js
+++ b/games/voice.js
@@ -1,4 +1,4 @@
-import { getColyseusWsUrl, hasColyseusClient } from "./network.js";
+import { getColyseusWsUrl, getColyseusHttpUrl, hasColyseusClient } from "./network.js";
 
 let voiceRoom = null;
 let localStream = null;
@@ -32,10 +32,11 @@ export function initVoice() {
 
 async function refreshVoiceRooms() {
     try {
-        if (!hasColyseusClient()) return;
-        const client = new window.Colyseus.Client(getColyseusWsUrl());
-
-        const rooms = await client.getAvailableRooms("voice_room");
+        const endpoint = getColyseusHttpUrl();
+        const res = await fetch(`${endpoint}/voice-servers`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const payload = await res.json();
+        const rooms = payload.servers || [];
 
         const listDiv = document.getElementById("voiceRoomList");
         if (!listDiv) return;
@@ -64,13 +65,8 @@ async function refreshVoiceRooms() {
             clientsSpan.style.fontSize = "10px";
             clientsSpan.style.color = "var(--accent)";
 
-            let userNames = room.metadata && room.metadata.playerNames ? room.metadata.playerNames : "Empty";
-            if (!room.metadata || !room.metadata.playerNames) {
-                // Fallback for older server instances
-                clientsSpan.textContent = `USERS: ${room.clients} / ${room.maxClients}`;
-            } else {
-                clientsSpan.textContent = `USERS: ${userNames} (${room.clients}/${room.maxClients})`;
-            }
+            let userNames = room.players && room.players.length ? room.players.map(p => p.name).join(", ") : "Empty";
+            clientsSpan.textContent = `USERS: ${userNames} (${room.clients}/${room.maxClients})`;
 
             info.appendChild(nameSpan);
             info.appendChild(clientsSpan);

--- a/server.js
+++ b/server.js
@@ -170,6 +170,7 @@ async function requestOilQuoteBody(url) {
 }
 const builderServerDirectory = new Map();
 const fpsServerDirectory = new Map();
+const voiceServerDirectory = new Map();
 function getFpsMapCatalog() {
   const dir = path.join(__dirname, "data", "fps", "maps");
   if (!fs.existsSync(dir)) return [];
@@ -2391,6 +2392,13 @@ class VoiceRoom extends colyseus.Room {
     this.maxClients = 4; // limit to 4 for peer-to-peer mesh
     this.setState(new VoiceState());
 
+    voiceServerDirectory.set(this.roomId, {
+      roomId: this.roomId,
+      clients: this.clients.length,
+      maxClients: this.maxClients,
+      players: []
+    });
+
     // Relay WebRTC signaling messages
     this.onMessage("signal", (client, message) => {
         // message should contain { to: targetSessionId, data: signalData }
@@ -2415,6 +2423,20 @@ class VoiceRoom extends colyseus.Room {
     const names = [];
     this.state.players.forEach(p => names.push(p.name));
     this.setMetadata({ playerNames: names.join(", ") });
+
+    const d = voiceServerDirectory.get(this.roomId);
+    if (d) {
+      d.clients = this.clients.length;
+      d.players = [];
+      this.state.players.forEach((p) => {
+        d.players.push({ name: p.name });
+      });
+      voiceServerDirectory.set(this.roomId, d);
+    }
+  }
+
+  onDispose() {
+    voiceServerDirectory.delete(this.roomId);
   }
 
   onJoin(client, options) {
@@ -3891,6 +3913,14 @@ app.get("/fps-servers", (req, res) => {
   });
   res.json({ servers });
 });
+
+app.get("/voice-servers", (req, res) => {
+  const servers = Array.from(voiceServerDirectory.values()).sort((a, b) => {
+    return b.clients - a.clients;
+  });
+  res.json({ servers });
+});
+
 app.get("/fps-maps", (req, res) => {
   res.json({ maps: getFpsMapCatalog() });
 });


### PR DESCRIPTION
🎯 What: 
- Replaced buggy `client.getAvailableRooms()` calls in `games/fps.js` and `games/voice.js` with direct `fetch()` calls to custom Express endpoints `/fps-servers` and `/voice-servers`.
- Created `voiceServerDirectory` and `/voice-servers` endpoint in `server.js` to manage active voice rooms.

💡 Why:
The Colyseus browser client (v0.15.28 / +esm CDN build) throws `TypeError: K[e] is not a function` because of a bug in its bundled `httpie` request package. Using our own backend Express REST endpoints mapped to server directories successfully bypasses this HTTP bug entirely and retrieves the same server lists.

✅ Verification:
- Created and successfully retrieved both FPS and Voice room instances using standalone Playwright tests running on the local server.
- Tests verified both `/fps-servers` and `/voice-servers` return active connections.

✨ Result:
Players can now reliably scan for and see active Multiplayer Arena and Voice Lounge servers in the UI again without the underlying browser exception causing the server scan to fail.

---
*PR created automatically by Jules for task [4661315435280270683](https://jules.google.com/task/4661315435280270683) started by @thefoxssss*