### PR TITLE
Fix syntax error in games/obby.js caused by escaped template literals

### DIFF
--- a/games/obby.js
+++ b/games/obby.js
@@ -89,10 +89,10 @@ export function initObby() {
       const pNames = Array.isArray(srv.players) ? srv.players : [];
       const names = pNames.length ? pNames.join(", ") : "No players";
 
-      row.innerHTML = \`
+      row.innerHTML = `
         <div style="font-size: 11px; color: #0f0;">\${srv.serverName || "Obby Server"}</div>
         <div style="font-size: 9px; opacity: 0.9; margin-top: 4px;">PLAYERS (\${srv.clients}/\${srv.maxClients}): \${names}</div>
-      \`;
+      `;
       row.onclick = () => {
         selectedRoomId = srv.roomId;
         renderServerList(servers);
@@ -106,7 +106,7 @@ export function initObby() {
     if (!btnRefresh) return;
     btnRefresh.textContent = "LOADING...";
     try {
-      const res = await fetch(\`\${getApiUrl()}/obby-servers\`);
+      const res = await fetch(`\${getApiUrl()}/obby-servers`);
       const data = await res.json();
       renderServerList(data.servers);
     } catch (e) {


### PR DESCRIPTION
### Motivation
- Fix a browser parse error (`Uncaught SyntaxError: Invalid or unexpected token`) caused by incorrectly escaped template-literal delimiters in the obby client so the file parses and runs correctly.

### Description
- Replace incorrectly escaped template backticks with real backticks in `games/obby.js`, restoring valid template literals in the server-list HTML (`row.innerHTML`) and the fetch URL template string.

### Testing
- Ran `node --check games/obby.js` which completed successfully, confirming the file now has valid JavaScript syntax.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03351823c48327aa9d49d2fe461fe7)