### PR TITLE
Add configuration option to toggle legacy UI mode

### DIFF
--- a/core.js
+++ b/core.js
@@ -3594,7 +3594,7 @@ window.toggleTopPanelOverlay = (id) => {
 // Open an overlay by id, optionally render its contents.
 export function openGame(id) {
   if (id === "overlayAdmin" && !isGodUser()) return;
-  if (id === "overlayMaintenance" || id === "overlayLogin") {
+  if (id === "overlayMaintenance" || id === "overlayLogin" || window.legacyUiEnabled) {
       const el = document.getElementById(id);
       if (el) {
           closeOverlays();

--- a/core.js
+++ b/core.js
@@ -3637,7 +3637,7 @@ export function openGame(id) {
   const excludedFromWMS = [];
   const isExcluded = excludedFromWMS.includes(id);
 
-  if (window.WMS && !isExcluded) {
+  if (window.WMS && !isExcluded && !window.legacyUiEnabled) {
       if (typeof window.beep === "function") window.beep(400, "square", 0.05);
       window.WMS.createWindow(id, title, contentElement, { icon });
       runOverlayOpenHooks(id);
@@ -6088,6 +6088,14 @@ document.getElementById("motionToggle").onclick = () => {
 };
 
 
+document.getElementById("legacyUiToggle").onclick = (e) => {
+    const isLegacy = !window.legacyUiEnabled;
+    window.legacyUiEnabled = isLegacy;
+    e.target.innerText = isLegacy ? "ON" : "OFF";
+    writeUiConfig({ useLegacyUi: isLegacy });
+    location.reload();
+};
+
 document.getElementById("bgTextToggle").onclick = (e) => {
     const bgText = document.getElementById("desktop-bg-text");
     if (!bgText) return;
@@ -6116,6 +6124,17 @@ document.getElementById("statusVisibilityToggle").onclick = async () => {
   applyContrastMode(Boolean(config.highContrast));
   applyReducedMotion(Boolean(config.reducedMotion));
   applyStatusVisibilityToggle(Boolean(config.hideStatus));
+  window.legacyUiEnabled = Boolean(config.useLegacyUi);
+
+  const desktopEl = document.getElementById("desktop");
+  const taskbarEl = document.getElementById("taskbar");
+  if (window.legacyUiEnabled) {
+    if (desktopEl) desktopEl.style.display = "none";
+    if (taskbarEl) taskbarEl.style.display = "none";
+  }
+
+  const legacyUiToggle = document.getElementById("legacyUiToggle");
+  if (legacyUiToggle) legacyUiToggle.innerText = window.legacyUiEnabled ? "ON" : "OFF";
   const bgTextEnabled = config.bgTextEnabled !== false;
   const bgText = document.getElementById("desktop-bg-text");
   if (bgText) bgText.style.display = bgTextEnabled ? "block" : "none";

--- a/index.html
+++ b/index.html
@@ -1127,6 +1127,7 @@
           <div class="config-row"><span>HIGH CONTRAST</span><button class="menu-btn" id="contrastToggle">OFF</button></div>
           <div class="config-row"><span>REDUCED MOTION</span><button class="menu-btn" id="motionToggle">OFF</button></div>
           <div class="config-row"><span>DESKTOP TEXT</span><button class="menu-btn" id="bgTextToggle">ON</button></div>
+          <div class="config-row"><span>LEGACY UI</span><button class="menu-btn" id="legacyUiToggle">OFF</button></div>
         </div>
       </div>
     </div>

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm i -g http-server
+http-server -p 8080 > server_output.log 2>&1 &

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-npm i -g http-server
-http-server -p 8080 > server_output.log 2>&1 &

--- a/wms.js
+++ b/wms.js
@@ -79,7 +79,7 @@ function openGameFallback(id) {
     if (!contentElement) return;
 
     const { title, icon } = resolveFallbackAppMetadata(id);
-    if (window.WMS) {
+    if (window.WMS && !window.legacyUiEnabled) {
         window.WMS.createWindow(id, title, contentElement, { icon });
         return;
     }


### PR DESCRIPTION
This commit adds a configuration option for toggling between the new WMS UI and the old full-screen overlay UI. It implements the legacy bypass logic inside core.js and wms.js and adds a setting element to the Visual config panel to control it.

---
*PR created automatically by Jules for task [17544535120647560142](https://jules.google.com/task/17544535120647560142) started by @thefoxssss*