### PR TITLE
Add custom background upload with Firebase-backed persistence

### DIFF
--- a/core.js
+++ b/core.js
@@ -5953,6 +5953,24 @@ function writeUiConfig(nextConfig) {
   localStorage.setItem(UI_CONFIG_KEY, JSON.stringify({ ...readUiConfig(), ...nextConfig }));
 }
 
+function applyCustomBackground(imageDataUrl) {
+  const hasImage = typeof imageDataUrl === "string" && imageDataUrl.startsWith("data:image/");
+  document.body.style.backgroundImage = hasImage ? `url(${imageDataUrl})` : "none";
+  document.body.style.backgroundSize = hasImage ? "cover" : "";
+  document.body.style.backgroundPosition = hasImage ? "center" : "";
+  document.body.style.backgroundRepeat = hasImage ? "no-repeat" : "";
+  document.body.style.backgroundAttachment = hasImage ? "fixed" : "";
+}
+
+async function persistCustomBackground(imageDataUrl) {
+  const nextDesktopConfig = { ...(desktopConfig || {}) };
+  if (imageDataUrl) nextDesktopConfig.customBackground = imageDataUrl;
+  else delete nextDesktopConfig.customBackground;
+  desktopConfig = nextDesktopConfig;
+  writeUiConfig({ customBackground: imageDataUrl || null });
+  if (myName !== "ANON") await saveStats();
+}
+
 function applyUiScale(value) {
   document.documentElement.style.setProperty("--ui-scale", String(value));
   document.body.style.zoom = `${value}`;
@@ -6041,6 +6059,33 @@ document.getElementById("themeColor").oninput = (e) => {
   const glowAlpha = luminance < 0.25 ? 0.95 : 0.7;
   document.documentElement.style.setProperty("--accent-glow", `rgba(${glowR},${glowG},${glowB},${glowAlpha})`);
 };
+
+document.getElementById("customBgUpload").onchange = async (e) => {
+  const [file] = Array.from(e.target.files || []);
+  if (!file) return;
+  if (!file.type.startsWith("image/")) {
+    showToast("INVALID FILE", "🖼️", "Please upload an image file.");
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = async () => {
+    const dataUrl = typeof reader.result === "string" ? reader.result : "";
+    if (!dataUrl) return;
+    applyCustomBackground(dataUrl);
+    await persistCustomBackground(dataUrl);
+    showToast("BACKGROUND SAVED", "🖼️");
+  };
+  reader.onerror = () => showToast("UPLOAD FAILED", "⚠️");
+  reader.readAsDataURL(file);
+};
+
+document.getElementById("clearCustomBgBtn").onclick = async () => {
+  applyCustomBackground(null);
+  await persistCustomBackground(null);
+  const input = document.getElementById("customBgUpload");
+  if (input) input.value = "";
+  showToast("BACKGROUND CLEARED", "🧹");
+};
 // Volume slider controls global audio volume.
 document.getElementById("volSlider").oninput = (e) => {
   globalVol = e.target.value / 100;
@@ -6121,6 +6166,8 @@ document.getElementById("statusVisibilityToggle").onclick = async () => {
   if (bgText) bgText.style.display = bgTextEnabled ? "block" : "none";
   const bgTextToggle = document.getElementById("bgTextToggle");
   if (bgTextToggle) bgTextToggle.innerText = bgTextEnabled ? "ON" : "OFF";
+  const customBackground = (desktopConfig && desktopConfig.customBackground) || config.customBackground || null;
+  applyCustomBackground(customBackground);
 
   const uiScaleSlider = document.getElementById("uiScaleSlider");
   const uiTextSlider = document.getElementById("uiTextSlider");

--- a/index.html
+++ b/index.html
@@ -1119,6 +1119,8 @@
 
         <div id="configTab-visual" class="config-tab-pane">
           <div class="config-row"><span>THEME</span><input type="color" id="themeColor" value="#ffffff" /></div>
+          <div class="config-row"><span>CUSTOM BG</span><input type="file" id="customBgUpload" accept="image/*" style="max-width: 180px;" /></div>
+          <div class="config-row"><span>BG ACTION</span><button class="menu-btn" id="clearCustomBgBtn">CLEAR</button></div>
           <div class="config-row"><span>MATRIX</span><button class="menu-btn" id="matrixToggle">OFF</button></div>
           <div class="config-row"><span>SCANLINES</span><input type="range" id="scanSlider" min="0" max="100" value="50" /></div>
           <div class="config-row"><span>FLICKER</span><button class="menu-btn" id="flickerToggle">ON</button></div>


### PR DESCRIPTION
### Motivation
- Provide a way for users to set a custom desktop background image and have that preference remembered across sessions and devices via the existing Firestore profile sync.

### Description
- Added UI controls to the Visual config: a file input `#customBgUpload` and a clear button `#clearCustomBgBtn` in `index.html`.
- Implemented `applyCustomBackground()` to apply an image data-URL to `document.body` and `persistCustomBackground()` to store/remove the background on `desktopConfig` and local UI config in `core.js`.
- Wired upload and clear handlers that validate image files, convert uploads to data URLs with `FileReader`, apply the background immediately, and persist the value; for logged-in users persistence triggers an existing `saveStats()` cloud sync so the image is stored in the Firestore-backed profile.
- Hydration was added to `hydrateUiConfig()` so the custom background is restored on load from `desktopConfig` (cloud) or from the local UI config fallback.

### Testing
- Ran `npm test --silent`; it failed because the repository has no `test` script defined.
- Ran `npm test`; it failed with `Missing script: "test"` and therefore no automated tests ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03382c9bd48327a678fd2c9244b812)