### PR TITLE
Remove in-app browser proxy and load URLs directly in iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,14 +1112,16 @@
             <div style="margin-left:8px;color:#d7dce5;font-size:11px;letter-spacing:.04em;">GOONER CHROME</div>
           </div>
           <div style="display:flex;gap:8px;align-items:center;">
-            <button class="term-btn" id="browserBackBtn" type="button">◀</button>
-            <button class="term-btn" id="browserForwardBtn" type="button">▶</button>
-            <button class="term-btn" id="browserReloadBtn" type="button">↻</button>
-            <input class="term-input" id="browserUrlInput" type="url" placeholder="Search or type URL" value="https://example.com" autocomplete="off" spellcheck="false" style="flex:1;min-width:0;background:#0b1220;border:2px solid #5d7391;color:#ffffff;border-radius:999px;padding:10px 14px;margin:0;text-align:left;font-family:'Roboto Mono',monospace;font-size:14px;font-weight:600;letter-spacing:0;text-transform:none;text-shadow:none;caret-color:#ffffff;" />
-            <button class="term-btn" id="browserGoBtn" type="button">GO</button>
+            <button class="term-btn" id="browserBackBtn" type="button" style="width:100px;margin:0;">◀</button>
+            <button class="term-btn" id="browserForwardBtn" type="button" style="width:100px;margin:0;">▶</button>
+            <button class="term-btn" id="browserReloadBtn" type="button" style="width:100px;margin:0;">↻</button>
           </div>
         </div>
-        <div id="browserStatus" style="font-size:10px;padding:4px 10px;border-bottom:1px solid #20242c;color:#9fb2c9;background:#12151b;">READY</div>
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid #20242c;color:#9fb2c9;background:#12151b;">
+          <div id="browserStatus" style="font-size:11px;white-space:nowrap;">READY</div>
+          <input class="term-input" id="browserUrlInput" type="url" placeholder="Type domain here" value="https://example.com" autocomplete="off" spellcheck="false" style="flex:1;min-width:0;background:#0b1220;border:2px solid #5d7391;color:#ffffff;border-radius:8px;padding:7px 10px;margin:0;text-align:left;font-family:'Roboto Mono',monospace;font-size:13px;font-weight:600;letter-spacing:0;text-transform:none;text-shadow:none;caret-color:#ffffff;" />
+          <button class="term-btn" id="browserGoBtn" type="button" style="width:90px;margin:0;">GO</button>
+        </div>
         <iframe id="browserFrame" title="In-app browser" src="about:blank" style="width:100%;flex:1;border:0;background:#fff;"></iframe>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1096,6 +1096,10 @@
       </div>
     </div>
 
+
+    <style>
+      #browserUrlInput::placeholder { color: #9fb2c9; opacity: 1; }
+    </style>
     <!-- Configuration overlay for display/audio toggles. -->
 
     <div class="overlay menu-overlay" id="overlayBrowser">
@@ -1111,7 +1115,7 @@
             <button class="term-btn" id="browserBackBtn" type="button">◀</button>
             <button class="term-btn" id="browserForwardBtn" type="button">▶</button>
             <button class="term-btn" id="browserReloadBtn" type="button">↻</button>
-            <input class="term-input" id="browserUrlInput" type="url" placeholder="Search or type URL" value="https://example.com" style="flex:1;background:#111722;border-color:#4e5d72;color:#e8eef7;border-radius:999px;padding-left:14px;" />
+            <input class="term-input" id="browserUrlInput" type="url" placeholder="Search or type URL" value="https://example.com" autocomplete="off" spellcheck="false" style="flex:1;min-width:0;background:#0b1220;border:2px solid #5d7391;color:#ffffff;border-radius:999px;padding:10px 14px;margin:0;text-align:left;font-family:'Roboto Mono',monospace;font-size:14px;font-weight:600;letter-spacing:0;text-transform:none;text-shadow:none;caret-color:#ffffff;" />
             <button class="term-btn" id="browserGoBtn" type="button">GO</button>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -2789,26 +2789,25 @@
           return `https://${raw}`;
         }
 
