### PR TITLE
Fix update log GitHub repo slug in website UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     </div>
 
     <div class="overlay menu-overlay" id="overlayUpdates">
-      <div id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="webstie" style="display:none"></div>
+      <div id="updateLogPanel" data-github-owner="thefoxssss" data-github-repo="website" style="display:none"></div>
       <div class="score-box panel-overlay-box">
         <h2>UPDATE LOG // FULL HISTORY</h2>
         <p class="panel-overlay-meta" id="updateLogFullMeta">SYNCING FULL MERGED PR HISTORY...</p>


### PR DESCRIPTION
### Motivation
- The update-log overlay referenced the wrong GitHub repository slug (`webstie`), preventing the UI from loading the project's changelog feed.

### Description
- Corrected the `data-github-repo` attribute on `#updateLogPanel` in `index.html` from `webstie` to `website` so the overlay targets the correct repository.

### Testing
- Ran the unit test suite with `node --test tests/*.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0332cd48248327b3330d119bbb0c33)