### PR TITLE
✨ Add configuration toggle for Legacy full-screen terminal UI mode

### DIFF
--- a/core.js
+++ b/core.js
@@ -3635,7 +3635,7 @@ export function openGame(id) {
   }
 
   const excludedFromWMS = [];
-  const isExcluded = excludedFromWMS.includes(id);
+  const isExcluded = excludedFromWMS.includes(id) || window.legacyUiEnabled;
 
   if (window.WMS && !isExcluded) {
       if (typeof window.beep === "function") window.beep(400, "square", 0.05);
@@ -5974,6 +5974,26 @@ function applyReducedMotion(enabled) {
   if (motionToggle) motionToggle.textContent = enabled ? "ON" : "OFF";
 }
 
+function applyLegacyUi(enabled) {
+  window.legacyUiEnabled = Boolean(enabled);
+  const legacyToggle = document.getElementById("legacyUiToggle");
+  if (legacyToggle) legacyToggle.textContent = enabled ? "ON" : "OFF";
+
+  const desktop = document.getElementById("desktop");
+  const taskbar = document.getElementById("taskbar");
+
+  if (enabled) {
+    if (desktop) desktop.style.display = "none";
+    if (taskbar) taskbar.style.display = "none";
+    if (window.WMS && typeof window.WMS.closeAll === "function") {
+      window.WMS.closeAll();
+    }
+  } else {
+    if (desktop) desktop.style.display = "";
+    if (taskbar) taskbar.style.display = "";
+  }
+}
+
 function applyStatusVisibilityToggle(hidden) {
   hideStatus = Boolean(hidden);
   const statusToggle = document.getElementById("statusVisibilityToggle");
@@ -6096,6 +6116,12 @@ document.getElementById("bgTextToggle").onclick = (e) => {
     e.target.innerText = isVisible ? "OFF" : "ON";
     writeUiConfig({ bgTextEnabled: !isVisible });
 };
+
+document.getElementById("legacyUiToggle").onclick = () => {
+  const enabled = !window.legacyUiEnabled;
+  applyLegacyUi(enabled);
+  writeUiConfig({ legacyUiEnabled: enabled });
+};
 document.getElementById("statusVisibilityToggle").onclick = async () => {
   applyStatusVisibilityToggle(!hideStatus);
   writeUiConfig({ hideStatus });
@@ -6116,6 +6142,7 @@ document.getElementById("statusVisibilityToggle").onclick = async () => {
   applyContrastMode(Boolean(config.highContrast));
   applyReducedMotion(Boolean(config.reducedMotion));
   applyStatusVisibilityToggle(Boolean(config.hideStatus));
+  applyLegacyUi(Boolean(config.legacyUiEnabled));
   const bgTextEnabled = config.bgTextEnabled !== false;
   const bgText = document.getElementById("desktop-bg-text");
   if (bgText) bgText.style.display = bgTextEnabled ? "block" : "none";

--- a/index.html
+++ b/index.html
@@ -1127,6 +1127,7 @@
           <div class="config-row"><span>HIGH CONTRAST</span><button class="menu-btn" id="contrastToggle">OFF</button></div>
           <div class="config-row"><span>REDUCED MOTION</span><button class="menu-btn" id="motionToggle">OFF</button></div>
           <div class="config-row"><span>DESKTOP TEXT</span><button class="menu-btn" id="bgTextToggle">ON</button></div>
+          <div class="config-row"><span>LEGACY UI</span><button class="menu-btn" id="legacyUiToggle">OFF</button></div>
         </div>
       </div>
     </div>

--- a/wms.js
+++ b/wms.js
@@ -79,7 +79,7 @@ function openGameFallback(id) {
     if (!contentElement) return;
 
     const { title, icon } = resolveFallbackAppMetadata(id);
-    if (window.WMS) {
+    if (window.WMS && !window.legacyUiEnabled) {
         window.WMS.createWindow(id, title, contentElement, { icon });
         return;
     }


### PR DESCRIPTION
Implemented a LEGACY UI toggle in the settings menu that allows users to switch between the modern desktop window management system (WMS) and the classic full-screen terminal style layout. 

When enabled, the `legacyUiEnabled` config flag is saved to local storage. It hides the desktop grid and taskbar, immediately closes any active floating windows, and routes all subsequent application/game launches directly to the full-screen `.overlay` elements. When disabled, the WMS mode resumes normal operation.

---
*PR created automatically by Jules for task [17066448197949080699](https://jules.google.com/task/17066448197949080699) started by @thefoxssss*