### PR TITLE
🧹 Fix Colyseus matchmaking host mismatch

### DIFF
--- a/games/network.js
+++ b/games/network.js
@@ -12,22 +12,21 @@ function normalizeServerMode(selectOrMode) {
 function currentHost() {
   if (window.GOONER_MULTIPLAYER_HOST) return String(window.GOONER_MULTIPLAYER_HOST).replace(/^https?:\/\//, "").replace(/^wss?:\/\//, "");
   if (isLocalHost()) return "localhost:2567";
-  return window.location.host || LEGACY_PROD_HOST;
+  return LEGACY_PROD_HOST;
 }
 
 export function getColyseusWsUrl(selectOrMode = "auto") {
   const mode = normalizeServerMode(selectOrMode);
   if (mode === "local") return "ws://localhost:2567";
   if (mode === "prod") return `wss://${LEGACY_PROD_HOST}`;
-  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const protocol = "wss";
   return `${protocol}://${currentHost()}`;
 }
 
 export function getColyseusHttpUrl(selectOrMode = "auto") {
-  const wsUrl = getColyseusWsUrl(selectOrMode);
-  if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice(6)}`;
-  if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice(5)}`;
-  return wsUrl;
+  const mode = normalizeServerMode(selectOrMode);
+  if (mode === "local") return "http://localhost:2567";
+  return `https://${LEGACY_PROD_HOST}`;
 }
 
 export function hasColyseusClient() {


### PR DESCRIPTION
* Fixes games/network.js to return the DigitalOcean host for both WSS and HTTPS Colyseus endpoints.
* Bypasses the default `window.location.host` which caused the application to fetch HTML pages instead of interacting with the API at thefoxsss.com.

---
*PR created automatically by Jules for task [9521142034329165689](https://jules.google.com/task/9521142034329165689) started by @thefoxssss*