-        async function navigate(rawUrl, pushToHistory = true) {
+        function navigate(rawUrl, pushToHistory = true) {
           const target = normalizeUrl(rawUrl);
           input.value = target;
           statusEl.textContent = `LOADING ${target}`;
-          try {
-            const response = await fetch(`/api/browser-proxy?url=${encodeURIComponent(target)}`);
-            const payload = await response.json();
-            if (!response.ok || !payload?.ok) throw new Error(payload?.error || 'Proxy request failed');
-            frame.srcdoc = payload.content;
-            statusEl.textContent = `PROXY OK • ${payload.finalUrl || target}`;
-            if (pushToHistory) {
-              history.splice(historyIndex + 1);
-              history.push(target);
-              historyIndex = history.length - 1;
-            }
-          } catch (error) {
-            frame.srcdoc = `<html><body style="font-family:monospace;background:#111;color:#f88;padding:20px;">Failed to open URL.<br>${String(error?.message || error)}</body></html>`;
-            statusEl.textContent = 'PROXY ERROR';
+          frame.removeAttribute('srcdoc');
+          frame.src = target;
+          if (pushToHistory) {
+            history.splice(historyIndex + 1);
+            history.push(target);
+            historyIndex = history.length - 1;
           }
         }
+
+        frame.addEventListener('load', () => {
+          statusEl.textContent = `READY • ${input.value}`;
+        });
+        frame.addEventListener('error', () => {
+          statusEl.textContent = 'LOAD ERROR';
+        });
 
         goBtn.addEventListener('click', () => navigate(input.value));
         input.addEventListener('keydown', (event) => {
@@ -2827,12 +2826,6 @@
           historyIndex += 1;
           navigate(history[historyIndex], false);
         });
-        window.addEventListener('message', (event) => {
-          if (!event?.data || event.data.type !== 'browser-proxy-nav') return;
-          if (typeof event.data.url !== 'string') return;
-          navigate(event.data.url);
-        });
-
         reloadBtn.addEventListener('click', () => {
           if (historyIndex >= 0) {
             navigate(history[historyIndex], false);

--- a/server.js
+++ b/server.js
@@ -694,88 +694,9 @@ app.get("/api/oil-quote", async (req, res) => {
   }
 });
 
-app.get("/api/browser-proxy", async (req, res) => {
-  const rawUrl = String(req.query?.url || "").trim();
-  if (!rawUrl) return res.status(400).json({ ok: false, error: "missing url" });
-  let target;
-  try {
-    target = new URL(rawUrl);
-  } catch {
-    return res.status(400).json({ ok: false, error: "invalid url" });
-  }
-  if (!["http:", "https:"].includes(target.protocol)) {
-    return res.status(400).json({ ok: false, error: "unsupported protocol" });
-  }
-  try {
-    const response = await fetch(target.toString(), {
-      redirect: "follow",
-      headers: {
-        "user-agent": "Mozilla/5.0 (compatible; GoonerBrowserProxy/1.0)",
-        "accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.5",
-      },
-    });
-    if (!response.ok) {
-      return res.status(502).json({ ok: false, error: `upstream ${response.status}` });
-    }
-    const contentType = String(response.headers.get("content-type") || "");
-    const bodyText = await response.text();
-    if (!/text\/html|application\/xhtml\+xml/i.test(contentType)) {
-      const escaped = bodyText
-        .slice(0, 20000)
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-      return res.json({
-        ok: true,
-        finalUrl: response.url || target.toString(),
-        content: `<!doctype html><html><body style="font-family:monospace;white-space:pre-wrap;padding:16px;"><h3>Non-HTML response</h3><p>Type: ${contentType || "unknown"}</p><pre>${escaped}</pre></body></html>`,
-      });
-    }
-    const finalUrl = response.url || target.toString();
-    const navBridge = `<script>(function(){
-  function toAbs(url){ try { return new URL(url, document.baseURI).toString(); } catch { return null; } }
-  function sendNav(url){ if(!url) return; try { window.top.postMessage({ type: "browser-proxy-nav", url }, "*"); } catch {} }
-  document.addEventListener("click", function(event){
-    const anchor = event.target && event.target.closest ? event.target.closest("a[href]") : null;
-    if (!anchor) return;
-    const href = anchor.getAttribute("href") || "";
-    if (href.startsWith("#") || href.toLowerCase().startsWith("javascript:")) return;
-    const abs = toAbs(href);
-    if (!abs) return;
-    event.preventDefault();
-    sendNav(abs);
-  }, true);
-  document.addEventListener("submit", function(event){
-    const form = event.target;
-    if (!(form instanceof HTMLFormElement)) return;
-    const method = String(form.method || "get").toLowerCase();
-    if (method !== "get") return;
-    const action = form.getAttribute("action") || document.baseURI;
-    let abs = toAbs(action);
-    if (!abs) return;
-    const qs = new URLSearchParams(new FormData(form));
-    const u = new URL(abs);
-    for (const [k,v] of qs.entries()) u.searchParams.append(k, v);
-    event.preventDefault();
-    sendNav(u.toString());
-  }, true);
-})();</script>`;
-    const htmlWithBase = bodyText
-      .replace(/<head([^>]*)>/i, `<head$1><base href="${finalUrl}">`)
-      .replace(/<\/body>/i, `${navBridge}</body>`);
-    const content = htmlWithBase.includes(navBridge)
-      ? htmlWithBase
-      : `${htmlWithBase}${navBridge}`;
-    res.set("cache-control", "no-store");
-    return res.json({
-      ok: true,
-      finalUrl,
-      content,
-    });
-  } catch (error) {
-    return res.status(502).json({ ok: false, error: String(error?.message || error) });
-  }
-});
+
+
+
 
 // --------------------------------------------------------
 // BASE TEST ROOM


### PR DESCRIPTION
### Motivation

- The in-app browser previously fetched remote pages through a local `/api/browser-proxy` endpoint which added complexity and a proxy dependency, so the browser was changed to navigate directly to target URLs to simplify behavior and make the overlay functional without the proxy.

### Description

- Replaced the frontend navigation flow in `index.html` to stop calling `/api/browser-proxy` and instead set the iframe `src` directly via `frame.src` while preserving URL normalization and history handling.
- Removed the `window.postMessage` handler for the old proxy navigation bridge and added `load` and `error` listeners on the iframe to update the `browserStatus` element with `READY` or `LOAD ERROR` states.
- Deleted the server-side `/api/browser-proxy` route from `server.js` since it is no longer used by the frontend.
- Kept existing UX behavior for back/forward/reload and ensured history is still tracked by the `navigate` function.

### Testing

- Ran `node --check server.js` to validate server-side syntax after removing the route, and it succeeded.
- Searched for remaining proxy references with `rg -n "api/browser-proxy|browser-proxy-nav" index.html server.js` and confirmed no functional references remain.
- Committed the changes with `git commit` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034210ef908327a10c64676f110f34)