### PR TITLE
Reduce incoming damage while firing Gatling gun

### DIFF
--- a/games/fps.js
+++ b/games/fps.js
@@ -2176,7 +2176,8 @@ function animate() {
       const euler = new THREE.Euler(0, 0, 0, 'YXZ');
       euler.setFromQuaternion(camera.quaternion);
 
-      room.send("move", { x: pos.x, y: pos.y, z: pos.z, rotY: euler.y });
+      const firingGatling = localPlayer.weapon === 3 && isPrimaryFireHeld && !isReloading && ammo[3] > 0 && isGatlingUnlocked();
+      room.send("move", { x: pos.x, y: pos.y, z: pos.z, rotY: euler.y, firingGatling });
     }
   }
 

--- a/server.js
+++ b/server.js
@@ -3090,6 +3090,9 @@ class FPSRoom extends colyseus.Room {
       player.y = data.y;
       player.z = data.z;
       player.rotY = data.rotY;
+      if (data.firingGatling === true && player.killStreak >= 5) {
+        this.gatlingFiringUntil.set(client.sessionId, Date.now() + FPS_GATLING_FIRING_GRACE_MS);
+      }
     });
 
     this.onMessage("shoot", (client, data) => {

--- a/server.js
+++ b/server.js
@@ -2581,7 +2581,32 @@ schema.defineTypes(FPSState, {
   blueFlagCarrier: "string"
 });
 
+const FPS_GATLING_WEAPON_ID = 3;
+const FPS_GATLING_FIRING_GRACE_MS = 250;
+const FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER = 0.5;
+
 class FPSRoom extends colyseus.Room {
+  isPlayerFiringGatling(playerId) {
+    return (this.gatlingFiringUntil?.get(playerId) || 0) > Date.now();
+  }
+
+  getDamageAfterGatlingResistance(targetId, damage) {
+    if (!this.isPlayerFiringGatling(targetId)) return damage;
+    return damage * FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER;
+  }
+
+  applyDamageToPlayer(target, targetId, incomingDamage) {
+    const damage = this.getDamageAfterGatlingResistance(targetId, incomingDamage);
+    if (target.armor > 0) {
+      const armorDmg = Math.min(target.armor, damage);
+      target.armor -= armorDmg;
+      target.health -= (damage - armorDmg);
+    } else {
+      target.health -= damage;
+    }
+    return damage;
+  }
+
   loadMapJSON(mapId) {
     try {
       const p = path.join(__dirname, "data", "fps", "maps", `${mapId}.json`);
@@ -2915,13 +2940,7 @@ class FPSRoom extends colyseus.Room {
       const dist = Math.sqrt((target.x - ex)**2 + (target.y - ey)**2 + (target.z - ez)**2);
       if (dist <= radius) {
         const damage = Math.floor(maxDamage * (1 - (dist / radius)));
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, targetId, damage);
 
         let hitClient = this.clients.find(c => c.sessionId === targetId);
         if (hitClient) {
@@ -2953,13 +2972,7 @@ class FPSRoom extends colyseus.Room {
       if (type === 1) { // Frag
           if (dist <= radius) {
             const damage = Math.floor(maxDamage * (1 - (dist / radius)));
-            if (target.armor > 0) {
-              const armorDmg = Math.min(target.armor, damage);
-              target.armor -= armorDmg;
-              target.health -= (damage - armorDmg);
-            } else {
-              target.health -= damage;
-            }
+            this.applyDamageToPlayer(target, targetId, damage);
 
             let hitClient = this.clients.find(c => c.sessionId === targetId);
             if (hitClient) {
@@ -3053,6 +3066,7 @@ class FPSRoom extends colyseus.Room {
     this.mapVotes = {};
     this.availableMapIds.forEach((id) => { this.mapVotes[id] = 0; });
     this.playerVotes = new Map();
+    this.gatlingFiringUntil = new Map();
 
     this.onMessage("voteMap", (client, mapId) => {
       if (!this.state.roundOver) return;
@@ -3084,7 +3098,10 @@ class FPSRoom extends colyseus.Room {
       if (!shooter || shooter.health <= 0) return;
       if (this.state.mapId === 5 && shooter.team === 0) return;
       const weaponId = Number(data.weaponId);
-      if (weaponId === 3 && shooter.killStreak < 5) return;
+      if (weaponId === FPS_GATLING_WEAPON_ID && shooter.killStreak < 5) return;
+      if (weaponId === FPS_GATLING_WEAPON_ID) {
+        this.gatlingFiringUntil.set(client.sessionId, Date.now() + FPS_GATLING_FIRING_GRACE_MS);
+      }
 
       this.broadcast("shoot", { origin: data.origin, dir: data.dir }, { except: client });
 
@@ -3137,16 +3154,10 @@ class FPSRoom extends colyseus.Room {
         let damage = 25;
         if (weaponId === 1) damage = 20; // Shotgun per bullet
         if (weaponId === 2) damage = 100; // Sniper
-        if (weaponId === 3) damage = 10; // Gatling
+        if (weaponId === FPS_GATLING_WEAPON_ID) damage = 10; // Gatling
         const target = hitClient.player;
 
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, hitClient.id, damage);
 
         if (target.health > 0) {
           client.send("hitmarker", { killed: false });
@@ -3187,13 +3198,7 @@ class FPSRoom extends colyseus.Room {
 
         const t = 1 - (dist / radius);
         const damage = Math.max(20, Math.round(100 * t));
-        if (target.armor > 0) {
-          const armorDmg = Math.min(target.armor, damage);
-          target.armor -= armorDmg;
-          target.health -= (damage - armorDmg);
-        } else {
-          target.health -= damage;
-        }
+        this.applyDamageToPlayer(target, targetId, damage);
         if (target.health <= 0) {
           const victimClient = this.clients.find(c => c.sessionId === targetId);
           this.handleElimination(shooter, client, target, victimClient);
@@ -3329,6 +3334,7 @@ class FPSRoom extends colyseus.Room {
 
   onLeave(client) {
     this.state.players.delete(client.sessionId);
+    this.gatlingFiringUntil.delete(client.sessionId);
     this.updateMetadata();
   }
 


### PR DESCRIPTION
### Motivation
- Give players a defensive benefit while using the high-rate Gatling weapon by halving damage taken during active Gatling firing windows. 
- Centralize FPS damage handling so the reduction applies consistently across hitscan and explosive damage paths.

### Description
- Added constants `FPS_GATLING_WEAPON_ID`, `FPS_GATLING_FIRING_GRACE_MS`, and `FPS_GATLING_DAMAGE_TAKEN_MULTIPLIER` and a `gatlingFiringUntil` tracker on the room. 
- Implemented `isPlayerFiringGatling`, `getDamageAfterGatlingResistance`, and `applyDamageToPlayer` helpers and routed damage application through `applyDamageToPlayer` for hitscan, rockets, barrels and frag grenades. 
- Mark the shooter as recently-firing Gatling in the `shoot` handler using the configured grace window so the resistance is applied while holding/firing the Gatling. 
- Initialize `gatlingFiringUntil` in room creation and clean it up on player leave to avoid stale state.

### Testing
- Ran `node --check server.js` to verify the modified file is syntactically valid and it succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02189fa9f083308fffcd86881c4877)