### PR TITLE
Fix in-app browser proxy navigation handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2827,6 +2827,12 @@
           historyIndex += 1;
           navigate(history[historyIndex], false);
         });
+        window.addEventListener('message', (event) => {
+          if (!event?.data || event.data.type !== 'browser-proxy-nav') return;
+          if (typeof event.data.url !== 'string') return;
+          navigate(event.data.url);
+        });
+
         reloadBtn.addEventListener('click', () => {
           if (historyIndex >= 0) {
             navigate(history[historyIndex], false);

--- a/server.js
+++ b/server.js
@@ -732,12 +732,45 @@ app.get("/api/browser-proxy", async (req, res) => {
       });
     }
     const finalUrl = response.url || target.toString();
-    const htmlWithBase = bodyText.replace(/<head([^>]*)>/i, `<head$1><base href="${finalUrl}">`);
+    const navBridge = `<script>(function(){
+  function toAbs(url){ try { return new URL(url, document.baseURI).toString(); } catch { return null; } }
+  function sendNav(url){ if(!url) return; try { window.top.postMessage({ type: "browser-proxy-nav", url }, "*"); } catch {} }
+  document.addEventListener("click", function(event){
+    const anchor = event.target && event.target.closest ? event.target.closest("a[href]") : null;
+    if (!anchor) return;
+    const href = anchor.getAttribute("href") || "";
+    if (href.startsWith("#") || href.toLowerCase().startsWith("javascript:")) return;
+    const abs = toAbs(href);
+    if (!abs) return;
+    event.preventDefault();
+    sendNav(abs);
+  }, true);
+  document.addEventListener("submit", function(event){
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    const method = String(form.method || "get").toLowerCase();
+    if (method !== "get") return;
+    const action = form.getAttribute("action") || document.baseURI;
+    let abs = toAbs(action);
+    if (!abs) return;
+    const qs = new URLSearchParams(new FormData(form));
+    const u = new URL(abs);
+    for (const [k,v] of qs.entries()) u.searchParams.append(k, v);
+    event.preventDefault();
+    sendNav(u.toString());
+  }, true);
+})();</script>`;
+    const htmlWithBase = bodyText
+      .replace(/<head([^>]*)>/i, `<head$1><base href="${finalUrl}">`)
+      .replace(/<\/body>/i, `${navBridge}</body>`);
+    const content = htmlWithBase.includes(navBridge)
+      ? htmlWithBase
+      : `${htmlWithBase}${navBridge}`;
     res.set("cache-control", "no-store");
     return res.json({
       ok: true,
       finalUrl,
-      content: htmlWithBase,
+      content,
     });
   } catch (error) {
     return res.status(502).json({ ok: false, error: String(error?.message || error) });


### PR DESCRIPTION
### Motivation
- The in-app browser could break after the first proxied page load because links and GET form submissions would navigate the iframe directly or be blocked, preventing continued browsing through the proxy.
- The change aims to keep all navigations routed through the existing `/api/browser-proxy` flow so proxied sessions remain functional.

### Description
- Inject a small navigation-bridge script into proxied HTML from `app.get('/api/browser-proxy')` that intercepts anchor clicks and GET form submits, resolves absolute URLs, and posts messages to the parent via `window.top.postMessage({ type: 'browser-proxy-nav', url })`.
- Preserve the existing `<base href="...">` rewriting and non-HTML handling, and append the nav bridge safely to the proxied document body before returning the `content` payload.
- Add a `window.addEventListener('message', ...)` handler in the browser overlay (`index.html`) that listens for `browser-proxy-nav` messages and calls the existing `navigate()` function to load the requested URL via the proxy.

### Testing
- Loaded `server.js` with Node using `node -e "require('./server.js'); console.log('server-load-ok')"` and observed `server-load-ok`, indicating the server module loads without syntax errors. 
- Verified `index.html` JavaScript includes the new `message` listener and that the proxy response still sets `cache-control: no-store` as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03402384788327a32e44dcb5d96a23)